### PR TITLE
Handle Claude rate-limit options prompt

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,6 +1,6 @@
 import { stripAnsi, isRateLimited, findRateLimitMessage } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
-import { capturePane, sendKeys, getPaneCommand, isProcessForeground } from './tmux.js';
+import { capturePane, sendKeys, sendEnter, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 
@@ -10,11 +10,28 @@ export function createMonitorState() {
   return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null };
 }
 
+function isRateLimitOptionsPrompt(text) {
+  return /\/rate-limit-options/i.test(text)
+    && /What do you want to do\?/i.test(text)
+    && /Stop and wait for limit to reset/i.test(text)
+    && /Enter to confirm/i.test(text);
+}
+
 export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) {
   if (!isAlive()) return 'exit';
 
   const raw = await tmuxAdapter.capturePane(pane, 20);
   const stripped = stripAnsi(raw);
+
+  if (state.status === 'monitoring' && isRateLimitOptionsPrompt(stripped)) {
+    const message = findRateLimitMessage(stripped, config.customPatterns);
+    const parsed = message ? parseResetTime(message) : null;
+    state.lastRateLimitMessage = message;
+    state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
+    state.status = 'waiting';
+    await tmuxAdapter.sendEnter(pane);
+    return 'confirmed-rate-limit-options';
+  }
 
   if (state.status === 'waiting') {
     if (Date.now() < state.waitUntil) return 'waiting';
@@ -79,7 +96,7 @@ export async function startMonitor(pane, pid) {
 
   await logger.info(`Monitor started for pane ${pane} (claude PID: ${pid})`);
 
-  const tmuxAdapter = { capturePane, sendKeys, getPaneCommand, isClaudeForeground: () => isProcessForeground(pid) };
+  const tmuxAdapter = { capturePane, sendKeys, sendEnter, getPaneCommand, isClaudeForeground: () => isProcessForeground(pid) };
   const isAlive = () => { try { process.kill(pid, 0); return true; } catch { return false; } };
 
   const loop = async () => {
@@ -93,6 +110,7 @@ export async function startMonitor(pane, pid) {
         await logger.info(`Rate limit detected: "${state.lastRateLimitMessage}". Waiting ${secs}s...`);
         state.lastRateLimitMessage = null;
       }
+      if (result === 'confirmed-rate-limit-options') await logger.info('Confirmed Claude rate-limit wait option.');
       if (result === 'retried') await logger.info(`Sent retry message (attempt ${state.attempts})`);
       if (result === 'user-continued') await logger.info('User already continued. Attempt counter reset.');
       if (result === 'max-retries') await logger.warn(`Max retries (${config.maxRetries}) reached. Monitor still active but will not send further retries until rate limit clears.`);

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -7,7 +7,14 @@ import { createLogger } from './logger.js';
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 
 export function createMonitorState() {
-  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null, retrySentForCurrentLimit: false };
+  return {
+    status: 'monitoring',
+    waitUntil: 0,
+    attempts: 0,
+    lastRateLimitMessage: null,
+    retrySentForCurrentLimit: false,
+    rateLimitOptionsConfirmed: false,
+  };
 }
 
 function isRateLimitOptionsPrompt(text) {
@@ -29,12 +36,13 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
   const raw = await tmuxAdapter.capturePane(pane, 20);
   const stripped = stripAnsi(raw);
 
-  if (state.status === 'monitoring' && isRateLimitOptionsPrompt(stripped)) {
+  if (!state.rateLimitOptionsConfirmed && isRateLimitOptionsPrompt(stripped)) {
     const message = findRateLimitMessage(stripped, config.customPatterns);
     const parsed = message ? parseResetTime(message) : null;
     state.lastRateLimitMessage = message;
     state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
     state.status = 'waiting';
+    state.rateLimitOptionsConfirmed = true;
     await tmuxAdapter.sendEnter(pane);
     return 'confirmed-rate-limit-options';
   }
@@ -44,14 +52,14 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
     if (!isAlive()) return 'exit';
 
     if (isClaudeBusy(stripped)) {
-      state.status = 'monitoring'; state.attempts = 0; state.retrySentForCurrentLimit = false;
+      state.status = 'monitoring'; state.attempts = 0; state.retrySentForCurrentLimit = false; state.rateLimitOptionsConfirmed = false;
       return 'user-continued';
     }
 
     // Always check if rate limit cleared FIRST — even when maxRetries
     // exhausted, the user (or time passing) may have resolved it.
     if (!isRateLimited(stripped, config.customPatterns)) {
-      state.status = 'monitoring'; state.attempts = 0; state.retrySentForCurrentLimit = false;
+      state.status = 'monitoring'; state.attempts = 0; state.retrySentForCurrentLimit = false; state.rateLimitOptionsConfirmed = false;
       return 'user-continued';
     }
 
@@ -98,6 +106,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
     const parsed = message ? parseResetTime(message) : null;
     state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
     state.status = 'waiting';
+    state.rateLimitOptionsConfirmed = false;
     return 'waiting';
   }
 

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -7,7 +7,7 @@ import { createLogger } from './logger.js';
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 
 export function createMonitorState() {
-  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null };
+  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null, retrySentForCurrentLimit: false };
 }
 
 function isRateLimitOptionsPrompt(text) {
@@ -15,6 +15,12 @@ function isRateLimitOptionsPrompt(text) {
     && /What do you want to do\?/i.test(text)
     && /Stop and wait for limit to reset/i.test(text)
     && /Enter to confirm/i.test(text);
+}
+
+function isClaudeBusy(text) {
+  return /\bHerding\b/i.test(text)
+    || /still thinking/i.test(text)
+    || /thinking (?:with|more|hard|.*effort)/i.test(text);
 }
 
 export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) {
@@ -37,11 +43,21 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
     if (Date.now() < state.waitUntil) return 'waiting';
     if (!isAlive()) return 'exit';
 
+    if (isClaudeBusy(stripped)) {
+      state.status = 'monitoring'; state.attempts = 0; state.retrySentForCurrentLimit = false;
+      return 'user-continued';
+    }
+
     // Always check if rate limit cleared FIRST — even when maxRetries
     // exhausted, the user (or time passing) may have resolved it.
     if (!isRateLimited(stripped, config.customPatterns)) {
-      state.status = 'monitoring'; state.attempts = 0;
+      state.status = 'monitoring'; state.attempts = 0; state.retrySentForCurrentLimit = false;
       return 'user-continued';
+    }
+
+    if (state.retrySentForCurrentLimit) {
+      state.waitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      return 'post-retry-waiting';
     }
 
     if (state.attempts >= config.maxRetries) {
@@ -70,12 +86,13 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
     // Increment attempts and set cooldown BEFORE sendKeys so that a failure
     // (e.g. pane destroyed) still consumes a retry and avoids tight-loop errors.
     state.attempts++;
+    state.retrySentForCurrentLimit = true;
     state.waitUntil = Date.now() + 30_000;
     await tmuxAdapter.sendKeys(pane, config.retryMessage);
     return 'retried';
   }
 
-  if (isRateLimited(stripped, config.customPatterns)) {
+  if (!isClaudeBusy(stripped) && isRateLimited(stripped, config.customPatterns)) {
     const message = findRateLimitMessage(stripped, config.customPatterns);
     state.lastRateLimitMessage = message;
     const parsed = message ? parseResetTime(message) : null;
@@ -112,6 +129,7 @@ export async function startMonitor(pane, pid) {
       }
       if (result === 'confirmed-rate-limit-options') await logger.info('Confirmed Claude rate-limit wait option.');
       if (result === 'retried') await logger.info(`Sent retry message (attempt ${state.attempts})`);
+      if (result === 'post-retry-waiting') await logger.info('Retry message already sent for current rate-limit event; waiting for pane to clear stale limit text.');
       if (result === 'user-continued') await logger.info('User already continued. Attempt counter reset.');
       if (result === 'max-retries') await logger.warn(`Max retries (${config.maxRetries}) reached. Monitor still active but will not send further retries until rate limit clears.`);
       if (result === 'skipped-not-claude') await logger.warn(`Foreground is "${state._lastForeground}", not Claude. Skipping send-keys. (Add to foregroundCommands in ~/.claude-auto-retry.json if this is wrong)`);

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -26,8 +26,12 @@ function isRateLimitOptionsPrompt(text) {
 
 function isClaudeBusy(text) {
   return /\bHerding\b/i.test(text)
+    || /\b(?:Booping|Cooking|Brewing|Brewed|Sautéing|Sauteing)\b/i.test(text)
     || /still thinking/i.test(text)
-    || /thinking (?:with|more|hard|.*effort)/i.test(text);
+    || /thinking (?:with|more|hard|.*effort)/i.test(text)
+    || /\([^)]+tokens\)/i.test(text)
+    || /\b\d+[smh]\s*·\s*↓\s*[\d.]+[kM]?\s*tokens\b/i.test(text)
+    || (/esc to interrupt/i.test(text) && /(?:tokens|↓ to manage|Backgrounded agent|Agent\()/i.test(text));
 }
 
 export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) {

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -23,7 +23,7 @@ export function stripAnsi(text) {
 // Detection: find a "limit" line and a "resets" line within 6 lines of each other.
 
 const LIMIT_PATTERNS = [
-  /(?:hit|exceeded|reached).*(?:your|the)\s*(?:\d+-hour\s+)?limit/i,  // "hit/exceeded/reached your limit"
+  /(?:hit|exceeded|reached).*(?:your|the).*(?:\d+-hour\s+)?limit/i,  // "hit/exceeded/reached your/session limit"
   /\d+-hour limit/i,                                // "5-hour limit"
   /limit reached/i,                                  // "limit reached"
   /usage limit/i,                                    // "usage limit"

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -8,7 +8,7 @@ export function buildCaptureArgs(pane, lines = 200) {
 }
 
 export function buildSendKeysArgs(pane, text) {
-  return ['send-keys', '-t', pane, text, 'Enter'];
+  return ['send-keys', '-l', '-t', pane, text];
 }
 
 export function buildSendEnterArgs(pane) {
@@ -37,6 +37,7 @@ export async function capturePane(pane, lines = 200) {
 
 export async function sendKeys(pane, text) {
   await execFileAsync('tmux', buildSendKeysArgs(pane, text));
+  await execFileAsync('tmux', buildSendEnterArgs(pane));
 }
 
 export async function sendEnter(pane) {

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -11,6 +11,10 @@ export function buildSendKeysArgs(pane, text) {
   return ['send-keys', '-t', pane, text, 'Enter'];
 }
 
+export function buildSendEnterArgs(pane) {
+  return ['send-keys', '-t', pane, 'Enter'];
+}
+
 export function buildDisplayArgs(pane, format) {
   return ['display-message', '-t', pane, '-p', format];
 }
@@ -33,6 +37,10 @@ export async function capturePane(pane, lines = 200) {
 
 export async function sendKeys(pane, text) {
   await execFileAsync('tmux', buildSendKeysArgs(pane, text));
+}
+
+export async function sendEnter(pane) {
+  await execFileAsync('tmux', buildSendEnterArgs(pane));
 }
 
 export async function getPaneCommand(pane) {

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -12,7 +12,7 @@ export function buildSendKeysArgs(pane, text) {
 }
 
 export function buildSendEnterArgs(pane) {
-  return ['send-keys', '-t', pane, 'Enter'];
+  return ['send-keys', '-t', pane, 'C-m'];
 }
 
 export function buildDisplayArgs(pane, format) {

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -6,9 +6,11 @@ import { DEFAULT_CONFIG } from '../src/config.js';
 function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
   const t = {
     _sent: [],
+    _entered: 0,
     capturePane: async () => paneContent,
     getPaneCommand: async () => paneCommand,
     sendKeys: async (_p, text) => { t._sent.push(text); },
+    sendEnter: async () => { t._entered++; },
     isClaudeForeground: async () => claudeForeground,
   };
   return t;
@@ -48,6 +50,28 @@ describe('processOneTick', () => {
     const t = mockTmux('⚠ You\'ve hit your limit\n· resets 3pm (UTC)');
     const s = createMonitorState();
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.ok(s.waitUntil > Date.now());
+  });
+  it('auto-confirms Claude Code rate-limit options menu', async () => {
+    const text = [
+      '⎿  You\'ve hit your session limit · resets 12:10am (Europe/Dublin)',
+      '',
+      '❯ /rate-limit-options',
+      '',
+      'What do you want to do?',
+      '',
+      '❯ 1. Stop and wait for limit to reset',
+      '  2. Upgrade your plan',
+      '  3. Upgrade to Team plan',
+      '',
+      'Enter to confirm · Esc to cancel',
+    ].join('\n');
+    const t = mockTmux(text);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'confirmed-rate-limit-options');
+    assert.equal(t._entered, 1);
+    assert.equal(t._sent.length, 0);
+    assert.equal(s.status, 'waiting');
     assert.ok(s.waitUntil > Date.now());
   });
   it('retries when Claude process is in foreground (fixes macOS zsh issue)', async () => {

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -42,9 +42,41 @@ describe('processOneTick', () => {
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'retried');
     assert.equal(t._sent.length, 1);
     assert.equal(s.attempts, 1);
+    assert.equal(s.retrySentForCurrentLimit, true);
     // Should stay in 'waiting' with a cooldown to let Claude process
     assert.equal(s.status, 'waiting');
     assert.ok(s.waitUntil > Date.now());
+  });
+  it('does not resend retry while stale rate-limit text remains visible', async () => {
+    const t = mockTmux('5-hour limit reached - resets 3pm (UTC)');
+    const s = createMonitorState();
+    s.waitUntil = Date.now() - 1000;
+    s.status = 'waiting';
+    s.retrySentForCurrentLimit = true;
+    s.attempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'post-retry-waiting');
+    assert.equal(t._sent.length, 0);
+    assert.equal(s.attempts, 1);
+    assert.equal(s.status, 'waiting');
+    assert.ok(s.waitUntil > Date.now());
+  });
+  it('ignores stale rate-limit text while Claude is visibly thinking', async () => {
+    const t = mockTmux('5-hour limit reached - resets 3pm (UTC)\n· Herding… (3m · thinking with xhigh effort)');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+  it('clears waiting state when Claude is visibly thinking after retry', async () => {
+    const t = mockTmux('5-hour limit reached - resets 3pm (UTC)\n· Herding… (3m · thinking with xhigh effort)');
+    const s = createMonitorState();
+    s.waitUntil = Date.now() - 1000;
+    s.status = 'waiting';
+    s.retrySentForCurrentLimit = true;
+    s.attempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'user-continued');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(s.attempts, 0);
+    assert.equal(s.retrySentForCurrentLimit, false);
   });
   it('detects multi-line TUI rate limit', async () => {
     const t = mockTmux('⚠ You\'ve hit your limit\n· resets 3pm (UTC)');

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -106,6 +106,29 @@ describe('processOneTick', () => {
     assert.equal(s.status, 'waiting');
     assert.ok(s.waitUntil > Date.now());
   });
+  it('auto-confirms rate-limit options menu even after entering waiting mode', async () => {
+    const text = [
+      '⎿  You\'ve hit your session limit · resets 5:10am (Europe/Dublin)',
+      '',
+      '❯ /rate-limit-options',
+      '',
+      'What do you want to do?',
+      '',
+      '❯ 1. Stop and wait for limit to reset',
+      '  2. Upgrade your plan',
+      '  3. Upgrade to Team plan',
+      '',
+      'Enter to confirm · Esc to cancel',
+    ].join('\n');
+    const t = mockTmux(text);
+    const s = createMonitorState();
+    s.status = 'waiting';
+    s.waitUntil = Date.now() + 10_000;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'confirmed-rate-limit-options');
+    assert.equal(t._entered, 1);
+    assert.equal(s.status, 'waiting');
+    assert.equal(s.rateLimitOptionsConfirmed, true);
+  });
   it('retries when Claude process is in foreground (fixes macOS zsh issue)', async () => {
     const t = mockTmux('5-hour limit reached - resets 3pm (UTC)', 'zsh', true);
     const s = createMonitorState();

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -66,8 +66,37 @@ describe('processOneTick', () => {
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'monitoring');
     assert.equal(t._sent.length, 0);
   });
+  it('ignores stale rate-limit text while Claude is showing active token status', async () => {
+    const text = [
+      '⎿  You\'ve hit your session limit · resets 2am (Europe/Dublin)',
+      '✽ Booping… (1m 43s · ↓ 5.6k tokens)',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt · ↓ to manage',
+      '  ◯ general-purpose  Retry demo-weekend engine prep  24s · ↓ 22.7k tokens',
+    ].join('\n');
+    const t = mockTmux(text);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
   it('clears waiting state when Claude is visibly thinking after retry', async () => {
     const t = mockTmux('5-hour limit reached - resets 3pm (UTC)\n· Herding… (3m · thinking with xhigh effort)');
+    const s = createMonitorState();
+    s.waitUntil = Date.now() - 1000;
+    s.status = 'waiting';
+    s.retrySentForCurrentLimit = true;
+    s.attempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'user-continued');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(s.attempts, 0);
+    assert.equal(s.retrySentForCurrentLimit, false);
+  });
+  it('clears waiting state when active token status appears after retry', async () => {
+    const text = [
+      '⎿  You\'ve hit your session limit · resets 2am (Europe/Dublin)',
+      '✽ Booping… (1m 43s · ↓ 5.6k tokens)',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt · ↓ to manage',
+    ].join('\n');
+    const t = mockTmux(text);
     const s = createMonitorState();
     s.waitUntil = Date.now() - 1000;
     s.status = 'waiting';

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -54,6 +54,9 @@ describe('isRateLimited', () => {
   it('detects "You\'ve hit your limit" (real Claude Code message)', () => {
     assert.equal(isRateLimited("You've hit your limit · resets 3pm (Asia/Tbilisi)"), true);
   });
+  it('detects "You\'ve hit your session limit" (new Claude Code message)', () => {
+    assert.equal(isRateLimited("You've hit your session limit · resets 12:10am (Europe/Dublin)"), true);
+  });
   it('detects "hit the limit resets"', () => {
     assert.equal(isRateLimited('You hit the limit. Resets at 5pm'), true);
   });

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCaptureArgs, buildSendKeysArgs, buildDisplayArgs, parseTmuxVersion } from '../src/tmux.js';
+import { buildCaptureArgs, buildSendKeysArgs, buildSendEnterArgs, buildDisplayArgs, parseTmuxVersion } from '../src/tmux.js';
 
 describe('buildCaptureArgs', () => {
   it('builds correct args', () => {
@@ -12,6 +12,11 @@ describe('buildSendKeysArgs', () => {
   it('builds correct args with Enter', () => {
     assert.deepEqual(buildSendKeysArgs('%3', 'hello world'),
       ['send-keys', '-t', '%3', 'hello world', 'Enter']);
+  });
+});
+describe('buildSendEnterArgs', () => {
+  it('builds correct args for bare Enter', () => {
+    assert.deepEqual(buildSendEnterArgs('%3'), ['send-keys', '-t', '%3', 'Enter']);
   });
 });
 describe('buildDisplayArgs', () => {

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -9,9 +9,9 @@ describe('buildCaptureArgs', () => {
   });
 });
 describe('buildSendKeysArgs', () => {
-  it('builds correct args with Enter', () => {
+  it('builds correct args for literal text', () => {
     assert.deepEqual(buildSendKeysArgs('%3', 'hello world'),
-      ['send-keys', '-t', '%3', 'hello world', 'Enter']);
+      ['send-keys', '-l', '-t', '%3', 'hello world']);
   });
 });
 describe('buildSendEnterArgs', () => {

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -15,8 +15,8 @@ describe('buildSendKeysArgs', () => {
   });
 });
 describe('buildSendEnterArgs', () => {
-  it('builds correct args for bare Enter', () => {
-    assert.deepEqual(buildSendEnterArgs('%3'), ['send-keys', '-t', '%3', 'Enter']);
+  it('builds correct args for carriage return', () => {
+    assert.deepEqual(buildSendEnterArgs('%3'), ['send-keys', '-t', '%3', 'C-m']);
   });
 });
 describe('buildDisplayArgs', () => {


### PR DESCRIPTION
## Summary

Claude Code now sometimes opens `/rate-limit-options` after a subscription/session limit is hit. The existing monitor can detect the limit text and wait/retry, but if Claude is sitting on the interactive options menu, the later retry message may be sent into the wrong UI state.

This patch:
- detects the `/rate-limit-options` prompt when option 1 (`Stop and wait for limit to reset`) is selected
- sends a bare Enter to confirm the wait option
- keeps the monitor in waiting mode so it can send the configured retry message after reset
- recognizes the newer `You've hit your session limit` wording

## Tests

- `npm test`

## Notes

This was reproduced against Claude Code 2.1.170 with output like:

```text
You've hit your session limit · resets 12:10am (Europe/Dublin)
/rate-limit-options
What do you want to do?
❯ 1. Stop and wait for limit to reset
Enter to confirm · Esc to cancel
```
