### PR TITLE
fix: reliable retry submission + session/weekly limit detection (#7, #15)

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -23,7 +23,7 @@ export function stripAnsi(text) {
 // Detection: find a "limit" line and a "resets" line within 6 lines of each other.
 
 const LIMIT_PATTERNS = [
-  /(?:hit|exceeded|reached).*(?:your|the)\s*(?:\d+-hour\s+)?limit/i,  // "hit/exceeded/reached your limit"
+  /(?:hit|exceeded|reached).*(?:your|the)\s*(?:[\w-]+\s+){0,3}limit/i,  // "hit/exceeded/reached your [session|weekly|5-hour] limit"
   /\d+-hour limit/i,                                // "5-hour limit"
   /limit reached/i,                                  // "limit reached"
   /usage limit/i,                                    // "usage limit"
@@ -73,14 +73,17 @@ export function isRateLimited(text, customPatterns = []) {
 export function findRateLimitMessage(text, customPatterns = []) {
   const lines = stripAnsi(text).split('\n');
 
-  // Return the "resets" line — that's what parseResetTime needs
-  for (const line of lines) {
-    if (RESET_PATTERNS.some(p => p.test(line))) return line.trim();
+  // Scan from the bottom up — the most recent "resets" line is the one to
+  // parse. The Claude TUI never clears earlier rate-limit messages from
+  // scrollback, so a forward scan would lock onto a stale line (e.g. an old
+  // "resets 11:30am" lingering above a fresh "resets 4:30pm").
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (RESET_PATTERNS.some(p => p.test(lines[i]))) return lines[i].trim();
   }
 
-  // Fallback: any "limit" line
-  for (const line of lines) {
-    if (LIMIT_PATTERNS.some(p => p.test(line))) return line.trim();
+  // Fallback: any "limit" line, also scanned from the bottom.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (LIMIT_PATTERNS.some(p => p.test(lines[i]))) return lines[i].trim();
   }
 
   return null;

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -7,8 +7,32 @@ export function buildCaptureArgs(pane, lines = 200) {
   return ['capture-pane', '-t', pane, '-p', '-S', `-${lines}`];
 }
 
+// Submit delay: when sending a message to a TUI like Claude Code (Ink-based),
+// the text and the submitting Enter must be sent as TWO separate tmux send-keys
+// calls with a brief pause between them. Without the pause, Ink on Linux often:
+//   - interprets the Enter as a newline within a bracketed-paste burst and just
+//     inserts "\n" into the input box instead of submitting (most common case)
+//   - or processes the Enter before React reconciliation has incorporated the
+//     text into input state, dropping the submit
+// 150ms is empirically reliable across Linux + macOS for Claude Code.
+export const SUBMIT_DELAY_MS = 150;
+
+// Single-call form. Kept for callers / tests that want the legacy shape; the
+// production sendKeys() below uses the split form for reliability.
 export function buildSendKeysArgs(pane, text) {
   return ['send-keys', '-t', pane, text, 'Enter'];
+}
+
+// Split form: text-only, sent literally (-l) so any tmux key names inside a
+// custom retry message (e.g. "Enter", "C-c") are typed as text rather than
+// interpreted as keypresses. No trailing Enter — that is a separate call.
+export function buildSendTextArgs(pane, text) {
+  return ['send-keys', '-t', pane, '-l', text];
+}
+
+// Split form: bare Enter to submit, sent outside the paste window.
+export function buildSendEnterArgs(pane) {
+  return ['send-keys', '-t', pane, 'Enter'];
 }
 
 export function buildDisplayArgs(pane, format) {
@@ -32,7 +56,10 @@ export async function capturePane(pane, lines = 200) {
 }
 
 export async function sendKeys(pane, text) {
-  await execFileAsync('tmux', buildSendKeysArgs(pane, text));
+  // Submit-to-TUI in two steps. See SUBMIT_DELAY_MS for why.
+  await execFileAsync('tmux', buildSendTextArgs(pane, text));
+  await new Promise(r => setTimeout(r, SUBMIT_DELAY_MS));
+  await execFileAsync('tmux', buildSendEnterArgs(pane));
 }
 
 export async function getPaneCommand(pane) {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -60,6 +60,15 @@ describe('isRateLimited', () => {
   it('detects "usage limit · resets in: 3 hours"', () => {
     assert.equal(isRateLimited('usage limit · resets in: 3 hours'), true);
   });
+  it('detects "You\'ve hit your session limit" (current Claude Code wording, #15)', () => {
+    assert.equal(isRateLimited("You've hit your session limit · resets 4:50pm (Asia/Shanghai)"), true);
+  });
+  it('detects "You\'ve hit your weekly limit" (#15)', () => {
+    assert.equal(isRateLimited("You've hit your weekly limit · resets 9am (Europe/London)"), true);
+  });
+  it('still detects "You\'ve hit your 5-hour limit" (no qualifier regression)', () => {
+    assert.equal(isRateLimited("You've hit your 5-hour limit · resets 3pm (UTC)"), true);
+  });
 });
 
 describe('stripAnsi (private-mode sequences)', () => {
@@ -86,6 +95,10 @@ describe('findRateLimitMessage', () => {
   it('returns Resets line when limit and resets on different lines', () => {
     const text = '5-hour limit reached\nResets at 3pm (UTC)';
     assert.ok(findRateLimitMessage(text).includes('3pm'));
+  });
+  it('returns the most recent resets line when scrollback has a stale one', () => {
+    const text = 'You\'ve hit your limit · resets 11:30am (UTC)\nlots of output\nYou\'ve hit your limit · resets 4:30pm (UTC)';
+    assert.ok(findRateLimitMessage(text).includes('4:30pm'));
   });
 });
 

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCaptureArgs, buildSendKeysArgs, buildDisplayArgs, parseTmuxVersion } from '../src/tmux.js';
+import { buildCaptureArgs, buildSendKeysArgs, buildSendTextArgs, buildSendEnterArgs, buildDisplayArgs, parseTmuxVersion, SUBMIT_DELAY_MS } from '../src/tmux.js';
 
 describe('buildCaptureArgs', () => {
   it('builds correct args', () => {
@@ -9,9 +9,31 @@ describe('buildCaptureArgs', () => {
   });
 });
 describe('buildSendKeysArgs', () => {
-  it('builds correct args with Enter', () => {
+  it('builds correct args with Enter (legacy single-call form)', () => {
     assert.deepEqual(buildSendKeysArgs('%3', 'hello world'),
       ['send-keys', '-t', '%3', 'hello world', 'Enter']);
+  });
+});
+describe('buildSendTextArgs', () => {
+  it('builds literal text-only send-keys args (no Enter)', () => {
+    assert.deepEqual(buildSendTextArgs('%3', 'hello world'),
+      ['send-keys', '-t', '%3', '-l', 'hello world']);
+  });
+  it('sends key-like words as literal text, not keypresses', () => {
+    assert.deepEqual(buildSendTextArgs('%3', 'press Enter to continue'),
+      ['send-keys', '-t', '%3', '-l', 'press Enter to continue']);
+  });
+});
+describe('buildSendEnterArgs', () => {
+  it('builds bare-Enter send-keys args', () => {
+    assert.deepEqual(buildSendEnterArgs('%3'),
+      ['send-keys', '-t', '%3', 'Enter']);
+  });
+});
+describe('SUBMIT_DELAY_MS', () => {
+  it('is a positive number giving Ink time to reconcile before Enter', () => {
+    assert.equal(typeof SUBMIT_DELAY_MS, 'number');
+    assert.ok(SUBMIT_DELAY_MS >= 50 && SUBMIT_DELAY_MS <= 1000);
   });
 });
 describe('buildDisplayArgs', () => {


### PR DESCRIPTION
## What

Fixes the two most-reported bugs in the tracker, each with tests:

### 1. Retry message never submitted (#7) — the "showstopper"
`sendKeys()` sent the retry text and `Enter` in a single `tmux send-keys`
call. Claude Code's Ink TUI treats that burst as a bracketed paste, so the
trailing Enter becomes a newline and the message piles up in the input box
unsent (the "5 messages, never sent" reports). Now split into **literal
text (`-l`) → short pause → bare Enter**, so the Enter lands outside the
paste window. `-l` also stops tmux key names inside a custom `retryMessage`
(e.g. "Enter", "C-c") from being interpreted as keypresses.

### 2. "session limit" / "weekly limit" not detected (#15)
Anthropic changed the wording to `You've hit your session limit` /
`weekly limit`. The limit regex only allowed an optional `N-hour` qualifier,
so these slipped past `isRateLimited()` and the monitor never waited or
retried. Broadened to accept up to three qualifier words (still backward
compatible with `5-hour limit` and bare `your limit`).

Also: `findRateLimitMessage()` now scans **bottom-up**, so it parses the
newest `resets` line instead of a stale one lingering in TUI scrollback.

## Closes
- Closes #7
- Closes #15

## Relationship to existing PRs
Consolidates the overlapping community fixes into one tested change:
- send-keys fix: supersedes #11, and the send-keys portion of #8, #12, #16
- detection fix: supersedes #18, #13, and the regex portion of #8, #12, #14

Deliberately **not** included (need separate review / out of scope here):
- `/rate-limit-options` menu handling (#17/#19) — option order varies, needs
  verification against current Claude Code before driving the menu
- #8's `waitMs > 22h → skip` guard — would break legitimate weekly-limit waits

## Tests
`npm test` → 93/93 pass (4 new: literal send-keys args, session/weekly
wording, no-qualifier regression, newest-resets-line).