### PR TITLE
fix: prevent infinite recursion in tmux session creation

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -147,7 +147,7 @@ async function createTmuxSession(args) {
       if (v == null) continue;
       envArgs.push('-e', `${k}=${v}`);
     }
-    newSessionArgs = ['new-session', '-d', '-s', sessionName, ...envArgs, innerCmd];
+    newSessionArgs = ['new-session', '-d', '-s', sessionName, '-e', `CLAUDE_AUTO_RETRY_ACTIVE=1`, ...envArgs, innerCmd];
   } else {
     // For tmux < 3.0: export critical env vars inline in the command
     const criticalVars = ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG',


### PR DESCRIPTION
## Problem

The `claude` shell function wrapper in `~/.zshrc` creates an infinite recursion loop when `createTmuxSession` spawns a new tmux session. The new session sources `~/.zshrc`, which re-defines the wrapper, but `CLAUDE_AUTO_RETRY_ACTIVE=1` was never propagated as a real environment variable into the tmux session — it was only set inline in the shell command string. This caused the wrapper to intercept `claude` again, spawning another tmux session, corrupting terminal state (broken scroll, inability to exit).

## Fix

Added `-e CLAUDE_AUTO_RETRY_ACTIVE=1` as an explicit tmux `-e` flag in `createTmuxSession()` (`src/launcher.js:150`). This ensures the environment variable exists in the new tmux session before the inner command runs, so the zsh wrapper's guard clause (`command claude "$@"`) fires immediately, breaking the recursion chain.

```diff
-    newSessionArgs = ['new-session', '-d', '-s', sessionName, ...envArgs, innerCmd];
+    newSessionArgs = ['new-session', '-d', '-s', sessionName, '-e', `CLAUDE_AUTO_RETRY_ACTIVE=1`, ...envArgs, innerCmd];
```

All 85 existing tests pass.
