### PR TITLE
fix(tmux): split send-keys into text + Enter so Ink TUIs reliably submit on Linux

### DIFF
--- a/src/tmux.js
+++ b/src/tmux.js
@@ -7,8 +7,30 @@ export function buildCaptureArgs(pane, lines = 200) {
   return ['capture-pane', '-t', pane, '-p', '-S', `-${lines}`];
 }
 
+// Submit delay: when sending a message to a TUI like Claude Code (Ink-based),
+// the text and the submitting Enter must be sent as TWO separate tmux send-keys
+// calls with a brief pause between them. Without the pause, Ink on Linux often:
+//   - interprets the Enter as a newline within a bracketed-paste burst and just
+//     inserts "\n" into the input box instead of submitting (most common case)
+//   - or processes the Enter before React reconciliation has incorporated the
+//     text into input state, dropping the submit
+// 150ms is empirically reliable across Linux + macOS for Claude Code.
+export const SUBMIT_DELAY_MS = 150;
+
+// Single-call form. Kept for callers / tests that want the legacy shape; the
+// production sendKeys() below uses the split form for reliability.
 export function buildSendKeysArgs(pane, text) {
   return ['send-keys', '-t', pane, text, 'Enter'];
+}
+
+// Split form: text-only (no Enter).
+export function buildSendTextArgs(pane, text) {
+  return ['send-keys', '-t', pane, text];
+}
+
+// Split form: bare Enter.
+export function buildSendEnterArgs(pane) {
+  return ['send-keys', '-t', pane, 'Enter'];
 }
 
 export function buildDisplayArgs(pane, format) {
@@ -32,7 +54,10 @@ export async function capturePane(pane, lines = 200) {
 }
 
 export async function sendKeys(pane, text) {
-  await execFileAsync('tmux', buildSendKeysArgs(pane, text));
+  // Submit-to-TUI in two steps. See SUBMIT_DELAY_MS for why.
+  await execFileAsync('tmux', buildSendTextArgs(pane, text));
+  await new Promise(r => setTimeout(r, SUBMIT_DELAY_MS));
+  await execFileAsync('tmux', buildSendEnterArgs(pane));
 }
 
 export async function getPaneCommand(pane) {

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCaptureArgs, buildSendKeysArgs, buildDisplayArgs, parseTmuxVersion } from '../src/tmux.js';
+import { buildCaptureArgs, buildSendKeysArgs, buildSendTextArgs, buildSendEnterArgs, buildDisplayArgs, parseTmuxVersion, SUBMIT_DELAY_MS } from '../src/tmux.js';
 
 describe('buildCaptureArgs', () => {
   it('builds correct args', () => {
@@ -9,9 +9,27 @@ describe('buildCaptureArgs', () => {
   });
 });
 describe('buildSendKeysArgs', () => {
-  it('builds correct args with Enter', () => {
+  it('builds correct args with Enter (legacy single-call form)', () => {
     assert.deepEqual(buildSendKeysArgs('%3', 'hello world'),
       ['send-keys', '-t', '%3', 'hello world', 'Enter']);
+  });
+});
+describe('buildSendTextArgs', () => {
+  it('builds text-only send-keys args (no Enter)', () => {
+    assert.deepEqual(buildSendTextArgs('%3', 'hello world'),
+      ['send-keys', '-t', '%3', 'hello world']);
+  });
+});
+describe('buildSendEnterArgs', () => {
+  it('builds bare-Enter send-keys args', () => {
+    assert.deepEqual(buildSendEnterArgs('%3'),
+      ['send-keys', '-t', '%3', 'Enter']);
+  });
+});
+describe('SUBMIT_DELAY_MS', () => {
+  it('is a positive number giving Ink time to reconcile before Enter', () => {
+    assert.equal(typeof SUBMIT_DELAY_MS, 'number');
+    assert.ok(SUBMIT_DELAY_MS >= 50 && SUBMIT_DELAY_MS <= 1000);
   });
 });
 describe('buildDisplayArgs', () => {


### PR DESCRIPTION
## Summary
- Splits `sendKeys()` from one `tmux send-keys "<text>" Enter` call into two calls (text-only, then bare Enter) with a 150ms delay between them.
- Fixes the Linux failure mode where the retry message lands in Claude's input box but is never actually submitted to the LLM — monitor logs "Sent retry message" while Claude sits idle waiting for input.

## Why this fails today on Linux

Claude Code is an Ink-based React TUI that reads stdin in raw mode and applies its own key-event processing. When tmux dispatches the text and Enter in a single `send-keys` call, the keystrokes arrive back-to-back, and one of three things goes wrong (most often on Linux):

1. **Bracketed-paste mode** (`\x1b[?2004h`) interprets the Enter as a newline-within-paste — `\n` gets inserted into the input rather than submitting (the most common failure)
2. Ink's async React reconciliation may not have incorporated the text into input state before Enter fires
3. Linux pty `\r`/`\n` translation differs from macOS — the same code that works on macOS can silently fail on Linux

I hit (1) consistently on Linux: monitor confirms "Sent retry message" and the literal string lands in Claude's input box, but the message is never sent to the LLM. The user has to hit Enter manually to actually submit.

## The fix

Send the text, wait ~150ms (lets Ink reconcile + exits paste-mode buffering), then send `Enter` alone as a discrete keystroke. 150ms is empirically reliable across both Linux and macOS for Claude Code.

```js
await execFile('tmux', ['send-keys', '-t', pane, text]);    // text only
await sleep(SUBMIT_DELAY_MS);                                // 150ms
await execFile('tmux', ['send-keys', '-t', pane, 'Enter']); // discrete Enter = submit
```

## Changes
- `src/tmux.js`: split `sendKeys()` into two `execFile` calls with `SUBMIT_DELAY_MS` (= 150) between. Added `buildSendTextArgs()` and `buildSendEnterArgs()` helpers. Kept `buildSendKeysArgs()` for backward compat.
- `test/tmux.test.js`: added tests for the new split helpers + delay constant.

## Test plan
- [x] `npm test` — all 88 tests pass on Linux
- [x] Manually verified the patched install on Linux against a real Claude Code session: text+Enter now submits reliably.