### PR TITLE
feat: enable mouse scroll + vi copy-mode in created tmux sessions

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -2,7 +2,7 @@ import { spawn, fork } from 'node:child_process';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { isInsideTmux, getCurrentPane, getTmuxVersion } from './tmux.js';
+import { isInsideTmux, getCurrentPane, getTmuxVersion, buildSetWindowOptionArgs } from './tmux.js';
 import { isRateLimited } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
 import { loadConfig } from './config.js';
@@ -163,6 +163,15 @@ async function createTmuxSession(args) {
 
   try {
     execFileSync('tmux', newSessionArgs);
+
+    // Best-effort: enable mouse mode (scroll, copy-mode, pane/window click) and
+    // vi-style copy-mode keys on the session's first window. Requires tmux >= 2.1;
+    // wrapped so an older tmux that rejects these options doesn't fail the whole
+    // session creation.
+    try {
+      execFileSync('tmux', buildSetWindowOptionArgs(`${sessionName}:0`, 'mouse', 'on'));
+      execFileSync('tmux', buildSetWindowOptionArgs(`${sessionName}:0`, 'mode-keys', 'vi'));
+    } catch { /* old tmux without these options — skip silently */ }
 
     // Attach to the session
     const attachResult = spawn('tmux', ['attach-session', '-t', sessionName], {

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -67,6 +67,10 @@ export async function getPaneCommand(pane) {
   return stdout.trim();
 }
 
+export function buildSetWindowOptionArgs(target, option, value) {
+  return ['set-window-option', '-t', target, option, value];
+}
+
 export async function isProcessForeground(pid) {
   try {
     const { stdout } = await execFileAsync('ps', ['-o', 'stat=', '-p', String(pid)]);

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCaptureArgs, buildSendKeysArgs, buildSendTextArgs, buildSendEnterArgs, buildDisplayArgs, parseTmuxVersion, SUBMIT_DELAY_MS } from '../src/tmux.js';
+import { buildCaptureArgs, buildSendKeysArgs, buildSendTextArgs, buildSendEnterArgs, buildDisplayArgs, parseTmuxVersion, SUBMIT_DELAY_MS, buildSetWindowOptionArgs } from '../src/tmux.js';
 
 describe('buildCaptureArgs', () => {
   it('builds correct args', () => {
@@ -46,4 +46,15 @@ describe('parseTmuxVersion', () => {
   it('parses "tmux 3.4"', () => { assert.equal(parseTmuxVersion('tmux 3.4'), 3.4); });
   it('parses "tmux 2.1"', () => { assert.equal(parseTmuxVersion('tmux 2.1'), 2.1); });
   it('returns 0 for unparseable', () => { assert.equal(parseTmuxVersion('not tmux'), 0); });
+});
+
+describe('buildSetWindowOptionArgs', () => {
+  it('builds correct args for mouse on', () => {
+    assert.deepEqual(buildSetWindowOptionArgs('session:0', 'mouse', 'on'),
+      ['set-window-option', '-t', 'session:0', 'mouse', 'on']);
+  });
+  it('builds correct args for mode-keys vi', () => {
+    assert.deepEqual(buildSetWindowOptionArgs('claude-retry-123:0', 'mode-keys', 'vi'),
+      ['set-window-option', '-t', 'claude-retry-123:0', 'mode-keys', 'vi']);
+  });
 });


### PR DESCRIPTION
## What

tmux sessions created by claude-auto-retry didn't support mouse scroll,
copy-mode, or pane/window clicks. Enable `mouse on` and `mode-keys vi` on the
session's first window right after creation.

## Notes
- Requires tmux >= 2.1; the two `set-window-option` calls are wrapped in
  try/catch so an older tmux that rejects them doesn't abort session creation.
- New helper `buildSetWindowOptionArgs` with unit tests.

## Provenance
This **salvages the mouse-scroll feature from #5**, which had bundled it with
several unrelated changes (a `launchInteractive` respawn rewrite, a duplicate
timezone fix, and a `findRateLimitMessage` change). Extracted as a focused,
self-contained PR; full credit to @benzntech. See the review on #5 for the
decomposition rationale.

## Tests
`npm test` → all pass (2 new for `buildSetWindowOptionArgs`).