### PR TITLE
Fix adjust spend limit menu handling

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,13 +1,26 @@
-import { stripAnsi, isRateLimited, findRateLimitMessage } from './patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, findSpendLimitMenuAction } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
-import { capturePane, sendKeys, getPaneCommand, isProcessForeground } from './tmux.js';
+import { capturePane, sendKeys, sendKeySequence, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
+const MENU_ACTION_COOLDOWN_MS = 15_000;
 
 export function createMonitorState() {
-  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null };
+  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null, menuActionCooldownUntil: 0 };
+}
+
+async function isClaudeReadyForInput(state, tmuxAdapter, pane, config) {
+  const isFg = await tmuxAdapter.isClaudeForeground();
+  if (isFg === true) return true;
+
+  const fg = await tmuxAdapter.getPaneCommand(pane);
+  const fgCommands = config.foregroundCommands || DEFAULT_FOREGROUND_COMMANDS;
+  if (fgCommands.some(c => fg.toLowerCase().includes(c))) return true;
+
+  state._lastForeground = fg;
+  return false;
 }
 
 export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) {
@@ -15,14 +28,27 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
 
   const raw = await tmuxAdapter.capturePane(pane, 20);
   const stripped = stripAnsi(raw);
+  const spendLimitMenuAction = findSpendLimitMenuAction(stripped);
+  const rateLimited = isRateLimited(stripped, config.customPatterns) || spendLimitMenuAction !== null;
 
   if (state.status === 'waiting') {
+    if (spendLimitMenuAction && Date.now() >= state.menuActionCooldownUntil) {
+      if (!isAlive()) return 'exit';
+      if (!await isClaudeReadyForInput(state, tmuxAdapter, pane, config)) {
+        state.waitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 6);
+        return 'skipped-not-claude';
+      }
+      state.menuActionCooldownUntil = Date.now() + MENU_ACTION_COOLDOWN_MS;
+      await tmuxAdapter.sendKeySequence(pane, spendLimitMenuAction.keys);
+      return 'selected-wait-for-reset';
+    }
+
     if (Date.now() < state.waitUntil) return 'waiting';
     if (!isAlive()) return 'exit';
 
     // Always check if rate limit cleared FIRST — even when maxRetries
     // exhausted, the user (or time passing) may have resolved it.
-    if (!isRateLimited(stripped, config.customPatterns)) {
+    if (!rateLimited) {
       state.status = 'monitoring'; state.attempts = 0;
       return 'user-continued';
     }
@@ -34,20 +60,9 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
       return 'max-retries';
     }
 
-    // Primary check: is the Claude process in the foreground process group?
-    // On macOS, pane_current_command reports "zsh" instead of the child process,
-    // so we use `ps -o stat=` to check the '+' (foreground) flag directly.
-    // `true` short-circuits past pane_current_command (fixes macOS).
-    // `false`/`null` falls back to pane_current_command for safety.
-    const isFg = await tmuxAdapter.isClaudeForeground();
-    if (isFg !== true) {
-      const fg = await tmuxAdapter.getPaneCommand(pane);
-      const fgCommands = config.foregroundCommands || DEFAULT_FOREGROUND_COMMANDS;
-      if (!fgCommands.some(c => fg.toLowerCase().includes(c))) {
-        state.waitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 6);
-        state._lastForeground = fg;
-        return 'skipped-not-claude';
-      }
+    if (!await isClaudeReadyForInput(state, tmuxAdapter, pane, config)) {
+      state.waitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 6);
+      return 'skipped-not-claude';
     }
 
     // Increment attempts and set cooldown BEFORE sendKeys so that a failure
@@ -58,12 +73,21 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
     return 'retried';
   }
 
-  if (isRateLimited(stripped, config.customPatterns)) {
+  if (rateLimited) {
     const message = findRateLimitMessage(stripped, config.customPatterns);
     state.lastRateLimitMessage = message;
     const parsed = message ? parseResetTime(message) : null;
     state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
     state.status = 'waiting';
+    if (spendLimitMenuAction && Date.now() >= state.menuActionCooldownUntil) {
+      if (!await isClaudeReadyForInput(state, tmuxAdapter, pane, config)) {
+        state.waitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 6);
+        return 'skipped-not-claude';
+      }
+      state.menuActionCooldownUntil = Date.now() + MENU_ACTION_COOLDOWN_MS;
+      await tmuxAdapter.sendKeySequence(pane, spendLimitMenuAction.keys);
+      return 'selected-wait-for-reset';
+    }
     return 'waiting';
   }
 
