### PR TITLE
fix: unalias claude before wrapper definition to fix shell source error (#10)

### DIFF
--- a/src/wrapper.sh
+++ b/src/wrapper.sh
@@ -1,4 +1,9 @@
 # >>> claude-auto-retry >>>
+# Drop any pre-existing `claude` alias (Claude Code's own installer adds one)
+# before defining the wrapper function. Without this, the shell expands the
+# alias while parsing `claude() {`, producing "syntax error near unexpected
+# token '('" when the rc file is sourced.
+unalias claude 2>/dev/null || true
 claude() {
   if [ "${CLAUDE_AUTO_RETRY_ACTIVE}" = "1" ]; then
     command claude "$@"

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -17,6 +17,15 @@ describe('injectWrapper', () => {
     assert.ok(content.includes(MARKER_END));
     assert.ok(content.includes('/path/to/launcher.js'));
   });
+  it('unaliases claude before defining the wrapper function (#10)', async () => {
+    await writeFile(testFile, '');
+    await injectWrapper(testFile, '/path/to/launcher.js');
+    const content = await readFile(testFile, 'utf-8');
+    const unaliasIdx = content.indexOf('unalias claude');
+    const fnIdx = content.indexOf('\nclaude() {');
+    assert.ok(unaliasIdx !== -1, 'wrapper should unalias claude');
+    assert.ok(unaliasIdx < fnIdx, 'unalias must come before the function definition');
+  });
   it('adds wrapper to file with existing content', async () => {
     await writeFile(testFile, 'export PATH=$HOME/bin:$PATH\n');
     await injectWrapper(testFile, '/path/to/launcher.js');


### PR DESCRIPTION
## What

Sourcing the rc file fails with:

```
.zshrc: line 21: syntax error near unexpected token '('
.zshrc: line 21: `claude() {'
```

## Root cause

When `claude` is already a shell **alias** (Claude Code's own local installer
adds `alias claude=...`), the shell expands that alias while parsing our
`claude() {` function definition, producing the malformed token and the syntax
error. The rc file then aborts mid-source.

## Fix

Prepend `unalias claude 2>/dev/null || true` inside the managed block, so the
alias is removed before the function definition is parsed. Harmless when no
alias exists.

## Verification

Reproduced with bash (`shopt -s expand_aliases` to mimic an interactive shell):

```
# before: alias claude=... ; claude() { ... }
syntax error near unexpected token '('     ← the reported bug

# after: alias claude=... ; unalias claude 2>/dev/null || true ; claude() { ... }
REACHED-END                                ← clean
```

## Closes
- Closes #10

## Tests
`npm test` → 86/86 pass (1 new: asserts the injected wrapper places `unalias
claude` before the function definition).