### PR TITLE
Fix off-by-a-day wait in positive-offset timezones

### DIFF
--- a/src/time-parser.js
+++ b/src/time-parser.js
@@ -76,7 +76,13 @@ export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, n
       const ch = parseInt(fp.find(p => p.type === 'hour').value) % 24;
       const cm = parseInt(fp.find(p => p.type === 'minute').value);
 
-      const diffMin = (h - ch) * 60 + (m - cm);
+      // Normalize to [-720, +720] minutes so we take the minimum-magnitude
+      // correction. Otherwise, in a UTC+10 tz looking for 23:40, the naive UTC
+      // guess formats as 09:40 next day local; a raw +14h adjustment lands on
+      // tomorrow instead of today.
+      let diffMin = (h - ch) * 60 + (m - cm);
+      diffMin = ((diffMin % 1440) + 1440) % 1440;
+      if (diffMin > 720) diffMin -= 1440;
       if (diffMin === 0) break;
       candidate += diffMin * 60_000;
     }

--- a/test/time-parser.test.js
+++ b/test/time-parser.test.js
@@ -92,4 +92,37 @@ describe('calculateWaitMs', () => {
     const wait = calculateWaitMs({ hour: 15, minute: 0, timezone: 'Invalid/Zone' }, 60, 5);
     assert.ok(Math.abs(wait - (5 * 3600 + 60) * 1000) < 2000); // fallback
   });
+
+  // Regression: in tz with positive UTC offset, e.g. 10:02 AM Melbourne (UTC+10)
+  // looking for "11:40pm Melbourne" should wait ~13.6h (today), not ~37.6h (tomorrow).
+  it('targets today for a future reset in a positive-offset timezone', () => {
+    const now = new Date('2026-05-03T00:02:15Z'); // 10:02 AM in Melbourne (UTC+10)
+    const wait = calculateWaitMs(
+      { hour: 23, minute: 40, timezone: 'Australia/Melbourne' }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 13 && hours < 14, `expected ~13.6h, got ${hours.toFixed(2)}h`);
+  });
+
+  // Regression: in tz with negative UTC offset, "resets 3am NY" at 1am NY
+  // should wait ~2h, not target tomorrow.
+  it('targets today for a future reset in a negative-offset timezone', () => {
+    const now = new Date('2026-05-03T05:00:00Z'); // 1:00 AM in New York (UTC-4 EDT)
+    const wait = calculateWaitMs(
+      { hour: 3, minute: 0, timezone: 'America/New_York' }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 1.9 && hours < 2.1, `expected ~2h, got ${hours.toFixed(2)}h`);
+  });
+
+  // Regression: reset time already passed today should target tomorrow (~24h away),
+  // not 48h. Covers the symmetric case for the off-by-a-day bug.
+  it('targets tomorrow when reset time already passed today', () => {
+    const now = new Date('2026-05-03T15:00:00Z'); // 1:00 AM next day in Melbourne
+    const wait = calculateWaitMs(
+      { hour: 23, minute: 40, timezone: 'Australia/Melbourne' }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 22 && hours < 23, `expected ~22.6h, got ${hours.toFixed(2)}h`);
+  });
 });


### PR DESCRIPTION
## Summary

`calculateWaitMs` produces a wait that is up to 24 hours too long when the user's timezone is east of UTC (e.g. `Australia/Melbourne`, `Asia/Tokyo`). In practice this means the auto-retry never fires within a normal session — the user has exited Claude long before the (wildly inflated) wait elapses.

## Repro

At 10:02 AM Melbourne (UTC+10), a Claude TUI message of `⎿ You've hit your limit · resets 11:40pm (Australia/Melbourne)` should produce a wait of ~13.6h. It currently produces **~37.6h** (targets 11:40pm *tomorrow* Melbourne instead of tonight).

```js
const now = new Date('2026-05-03T00:02:15Z'); // 10:02 AM in Melbourne
calculateWaitMs(
  { hour: 23, minute: 40, timezone: 'Australia/Melbourne' }, 60, 5, now
);
// before: 135525000 ms (~37.65 h)
// after:   49125000 ms (~13.65 h)
```

I noticed this when reviewing real logs — every rate-limit detection in my install logged a 23–28 hour wait, and `Claude exited. Monitor shutting down.` appeared shortly after each one because I'd long since closed the session.

## Root cause

In `getTargetTimestamp`, the iterative correction adds the raw `(h - ch) * 60 + (m - cm)` minute difference. For a UTC+N tz, the naive UTC starting timestamp formats as N hours *earlier* in local time, so a desired late-evening hour (e.g. 23:40) registers as a large positive diff (e.g. 09:40 → 23:40 = +14h) and pushes the candidate a full day forward instead of pulling back to today.

The bug is asymmetric — for negative-offset zones the naive guess already lands on today's date, so the raw correction works.

## Fix

Normalize `diffMin` to `[-720, +720]` minutes so the iteration takes the minimum-magnitude correction (the nearest matching hour:minute in either direction). The outer `if (diff < 0) diff += 86400_000` already handles the case where the resulting timestamp is in the past.

```js
let diffMin = (h - ch) * 60 + (m - cm);
diffMin = ((diffMin % 1440) + 1440) % 1440;
if (diffMin > 720) diffMin -= 1440;
```

## Tests

Adds three regression tests in `test/time-parser.test.js`:

- positive-offset tz with future reset → targets today (~13.6h, was ~37.6h)
- negative-offset tz with future reset → targets today (~2h) — passes before the fix too, documents the asymmetry
- positive-offset tz with reset already passed today → targets tomorrow (~22.6h, was ~46.6h)

Full suite: 88/88 pass.

## Test plan

- [x] `node --test test/*.test.js` — all 88 pass
- [x] Manually re-ran end-to-end against the May 3 / May 4 messages from my own install's logs — both now compute correct waits