### PR TITLE
fix: stop retries piling up in input box and stop redundant resends after Claude resumes

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -6,8 +6,19 @@ import { createLogger } from './logger.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 
+// Signature of the bottom of the pane — used to detect whether Claude has
+// actually started responding after we sent a retry message. The rate-limit
+// message lingers in the TUI scrollback even after Claude resumes, so
+// re-running isRateLimited() always returns true and produces redundant
+// retries. A change in the bottom 5 non-blank lines is a much more reliable
+// "Claude is alive again" signal.
+function paneSignature(stripped) {
+  const lines = stripped.split('\n').map(l => l.trimEnd()).filter(l => l.length > 0);
+  return lines.slice(-5).join('\n');
+}
+
 export function createMonitorState() {
-  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null };
+  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null, _sigBeforeSend: null };
 }
 
 export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) {
@@ -20,10 +31,22 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
     if (Date.now() < state.waitUntil) return 'waiting';
     if (!isAlive()) return 'exit';
 
+    // After we've sent at least one retry, prefer the "pane moved" signal
+    // over re-pattern-matching the rate-limit text. The limit message stays
+    // in scrollback after Claude resumes, so isRateLimited() would keep
+    // returning true and the loop would resend the retry message every 30s.
+    if (state._sigBeforeSend && paneSignature(stripped) !== state._sigBeforeSend) {
+      state.status = 'monitoring';
+      state.attempts = 0;
+      state._sigBeforeSend = null;
+      return 'user-continued';
+    }
+
     // Always check if rate limit cleared FIRST — even when maxRetries
     // exhausted, the user (or time passing) may have resolved it.
     if (!isRateLimited(stripped, config.customPatterns)) {
       state.status = 'monitoring'; state.attempts = 0;
+      state._sigBeforeSend = null;
       return 'user-continued';
     }
 
@@ -52,6 +75,9 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
 
     // Increment attempts and set cooldown BEFORE sendKeys so that a failure
     // (e.g. pane destroyed) still consumes a retry and avoids tight-loop errors.
+    // Snapshot the pane signature before sending so the next tick can detect
+    // whether Claude actually started responding (vs. our retry being eaten).
+    state._sigBeforeSend = paneSignature(stripped);
     state.attempts++;
     state.waitUntil = Date.now() + 30_000;
     await tmuxAdapter.sendKeys(pane, config.retryMessage);

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -86,9 +86,21 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
 
   if (isRateLimited(stripped, config.customPatterns)) {
     const message = findRateLimitMessage(stripped, config.customPatterns);
-    state.lastRateLimitMessage = message;
     const parsed = message ? parseResetTime(message) : null;
-    state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
+    const waitMs = calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
+
+    // Stale-message guard: if an absolute reset time is already in the past,
+    // calculateWaitMs adds 24h and returns ~next-day waiting. That's almost
+    // never what we want — the Claude TUI keeps old "resets HH:MMam" lines
+    // in scrollback, and treating them as "tomorrow" makes the monitor sleep
+    // through the actual fresh rate limit. If the wait is suspiciously close
+    // to a full day, stay in monitoring and re-check on the next tick.
+    if (waitMs > 22 * 3600 * 1000) {
+      return 'monitoring';
+    }
+
+    state.lastRateLimitMessage = message;
+    state.waitUntil = Date.now() + waitMs;
     state.status = 'waiting';
     return 'waiting';
   }

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -73,14 +73,18 @@ export function isRateLimited(text, customPatterns = []) {
 export function findRateLimitMessage(text, customPatterns = []) {
   const lines = stripAnsi(text).split('\n');
 
-  // Return the "resets" line — that's what parseResetTime needs
-  for (const line of lines) {
-    if (RESET_PATTERNS.some(p => p.test(line))) return line.trim();
+  // Scan from the bottom up — the most recent "resets" line in the pane is
+  // the one we should parse. The Claude TUI never clears earlier rate-limit
+  // messages from scrollback, so a forward scan would lock on stale ones
+  // (e.g. an 11:30am message lingering after Claude has resumed; a fresh
+  // 4:30pm message is below it but never reached).
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (RESET_PATTERNS.some(p => p.test(lines[i]))) return lines[i].trim();
   }
 
-  // Fallback: any "limit" line
-  for (const line of lines) {
-    if (LIMIT_PATTERNS.some(p => p.test(line))) return line.trim();
+  // Fallback: any "limit" line, also scanned from the bottom.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (LIMIT_PATTERNS.some(p => p.test(lines[i]))) return lines[i].trim();
   }
 
   return null;

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -3,12 +3,30 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFileCb);
 
+const SEND_ENTER_DELAY_MS = 300;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 export function buildCaptureArgs(pane, lines = 200) {
   return ['capture-pane', '-t', pane, '-p', '-S', `-${lines}`];
 }
 
+/**
+ * @deprecated Single-shot send-keys (text + Enter atomically) races with the
+ * Claude TUI paste-heuristic: when text + \r arrive in the same pty write,
+ * \r is treated as a paste-newline rather than a submit. Retries pile into
+ * the input box without ever being submitted. Use buildSendLiteralArgs +
+ * buildSendEnterArgs with a delay between them instead.
+ */
 export function buildSendKeysArgs(pane, text) {
   return ['send-keys', '-t', pane, text, 'Enter'];
+}
+
+export function buildSendLiteralArgs(pane, text) {
+  return ['send-keys', '-t', pane, '-l', text];
+}
+
+export function buildSendEnterArgs(pane) {
+  return ['send-keys', '-t', pane, 'Enter'];
 }
 
 export function buildDisplayArgs(pane, format) {
@@ -32,7 +50,9 @@ export async function capturePane(pane, lines = 200) {
 }
 
 export async function sendKeys(pane, text) {
-  await execFileAsync('tmux', buildSendKeysArgs(pane, text));
+  await execFileAsync('tmux', buildSendLiteralArgs(pane, text));
+  await sleep(SEND_ENTER_DELAY_MS);
+  await execFileAsync('tmux', buildSendEnterArgs(pane));
 }
 
 export async function getPaneCommand(pane) {


### PR DESCRIPTION
## Summary

Three related bugs in the retry pipeline. Each one only becomes visible after the previous is fixed:

1. Retry messages stack in the Claude input box without ever submitting (`sendKeys` race).
2. Once submission works, the same retry is re-sent every 30s for the rest of the window (`isRateLimited` matches stale scrollback).
3. Once the duplicate-send is suppressed, a *new* rate limit later in the day is missed because the monitor reads the lingering "resets HH:MMam" line, computes that as "in the past → +24h", and sleeps until tomorrow.

### 1. tmux send-keys text + Enter race with Claude TUI paste-heuristic

`buildSendKeysArgs` packs the retry text and the `Enter` key into a single `tmux send-keys` invocation. tmux writes them atomically to the pane PTY, so they arrive at the ink-based Claude TUI back-to-back. The TUI's paste-heuristic treats the burst as a paste and the trailing `\r` becomes a paste-newline rather than a submit.

Symptom: 5 identical "Continue where you left off. The previous attempt was rate limited." lines stacked in the input box, none submitted, ending with `Max retries (5) reached`.

Fix: split `sendKeys` into two `tmux send-keys` calls — first `-l <text>` (literal, no key parsing), then a 300 ms delay, then `Enter`. New helpers `buildSendLiteralArgs` / `buildSendEnterArgs`; the legacy `buildSendKeysArgs` is kept and marked `@deprecated` for backward compat.

### 2. Stale rate-limit text in scrollback causes duplicate retries

`isRateLimited()` is stateless: it only checks whether the captured 20 lines contain a `limit` line and a `resets` line within 6 lines of each other. The Claude TUI never clears the rate-limit message from its scrollback, so once the limit text appears it keeps matching forever, even after Claude has resumed.

Symptom (after fix #1): the first retry submission triggers Claude to resume; 30 s later the cooldown ends, the monitor re-captures the pane, the historical rate-limit text is still there, `isRateLimited()` returns true again, and the retry message is sent a second, third, fourth time. Up to 5 redundant submissions per window.

Fix: snapshot a signature of the bottom 5 non-blank lines (`paneSignature`) right before each `sendKeys`. On the next tick, if that signature has changed, treat it as 'Claude is alive again' and exit waiting state immediately, regardless of whether the historical limit text still pattern-matches. Purely additive — `_sigBeforeSend` is null until the first retry, so the first-ever retry path is unchanged.

### 3. Stale "resets" line makes the monitor sleep until next day

After fix #2 the monitor correctly returns to monitoring once Claude resumes — but the rate-limit text still lingers in scrollback. The next time `isRateLimited()` matches it (which can happen on any subsequent tick), `findRateLimitMessage()` was scanning lines forward and returning the *oldest* "resets" line found. If that hour has already passed, `calculateWaitMs()` adds 86_400_000 ms to push it into "tomorrow", and the monitor commits to sleeping ~23–24h. Any *real* fresh rate limit that arrives later the same day is silently missed.

Symptom from a production log: Claude resumed at 03:33 UTC after a real `resets 11:30am Asia/Shanghai` limit; at 03:49 UTC the monitor re-saw the lingering "resets 11:30am" text, computed `waitMs = 85316s` (~23h41m), and slept until the next morning. The user's actual fresh afternoon rate limit was never picked up.

Fix, two independent guards (either one would mitigate, both is robust):
- `findRateLimitMessage` now scans bottom-up. The most recently rendered message wins, so a real new limit at the bottom of the pane is preferred over a stale one above it.
- The monitor's `monitoring → waiting` transition rejects any computed `waitMs > 22h` and stays in monitoring (re-checks each tick). 22h is well above the longest realistic Anthropic reset window and well below the ~24h that gets produced when `+86_400_000` is added to a past-time delta.

## Test plan

- [x] `node --check` passes for `src/tmux.js`, `src/monitor.js`, `src/patterns.js`.
- [x] Manual repro of fix #1: triggered a real rate-limit window, the first retry submitted on its own and Claude resumed.
- [x] Manual repro of fix #2: log shows `Sent retry message (attempt 1)` followed by `User already continued. Attempt counter reset.` instead of attempts 2–5.
- [x] Reproduced fix #3 from a real production log: the same scrollback state that produced `Waiting 85316s` now stays in monitoring until a non-stale message arrives.
- [ ] Add unit tests around `paneSignature`, the `monitoring → waiting` 22h guard, and `findRateLimitMessage` bottom-up scan — happy to do this in a follow-up if a particular shape of test is preferred for this repo.

## Notes

- Three commits kept separate because the bugs are independent at root cause (TUI keystroke timing, monitor state machine, and scrollback-vs-time interaction respectively). Happy to squash if preferred.
- The 300 ms send-keys delay and 22h stale threshold are conservative defaults; both could be made configurable via `~/.claude-auto-retry.json` if there's interest.