### PR TITLE
fix: correct 24h over-wait for UTC+ timezone rate limit resets

### DIFF
--- a/src/time-parser.js
+++ b/src/time-parser.js
@@ -81,6 +81,16 @@ export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, n
       candidate += diffMin * 60_000;
     }
 
+    // The iterative correction may converge on tomorrow's occurrence when
+    // the initial UTC guess (line 66) lands past midnight in the target
+    // timezone. This happens for all UTC+ zones (e.g. Europe/Warsaw UTC+2:
+    // "22:00Z" = 00:00 Warsaw → correction adds 22h → tomorrow's 10pm).
+    // Roll back one day if today's occurrence is still in the future.
+    const prevDay = candidate - 86400_000;
+    if (prevDay > now.getTime()) {
+      candidate = prevDay;
+    }
+
     return candidate;
   }
 

--- a/test/time-parser.test.js
+++ b/test/time-parser.test.js
@@ -92,4 +92,26 @@ describe('calculateWaitMs', () => {
     const wait = calculateWaitMs({ hour: 15, minute: 0, timezone: 'Invalid/Zone' }, 60, 5);
     assert.ok(Math.abs(wait - (5 * 3600 + 60) * 1000) < 2000); // fallback
   });
+  it('computes ~2h wait for UTC+ timezone same-day reset, not ~26h', () => {
+    // Simulate: "resets 10pm (Europe/Warsaw)" detected at 19:49 Warsaw time.
+    // Europe/Warsaw = UTC+2 in April (CEST). 19:49 Warsaw = 17:49 UTC.
+    // Target is 22:00 Warsaw = 20:00 UTC. Expected wait ≈ 2h 11m, not ~26h.
+    const now = new Date('2026-04-14T17:49:16Z'); // 19:49:16 Warsaw
+    const wait = calculateWaitMs(
+      { hour: 22, minute: 0, timezone: 'Europe/Warsaw' }, 60, 5, now
+    );
+    const waitHours = wait / 3_600_000;
+    assert.ok(waitHours > 1.5 && waitHours < 3,
+      `Expected ~2h wait, got ${waitHours.toFixed(2)}h`);
+  });
+  it('waits until tomorrow if UTC+ same-day reset already passed', () => {
+    // 22:30 Warsaw = 20:30 UTC. Target 10pm already passed → wait ~23.5h.
+    const now = new Date('2026-04-14T20:30:00Z'); // 22:30 Warsaw
+    const wait = calculateWaitMs(
+      { hour: 22, minute: 0, timezone: 'Europe/Warsaw' }, 60, 5, now
+    );
+    const waitHours = wait / 3_600_000;
+    assert.ok(waitHours > 22 && waitHours < 25,
+      `Expected ~23.5h wait, got ${waitHours.toFixed(2)}h`);
+  });
 });


### PR DESCRIPTION
## Summary

- For UTC+ timezones (e.g. `Europe/Warsaw` = UTC+2), `getTargetTimestamp` in `time-parser.js` converges on **tomorrow's** occurrence instead of today's, causing a ~26h wait instead of ~2h
- Root cause: line 66 treats the target wall-clock time as UTC (`new Date(targetStr + 'Z')`). For `Europe/Warsaw`, `"22:00Z"` = `00:00 Warsaw` (next day). The iterative correction then adds 22h forward, landing on tomorrow's 10pm
- Fix: after convergence, roll back 24h if today's occurrence is still in the future
- Added two regression tests covering the fix and the "already passed" case

### Reproduction

```
[2026-04-14 19:49:16] [INFO] Rate limit detected: "⎿  You've hit your limit · resets 10pm (Europe/Warsaw)". Waiting 87104s...
```

Expected: ~7900s (~2h 11m). Actual: 87104s (~24h 12m).

## Test plan

- [x] Existing 18 tests pass unchanged
- [x] New test: `"resets 10pm (Europe/Warsaw)"` at 19:49 Warsaw → wait ~2h (not ~26h)
- [x] New test: same timezone after reset passed (22:30 Warsaw) → correctly waits ~23.5h for tomorrow
- [ ] Verify with other UTC+ zones (Asia/Kolkata UTC+5:30, Asia/Tokyo UTC+9)
- [ ] Verify UTC- zones (America/New_York) remain unaffected