### PR TITLE
fix: drive /rate-limit-options menu to "Stop and wait", any layout (#19)

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,6 +1,6 @@
-import { stripAnsi, isRateLimited, findRateLimitMessage } from './patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, isRateLimitOptionsPrompt, menuStepsToWaitOption } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
-import { capturePane, sendKeys, getPaneCommand, isProcessForeground } from './tmux.js';
+import { capturePane, sendKeys, sendKey, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 
@@ -15,6 +15,36 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
 
   const raw = await tmuxAdapter.capturePane(pane, 20);
   const stripped = stripAnsi(raw);
+
+  // Handle the interactive /rate-limit-options menu before any other logic. A bare
+  // Enter here confirms the highlighted default, which on some Claude Code versions
+  // is "Upgrade your plan". Navigate to "Stop and wait for limit to reset" wherever
+  // it sits, confirm it, then enter the normal (hours-scale) wait state.
+  if (tmuxAdapter.sendKey && isRateLimitOptionsPrompt(stripped)
+      && Date.now() >= (state._menuCooldownUntil || 0)) {
+    const steps = menuStepsToWaitOption(stripped);
+    const cooldown = config.pollIntervalSeconds * 1000 * 2;
+    if (steps === null) {
+      // Layout unreadable — refuse to press Enter (could confirm "Upgrade").
+      state._menuCooldownUntil = Date.now() + cooldown;
+      return 'menu-unreadable';
+    }
+    const key = steps >= 0 ? 'Down' : 'Up';
+    for (let i = 0; i < Math.abs(steps); i++) {
+      await tmuxAdapter.sendKey(pane, key);
+      await new Promise(r => setTimeout(r, 80));
+    }
+    await tmuxAdapter.sendKey(pane, 'Enter');
+    // Parse the reset time straight from the menu text, so the wait does not depend
+    // on the limit banner still being visible afterward.
+    const message = findRateLimitMessage(stripped, config.customPatterns);
+    state.lastRateLimitMessage = message;
+    const parsed = message ? parseResetTime(message) : null;
+    state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
+    state.status = 'waiting';
+    state._menuCooldownUntil = Date.now() + cooldown;
+    return 'menu-confirmed';
+  }
 
   if (state.status === 'waiting') {
     if (Date.now() < state.waitUntil) return 'waiting';
@@ -79,7 +109,7 @@ export async function startMonitor(pane, pid) {
 
   await logger.info(`Monitor started for pane ${pane} (claude PID: ${pid})`);
 
-  const tmuxAdapter = { capturePane, sendKeys, getPaneCommand, isClaudeForeground: () => isProcessForeground(pid) };
+  const tmuxAdapter = { capturePane, sendKeys, sendKey, getPaneCommand, isClaudeForeground: () => isProcessForeground(pid) };
   const isAlive = () => { try { process.kill(pid, 0); return true; } catch { return false; } };
 
   const loop = async () => {
@@ -93,6 +123,12 @@ export async function startMonitor(pane, pid) {
         await logger.info(`Rate limit detected: "${state.lastRateLimitMessage}". Waiting ${secs}s...`);
         state.lastRateLimitMessage = null;
       }
+      if (result === 'menu-confirmed') {
+        const secs = Math.round((state.waitUntil - Date.now()) / 1000);
+        await logger.info(`Rate-limit options menu: selected "Stop and wait for limit to reset". Waiting ${secs}s...`);
+        state.lastRateLimitMessage = null;
+      }
+      if (result === 'menu-unreadable') await logger.warn('Rate-limit options menu detected but its layout could not be read; not pressing Enter (would risk confirming "Upgrade your plan"). Will recheck.');
       if (result === 'retried') await logger.info(`Sent retry message (attempt ${state.attempts})`);
       if (result === 'user-continued') await logger.info('User already continued. Attempt counter reset.');
       if (result === 'max-retries') await logger.warn(`Max retries (${config.maxRetries}) reached. Monitor still active but will not send further retries until rate limit clears.`);

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -70,6 +70,40 @@ export function isRateLimited(text, customPatterns = []) {
   return false;
 }
 
+// --- Interactive /rate-limit-options menu ---
+// Newer Claude Code shows a selectable menu when a session/weekly limit is hit:
+//   What do you want to do?
+//   ❯ 1. Upgrade your plan
+//     2. Stop and wait for limit to reset
+// A bare Enter confirms the highlighted default — which is "Upgrade your plan"
+// on some versions. The option ORDER varies between versions, so we never assume
+// a position: we locate the cursor (❯) and the "Stop and wait" option and compute
+// the cursor moves needed to land on it.
+
+const MENU_CURSOR = '❯';
+const WAIT_OPTION_REGEX = /stop and wait for limit to reset/i;
+const MENU_OPTION_REGEX = /^\s*❯?\s*\d+\.\s/;
+
+export function isRateLimitOptionsPrompt(text) {
+  const t = stripAnsi(text);
+  return /what do you want to do\?/i.test(t)
+    && WAIT_OPTION_REGEX.test(t)
+    && (/enter to confirm/i.test(t) || /esc to cancel/i.test(t) || t.includes(MENU_CURSOR));
+}
+
+// Cursor moves to reach the "Stop and wait for limit to reset" option, counted in
+// option steps: positive => press Down N times, negative => Up, 0 => already there.
+// Returns null when the layout can't be read (no cursor or option not found); the
+// caller MUST NOT press Enter in that case, to avoid confirming the wrong option.
+export function menuStepsToWaitOption(text) {
+  const optionLines = stripAnsi(text).split('\n').filter(l => MENU_OPTION_REGEX.test(l));
+  if (optionLines.length === 0) return null;
+  const cursorPos = optionLines.findIndex(l => l.includes(MENU_CURSOR));
+  const waitPos = optionLines.findIndex(l => WAIT_OPTION_REGEX.test(l));
+  if (cursorPos === -1 || waitPos === -1) return null;
+  return waitPos - cursorPos;
+}
+
 export function findRateLimitMessage(text, customPatterns = []) {
   const lines = stripAnsi(text).split('\n');
 

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -35,6 +35,16 @@ export function buildSendEnterArgs(pane) {
   return ['send-keys', '-t', pane, 'Enter'];
 }
 
+// Send a single named key (e.g. 'Down', 'Up', 'Enter', 'Escape') — used to drive
+// the interactive /rate-limit-options menu.
+export function buildSendKeyArgs(pane, key) {
+  return ['send-keys', '-t', pane, key];
+}
+
+export async function sendKey(pane, key) {
+  await execFileAsync('tmux', buildSendKeyArgs(pane, key));
+}
+
 export function buildDisplayArgs(pane, format) {
   return ['display-message', '-t', pane, '-p', format];
 }

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -6,13 +6,31 @@ import { DEFAULT_CONFIG } from '../src/config.js';
 function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
   const t = {
     _sent: [],
+    _keys: [],
     capturePane: async () => paneContent,
     getPaneCommand: async () => paneCommand,
     sendKeys: async (_p, text) => { t._sent.push(text); },
+    sendKey: async (_p, key) => { t._keys.push(key); },
     isClaudeForeground: async () => claudeForeground,
   };
   return t;
 }
+
+const MENU_UPGRADE_FIRST = [
+  "You've hit your session limit · resets 6:50pm (Europe/London)",
+  'What do you want to do?',
+  '❯ 1. Upgrade your plan',
+  '  2. Stop and wait for limit to reset',
+  'Enter to confirm · Esc to cancel',
+].join('\n');
+
+const MENU_WAIT_FIRST = [
+  "You've hit your session limit · resets 12:10am (Europe/Dublin)",
+  'What do you want to do?',
+  '❯ 1. Stop and wait for limit to reset',
+  '  2. Upgrade your plan',
+  'Enter to confirm · Esc to cancel',
+].join('\n');
 
 describe('processOneTick', () => {
   it('returns monitoring when no rate limit', async () => {
@@ -26,6 +44,35 @@ describe('processOneTick', () => {
     const s = createMonitorState();
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
     assert.ok(s.waitUntil > Date.now());
+  });
+
+  it('navigates the menu down to "Stop and wait" when "Upgrade" is the default (#19)', async () => {
+    const t = mockTmux(MENU_UPGRADE_FIRST);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'menu-confirmed');
+    // One Down to move off "Upgrade", then Enter to confirm "Stop and wait".
+    assert.deepEqual(t._keys, ['Down', 'Enter']);
+    assert.equal(t._sent.length, 0);            // never typed a stray message
+    assert.equal(s.status, 'waiting');
+    assert.ok(s.waitUntil > Date.now());
+  });
+
+  it('confirms directly when "Stop and wait" is already highlighted (#19)', async () => {
+    const t = mockTmux(MENU_WAIT_FIRST);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'menu-confirmed');
+    assert.deepEqual(t._keys, ['Enter']);       // no navigation needed
+    assert.equal(s.status, 'waiting');
+  });
+
+  it('refuses to press Enter when the menu layout is unreadable (#19)', async () => {
+    // Cursor marker absent → we cannot tell which option is highlighted.
+    const noCursor = ['What do you want to do?', '  1. Upgrade your plan', '  2. Stop and wait for limit to reset', 'Enter to confirm'].join('\n');
+    const t = mockTmux(noCursor);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'menu-unreadable');
+    assert.equal(t._keys.length, 0);            // pressed nothing
+    assert.equal(t._sent.length, 0);
   });
   it('exits when PID dead', async () => {
     const t = mockTmux('5-hour limit reached - resets 3pm (UTC)');

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -1,6 +1,23 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { stripAnsi, isRateLimited, findRateLimitMessage } from '../src/patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, isRateLimitOptionsPrompt, menuStepsToWaitOption } from '../src/patterns.js';
+
+const MENU_UPGRADE_FIRST = [
+  "You've hit your session limit · resets 6:50pm (Europe/London)",
+  '/rate-limit-options',
+  'What do you want to do?',
+  '❯ 1. Upgrade your plan',
+  '  2. Stop and wait for limit to reset',
+  'Enter to confirm · Esc to cancel',
+].join('\n');
+
+const MENU_WAIT_FIRST = [
+  "You've hit your session limit · resets 12:10am (Europe/Dublin)",
+  'What do you want to do?',
+  '❯ 1. Stop and wait for limit to reset',
+  '  2. Upgrade your plan',
+  'Enter to confirm · Esc to cancel',
+].join('\n');
 
 describe('stripAnsi', () => {
   it('removes bold codes', () => {
@@ -99,6 +116,44 @@ describe('findRateLimitMessage', () => {
   it('returns the most recent resets line when scrollback has a stale one', () => {
     const text = 'You\'ve hit your limit · resets 11:30am (UTC)\nlots of output\nYou\'ve hit your limit · resets 4:30pm (UTC)';
     assert.ok(findRateLimitMessage(text).includes('4:30pm'));
+  });
+});
+
+describe('isRateLimitOptionsPrompt (#19)', () => {
+  it('detects the menu with "Upgrade" highlighted first', () => {
+    assert.equal(isRateLimitOptionsPrompt(MENU_UPGRADE_FIRST), true);
+  });
+  it('detects the menu with "Stop and wait" highlighted first', () => {
+    assert.equal(isRateLimitOptionsPrompt(MENU_WAIT_FIRST), true);
+  });
+  it('detects through ANSI codes', () => {
+    assert.equal(isRateLimitOptionsPrompt('\x1b[1mWhat do you want to do?\x1b[0m\n❯ 1. Stop and wait for limit to reset'), true);
+  });
+  it('returns false for a plain rate-limit banner (no menu)', () => {
+    assert.equal(isRateLimitOptionsPrompt("You've hit your limit · resets 3pm (UTC)"), false);
+  });
+  it('returns false for normal output', () => {
+    assert.equal(isRateLimitOptionsPrompt('What do you want to do? Build a feature?'), false);
+  });
+});
+
+describe('menuStepsToWaitOption (#19)', () => {
+  it('returns +1 when "Stop and wait" is one below the cursor (Upgrade first)', () => {
+    assert.equal(menuStepsToWaitOption(MENU_UPGRADE_FIRST), 1);
+  });
+  it('returns 0 when "Stop and wait" is already highlighted', () => {
+    assert.equal(menuStepsToWaitOption(MENU_WAIT_FIRST), 0);
+  });
+  it('returns -1 when "Stop and wait" is above the cursor', () => {
+    const text = ['What do you want to do?', '  1. Stop and wait for limit to reset', '❯ 2. Upgrade your plan'].join('\n');
+    assert.equal(menuStepsToWaitOption(text), -1);
+  });
+  it('returns null when there is no cursor to anchor on', () => {
+    const text = ['What do you want to do?', '  1. Upgrade your plan', '  2. Stop and wait for limit to reset'].join('\n');
+    assert.equal(menuStepsToWaitOption(text), null);
+  });
+  it('returns null when no menu options are present', () => {
+    assert.equal(menuStepsToWaitOption('just some text'), null);
   });
 });
 

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCaptureArgs, buildSendKeysArgs, buildSendTextArgs, buildSendEnterArgs, buildDisplayArgs, parseTmuxVersion, SUBMIT_DELAY_MS, buildSetWindowOptionArgs } from '../src/tmux.js';
+import { buildCaptureArgs, buildSendKeysArgs, buildSendTextArgs, buildSendEnterArgs, buildSendKeyArgs, buildDisplayArgs, parseTmuxVersion, SUBMIT_DELAY_MS, buildSetWindowOptionArgs } from '../src/tmux.js';
 
 describe('buildCaptureArgs', () => {
   it('builds correct args', () => {
@@ -27,6 +27,16 @@ describe('buildSendTextArgs', () => {
 describe('buildSendEnterArgs', () => {
   it('builds bare-Enter send-keys args', () => {
     assert.deepEqual(buildSendEnterArgs('%3'),
+      ['send-keys', '-t', '%3', 'Enter']);
+  });
+});
+describe('buildSendKeyArgs', () => {
+  it('builds args for a named key (Down)', () => {
+    assert.deepEqual(buildSendKeyArgs('%3', 'Down'),
+      ['send-keys', '-t', '%3', 'Down']);
+  });
+  it('builds args for Enter', () => {
+    assert.deepEqual(buildSendKeyArgs('%3', 'Enter'),
       ['send-keys', '-t', '%3', 'Enter']);
   });
 });


### PR DESCRIPTION
## What

When a session/weekly limit is hit, newer Claude Code shows an interactive menu:

```
What do you want to do?
❯ 1. Upgrade your plan
  2. Stop and wait for limit to reset
```

A bare Enter confirms the **highlighted default**. The option order varies by
version — #17 saw "Stop and wait" highlighted; #19 saw "Upgrade your plan" — so
pressing Enter blindly can confirm "Upgrade".

## Fix (position-independent)

- `isRateLimitOptionsPrompt()` detects the menu.
- `menuStepsToWaitOption()` locates the cursor (`❯`) and the "Stop and wait"
  option among the numbered lines and returns the signed number of cursor moves.
- The monitor sends that many `Down`/`Up` keys, then `Enter`, then enters the
  normal hours-scale wait (reset time parsed from the menu text itself).
- If the layout can't be read (no cursor), it **refuses to press Enter** and
  rechecks — never risks confirming "Upgrade".

Works for both observed layouts and is robust to future reordering.

## Closes
- Closes #19

## Supersedes
- #17 and #14 (menu handling) — same goal, made layout-robust and rebased on the
  already-merged send-keys (#22) work.

## Tests
`npm test` → 114/114 pass. New: detection through both layouts + ANSI, navigation
steps (+1 / 0 / -1 / null), and monitor-level tests asserting the exact key
sequence (`Down,Enter` / `Enter`) and the no-cursor refusal.