### PR TITLE
fix: correct off-by-a-day retry wait in offset timezones (#6)

### DIFF
--- a/src/time-parser.js
+++ b/src/time-parser.js
@@ -76,7 +76,13 @@ export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, n
       const ch = parseInt(fp.find(p => p.type === 'hour').value) % 24;
       const cm = parseInt(fp.find(p => p.type === 'minute').value);
 
-      const diffMin = (h - ch) * 60 + (m - cm);
+      // Normalize to [-720, +720] minutes so we take the minimum-magnitude
+      // correction. Otherwise, in a UTC+10 tz looking for 23:40, the naive UTC
+      // guess formats as 09:40 next day local, and a raw +14h adjustment lands
+      // on tomorrow's occurrence instead of today's (the off-by-a-day bug).
+      let diffMin = (h - ch) * 60 + (m - cm);
+      diffMin = ((diffMin % 1440) + 1440) % 1440;
+      if (diffMin > 720) diffMin -= 1440;
       if (diffMin === 0) break;
       candidate += diffMin * 60_000;
     }

--- a/test/time-parser.test.js
+++ b/test/time-parser.test.js
@@ -92,4 +92,36 @@ describe('calculateWaitMs', () => {
     const wait = calculateWaitMs({ hour: 15, minute: 0, timezone: 'Invalid/Zone' }, 60, 5);
     assert.ok(Math.abs(wait - (5 * 3600 + 60) * 1000) < 2000); // fallback
   });
+
+  // Regression (#6): in a positive-offset tz, 10:02 AM Melbourne (UTC+10)
+  // looking for "11:40pm Melbourne" should wait ~13.6h (today), not ~37.6h.
+  it('targets today for a future reset in a positive-offset timezone', () => {
+    const now = new Date('2026-05-03T00:02:15Z'); // 10:02 AM in Melbourne (UTC+10)
+    const wait = calculateWaitMs(
+      { hour: 23, minute: 40, timezone: 'Australia/Melbourne' }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 13 && hours < 14, `expected ~13.6h, got ${hours.toFixed(2)}h`);
+  });
+
+  // Regression (#6): negative-offset tz, "resets 3am NY" at 1am NY → ~2h.
+  it('targets today for a future reset in a negative-offset timezone', () => {
+    const now = new Date('2026-05-03T05:00:00Z'); // 1:00 AM in New York (UTC-4 EDT)
+    const wait = calculateWaitMs(
+      { hour: 3, minute: 0, timezone: 'America/New_York' }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 1.9 && hours < 2.1, `expected ~2h, got ${hours.toFixed(2)}h`);
+  });
+
+  // Regression (#6): reset already passed today → target tomorrow (~22.6h),
+  // not 48h. Symmetric case for the off-by-a-day bug.
+  it('targets tomorrow when reset time already passed today', () => {
+    const now = new Date('2026-05-03T15:00:00Z'); // 1:00 AM next day in Melbourne
+    const wait = calculateWaitMs(
+      { hour: 23, minute: 40, timezone: 'Australia/Melbourne' }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 22 && hours < 23, `expected ~22.6h, got ${hours.toFixed(2)}h`);
+  });
 });


### PR DESCRIPTION
## What

In timezones with a non-zero UTC offset, `calculateWaitMs()` could schedule
the retry **~24h late** — long after the user has left the session.

## Root cause

`getTargetTimestamp()` converges on the reset time by formatting a guess in
the target zone and applying the raw `hour:minute` delta. In a UTC+ zone the
naive UTC guess for "today HH:MM" already falls *past midnight* in the target
zone, so the correction is a near-full-day jump that lands on **tomorrow's**
occurrence:

- `resets 11:40pm (Australia/Melbourne)` → waited ~37.6h instead of ~13.6h
- `resets 10pm (Europe/Warsaw)` → waited ~26h instead of ~2h

## Fix

Normalize each iteration's correction to `[-720, +720]` minutes, so it always
takes the minimum-magnitude adjustment and stays anchored on today's local
date. Symmetric for positive- and negative-offset zones.

## Closes
- Closes #6

## Relationship to existing PRs
- Supersedes **#4** (same root cause; #4 rolled back a day *after* convergence
  on the non-ambiguous path — this fixes the convergence math itself, so the
  ambiguous-hour path benefits too).

## Tests
`npm test` → 96/96 pass (3 new regressions: positive-offset same-day,
negative-offset same-day, and already-passed → tomorrow).