@@ -79,7 +103,7 @@ export async function startMonitor(pane, pid) {
 
   await logger.info(`Monitor started for pane ${pane} (claude PID: ${pid})`);
 
-  const tmuxAdapter = { capturePane, sendKeys, getPaneCommand, isClaudeForeground: () => isProcessForeground(pid) };
+  const tmuxAdapter = { capturePane, sendKeys, sendKeySequence, getPaneCommand, isClaudeForeground: () => isProcessForeground(pid) };
   const isAlive = () => { try { process.kill(pid, 0); return true; } catch { return false; } };
 
   const loop = async () => {
@@ -88,11 +112,12 @@ export async function startMonitor(pane, pid) {
       consecutiveErrors = 0;
 
       if (result === 'exit') { await logger.info('Claude exited. Monitor shutting down.'); process.exit(0); }
-      if (result === 'waiting' && state.lastRateLimitMessage) {
+      if ((result === 'waiting' || result === 'selected-wait-for-reset') && state.lastRateLimitMessage) {
         const secs = Math.round((state.waitUntil - Date.now()) / 1000);
         await logger.info(`Rate limit detected: "${state.lastRateLimitMessage}". Waiting ${secs}s...`);
         state.lastRateLimitMessage = null;
       }
+      if (result === 'selected-wait-for-reset') await logger.info('Detected Claude spend-limit menu and selected "Wait for limit to reset".');
       if (result === 'retried') await logger.info(`Sent retry message (attempt ${state.attempts})`);
       if (result === 'user-continued') await logger.info('User already continued. Attempt counter reset.');
       if (result === 'max-retries') await logger.warn(`Max retries (${config.maxRetries}) reached. Monitor still active but will not send further retries until rate limit clears.`);

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -26,6 +26,8 @@ const LIMIT_PATTERNS = [
   /(?:hit|exceeded|reached).*(?:your|the)\s*(?:\d+-hour\s+)?limit/i,  // "hit/exceeded/reached your limit"
   /\d+-hour limit/i,                                // "5-hour limit"
   /limit reached/i,                                  // "limit reached"
+  /session limit/i,                                  // "You've hit your session limit"
+  /weekly limit/i,                                   // "Weekly limit reached"
   /usage limit/i,                                    // "usage limit"
   /out of.*usage/i,                                  // "out of extra usage"
   /rate limit/i,                                     // "rate limit"

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -90,12 +90,27 @@ export function findRateLimitMessage(text, customPatterns = []) {
 
 export function findSpendLimitMenuAction(text) {
   const lines = stripAnsi(text).split('\n');
-  const promptIdx = lines.findIndex(line => /What do you want to do\?/i.test(line));
-  const waitIdx = lines.findIndex(line => /Wait for limit to reset/i.test(line));
+  const promptIdx = lines.findLastIndex
+    ? lines.findLastIndex(line => /What do you want to do\?/i.test(line))
+    : (() => {
+        for (let i = lines.length - 1; i >= 0; i--) {
+          if (/What do you want to do\?/i.test(lines[i])) return i;
+        }
+        return -1;
+      })();
 
-  if (promptIdx === -1 || waitIdx === -1) return null;
+  if (promptIdx === -1) return null;
 
-  const selectedIdx = lines.findIndex(line => /^[\s]*[❯>]/.test(line));
+  const blockEnd = Math.min(lines.length, promptIdx + 8);
+  const block = lines.slice(promptIdx, blockEnd);
+
+  const hasSpendLimitOption = block.some(line => /Adjust monthly spend limit/i.test(line));
+  const waitOffset = block.findIndex(line => /Wait for limit to reset/i.test(line));
+  if (!hasSpendLimitOption || waitOffset === -1) return null;
+
+  const selectedOffset = block.findIndex(line => /^[\s]*[❯>]/.test(line));
+  const waitIdx = promptIdx + waitOffset;
+  const selectedIdx = selectedOffset === -1 ? -1 : promptIdx + selectedOffset;
   const keys = [];
 
   if (selectedIdx === -1) {

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -87,3 +87,25 @@ export function findRateLimitMessage(text, customPatterns = []) {
 
   return null;
 }
+
+export function findSpendLimitMenuAction(text) {
+  const lines = stripAnsi(text).split('\n');
+  const promptIdx = lines.findIndex(line => /What do you want to do\?/i.test(line));
+  const waitIdx = lines.findIndex(line => /Wait for limit to reset/i.test(line));
+
+  if (promptIdx === -1 || waitIdx === -1) return null;
+
+  const selectedIdx = lines.findIndex(line => /^[\s]*[❯>]/.test(line));
+  const keys = [];
+
+  if (selectedIdx === -1) {
+    keys.push('Down');
+  } else if (selectedIdx < waitIdx) {
+    keys.push(...Array(waitIdx - selectedIdx).fill('Down'));
+  } else if (selectedIdx > waitIdx) {
+    keys.push(...Array(selectedIdx - waitIdx).fill('Up'));
+  }
+
+  keys.push('Enter');
+  return { keys };
+}

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -32,7 +32,12 @@ export async function capturePane(pane, lines = 200) {
 }
 
 export async function sendKeys(pane, text) {
-  await execFileAsync('tmux', buildSendKeysArgs(pane, text));
+  // Send text and Enter as separate commands with a delay between them.
+  // Sending both in one tmux call causes Enter to fire before Claude Code's
+  // input handler finishes processing the text, silently dropping the submit.
+  await execFileAsync('tmux', ['send-keys', '-t', pane, text]);
+  await new Promise(r => setTimeout(r, 500));
+  await execFileAsync('tmux', ['send-keys', '-t', pane, 'Enter']);
 }
 
 export async function getPaneCommand(pane) {

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -40,6 +40,15 @@ export async function sendKeys(pane, text) {
   await execFileAsync('tmux', ['send-keys', '-t', pane, 'Enter']);
 }
 
+export async function sendKeySequence(pane, keys, delayMs = 250) {
+  for (let i = 0; i < keys.length; i++) {
+    await execFileAsync('tmux', ['send-keys', '-t', pane, keys[i]]);
+    if (i < keys.length - 1) {
+      await new Promise(r => setTimeout(r, delayMs));
+    }
+  }
+}
+
 export async function getPaneCommand(pane) {
   const { stdout } = await execFileAsync('tmux', buildDisplayArgs(pane, '#{pane_current_command}'));
   return stdout.trim();

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -6,9 +6,11 @@ import { DEFAULT_CONFIG } from '../src/config.js';
 function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
   const t = {
     _sent: [],
+    _sentKeySequences: [],
     capturePane: async () => paneContent,
     getPaneCommand: async () => paneCommand,
     sendKeys: async (_p, text) => { t._sent.push(text); },
+    sendKeySequence: async (_p, keys) => { t._sentKeySequences.push(keys); },
     isClaudeForeground: async () => claudeForeground,
   };
   return t;
@@ -48,6 +50,19 @@ describe('processOneTick', () => {
     const t = mockTmux('⚠ You\'ve hit your limit\n· resets 3pm (UTC)');
     const s = createMonitorState();
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.ok(s.waitUntil > Date.now());
+  });
+  it('selects "Wait for limit to reset" when Claude shows the spend-limit menu', async () => {
+    const t = mockTmux([
+      'What do you want to do?',
+      '❯ Adjust monthly spend limit: Unlimited',
+      '  Wait for limit to reset',
+      '  Resets 11:20pm (America/New_York)',
+    ].join('\n'));
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'selected-wait-for-reset');
+    assert.deepEqual(t._sentKeySequences, [['Down', 'Enter']]);
+    assert.equal(s.status, 'waiting');
     assert.ok(s.waitUntil > Date.now());
   });
   it('retries when Claude process is in foreground (fixes macOS zsh issue)', async () => {
@@ -93,6 +108,20 @@ describe('processOneTick', () => {
     s.waitUntil = Date.now() - 1000; s.status = 'waiting'; s.attempts = 2;
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'user-continued');
     assert.equal(s.attempts, 0);
+  });
+  it('can select the spend-limit menu while already waiting', async () => {
+    const t = mockTmux([
+      'What do you want to do?',
+      '❯ Adjust monthly spend limit: Unlimited',
+      '  Wait for limit to reset',
+      '  Resets 11:20pm (America/New_York)',
+    ].join('\n'));
+    const s = createMonitorState();
+    s.status = 'waiting';
+    s.waitUntil = Date.now() + 60_000;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'selected-wait-for-reset');
+    assert.deepEqual(t._sentKeySequences, [['Down', 'Enter']]);
+    assert.equal(t._sent.length, 0);
   });
   it('stops retrying after max attempts and stays in waiting', async () => {
     const t = mockTmux('5-hour limit reached - resets 3pm (UTC)');

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -137,6 +137,32 @@ describe('findSpendLimitMenuAction', () => {
   it('returns null when the spend-limit menu is absent', () => {
     assert.equal(findSpendLimitMenuAction('Normal Claude output'), null);
   });
+
+  it('ignores stale spend-limit text when a later unrelated menu is selected', () => {
+    const text = [
+      'What do you want to do?',
+      '❯ Adjust monthly spend limit: Unlimited',
+      '  Wait for limit to reset',
+      '  Upgrade to Max for higher session limits every month',
+      'Some later output',
+      'What do you want to do?',
+      '❯ Open conversation history',
+      '  Cancel',
+    ].join('\n');
+
+    assert.equal(findSpendLimitMenuAction(text), null);
+  });
+
+  it('requires the monthly spend option to be present', () => {
+    const text = [
+      'What do you want to do?',
+      '❯ Retry request',
+      '  Wait for limit to reset',
+      '  Cancel',
+    ].join('\n');
+
+    assert.equal(findSpendLimitMenuAction(text), null);
+  });
 });
 
 describe('stripAnsi (OSC sequences)', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { stripAnsi, isRateLimited, findRateLimitMessage } from '../src/patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, findSpendLimitMenuAction } from '../src/patterns.js';
 
 describe('stripAnsi', () => {
   it('removes bold codes', () => {
@@ -108,6 +108,34 @@ describe('isRateLimited (multi-line TUI renders)', () => {
   });
   it('rejects normal output with no rate limit keywords', () => {
     assert.equal(isRateLimited('Working on your request\nHere is the code\nDone'), false);
+  });
+});
+
+describe('findSpendLimitMenuAction', () => {
+  it('returns Down + Enter when the wait option is one row below the selected item', () => {
+    const text = [
+      'What do you want to do?',
+      '❯ Adjust monthly spend limit: Unlimited',
+      '  Wait for limit to reset',
+      '  Upgrade to Max for higher session limits every month',
+    ].join('\n');
+
+    assert.deepEqual(findSpendLimitMenuAction(text), { keys: ['Down', 'Enter'] });
+  });
+
+  it('returns Enter when wait is already selected', () => {
+    const text = [
+      'What do you want to do?',
+      '  Adjust monthly spend limit: Unlimited',
+      '❯ Wait for limit to reset',
+      '  Upgrade to Max for higher session limits every month',
+    ].join('\n');
+
+    assert.deepEqual(findSpendLimitMenuAction(text), { keys: ['Enter'] });
+  });
+
+  it('returns null when the spend-limit menu is absent', () => {
+    assert.equal(findSpendLimitMenuAction('Normal Claude output'), null);
   });
 });
 

--- a/test/session-limit.test.js
+++ b/test/session-limit.test.js
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isRateLimited, findRateLimitMessage } from '../src/patterns.js';
+
+// Regression tests for newer Claude Code rate-limit wordings that the
+// original LIMIT_PATTERNS did not cover: "session limit" and "weekly limit".
+// See: https://github.com/cheapestinference/claude-auto-retry/issues
+
+test('detects "You\'ve hit your session limit" with reset time', () => {
+  const msg = "⚠ You've hit your session limit · resets 6pm (America/Chicago)";
+  assert.equal(isRateLimited(msg), true);
+});
+
+test('detects session limit rendered across multiple TUI lines', () => {
+  const msg = [
+    "⏺ Update(src/app.js)",
+    "  ⎿  You've hit your session limit",
+    "     · resets 3pm (UTC)",
+  ].join('\n');
+  assert.equal(isRateLimited(msg), true);
+});
+
+test('detects "Weekly limit reached" with reset time', () => {
+  const msg = 'Weekly limit reached · resets 9am';
+  assert.equal(isRateLimited(msg), true);
+});
+
+test('findRateLimitMessage returns the resets line for a session limit', () => {
+  const msg = "You've hit your session limit · resets 6pm (America/Chicago)";
+  const found = findRateLimitMessage(msg);
+  assert.ok(found && /resets/i.test(found), `expected a resets line, got: ${found}`);
+});
+
+test('does not flag a benign mention of "session limit" without a reset', () => {
+  const msg = 'We were discussing the session limit feature in the meeting.';
+  assert.equal(isRateLimited(msg), false);
+});
+
+test('does not flag the word "weekly limit" without a reset', () => {
+  const msg = 'The weekly limit feature shipped last week.';
+  assert.equal(isRateLimited(msg), false);
+});


### PR DESCRIPTION
This is an extension of #13

#13 only taught claude-auto-retry to recognize newer rate-limit text like “session limit” and “weekly limit.” It improved detection in src/patterns.js, but it still assumed the recovery path was the same as before: wait until reset, then send the normal retry/continue message.

My case was different because Claude didn’t just show a passive rate-limit message. It showed an interactive spend-limit menu with What do you want to do? and Wait for limit to reset. In that flow, sending the usual continue message is not enough. The tool has to drive the TUI first by selecting the Wait for limit to reset option with tmux keypresses, then wait, then send continue. The base branch had no menu detection or tmux navigation logic for that path, so it couldn’t handle this use case.

One follow-up issue I found while adding that support was that generic menu detection can be dangerous: Claude can show other What do you want to do? menus, and stale scrollback can also confuse matching. So the final fix narrows the matcher to the specific spend-limit menu block, rather than any generic menu with similar text.