### PR TITLE
fix: update regex to support 'session limit' message

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -23,7 +23,7 @@ export function stripAnsi(text) {
 // Detection: find a "limit" line and a "resets" line within 6 lines of each other.
 
 const LIMIT_PATTERNS = [
-  /(?:hit|exceeded|reached).*(?:your|the)\s*(?:\d+-hour\s+)?limit/i,  // "hit/exceeded/reached your limit"
+  /(?:hit|exceeded|reached).*(?:your|the)\s*(?:\d+-hour\s+|session\s+)?limit/i,  // "hit/exceeded/reached your limit"
   /\d+-hour limit/i,                                // "5-hour limit"
   /limit reached/i,                                  // "limit reached"
   /usage limit/i,                                    // "usage limit"

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -54,6 +54,9 @@ describe('isRateLimited', () => {
   it('detects "You\'ve hit your limit" (real Claude Code message)', () => {
     assert.equal(isRateLimited("You've hit your limit · resets 3pm (Asia/Tbilisi)"), true);
   });
+  it('detects "You\'ve hit your session limit" (new Claude Code message)', () => {
+    assert.equal(isRateLimited("You've hit your session limit · resets 4:40am (Asia/Tokyo)"), true);
+  });
   it('detects "hit the limit resets"', () => {
     assert.equal(isRateLimited('You hit the limit. Resets at 5pm'), true);
   });


### PR DESCRIPTION
Anthropic recently updated their rate limit message from 'your 5-hour limit' to 'your session limit' in Claude Code. This PR updates the regex to correctly detect the new message and adds a corresponding test case.