### PR TITLE
feat: sustained API overload (529/500/503) backoff — integrate #20

### DIFF
--- a/DESIGN-NOTES.md
+++ b/DESIGN-NOTES.md
@@ -1,0 +1,201 @@
+# Design notes
+
+Forward-looking design notes for `claude-auto-retry`, grounded in a research pass
+(2026-06) against the installed Claude Code binary (v2.1.195, decompiled), the
+Anthropic API error schema, and Claude Code's hooks/transcript surfaces. Ordered by
+leverage. Items marked **[done]** ship in the current version; the rest are proposals
+with enough detail to execute.
+
+## 0. The core problem: we scrape a human-facing render
+
+The overload path detects a *terminal* API error by scraping `tmux capture-pane` and
+string-matching. That is fundamentally a heuristic over output meant for humans, and
+every false positive we've hit (a `res.status(503)` under edit, an HTTP status code in
+tool output in scrollback) and every false negative we worry about is a symptom of that
+layer choice.
+The hardening below makes the scraper as good as a scraper can be — but the strategic
+move is to stop using the scrape as the *trigger*.
+
+### Verified ground truth (informs everything else)
+
+- **Two render forms, opposite meaning.** Terminal (retries exhausted):
+  `API Error: <code> <body>` (colon form). Transient (still retrying):
+  `API Error (<code> …) · Retrying in 5s · attempt 3/10` (parens, and/or a `· Retrying`
+  suffix on the colon form). Acting on the transient form interrupts Claude's *own*
+  backoff. **[done]** — we require the colon form and suppress the retry suffix via the
+  working gate.
+- **Error → HTTP status → retryability.** Retryable: `429 rate_limit_error`,
+  `500 api_error`, `504 timeout_error`, `529 overloaded_error`, plus edge `502/503`
+  (no JSON body — plain text/HTML from Cloudflare/envoy, e.g. `503 no healthy upstream`).
+  Never retry: `400/401/402/403/404/413`. The official SDK retry set is `408/409/429 +
+  all 5xx`. **[done]** — default patterns cover `429|500|502|503|504|529` + `overloaded_error`.
+- **API-429 has no 3-digit code in the slot.** It renders
+  `API Error: Server is temporarily limiting requests (not your usage limit) · Rate
+  limited`. A code-keyed matcher misses it. **[done]** — phrase pattern added.
+- **529 is global capacity, not per-key.** Naive fixed backoff makes every client
+  resynchronize into the same overload window → use **full jitter**. See §3.
+- **Streaming caveat.** An error after a 200 (SSE `error` event) bypasses HTTP status.
+  Claude streams, so a mid-response overload may render differently than a pre-flight
+  failure. Not currently special-cased; low observed frequency.
+
+## 1. Replace the trigger with `StopFailure` (highest leverage) — **[done, v0.4.0]**
+
+**Implemented.** The launcher stamps `CLAUDE_AUTO_RETRY_PANE` onto claude's env; the
+`StopFailure` hook (`claude-auto-retry _stopfailure-hook`, installed via
+`install-hook`) runs as a claude child, inherits that var, and writes a pane-keyed
+marker under `~/.claude-auto-retry/events/` for retryable error types
+(`overloaded|server_error|rate_limit`). The monitor reads the marker for its own pane
+each tick; the first marker latches `eventMode`, which disables the scraper for that
+session. Edge-triggered: one backoff-then-send per failure, then back to monitoring;
+self-recovery and foreground/shell gates still apply; the cumulative cap is shared with
+the scraper path. The scraper remains the fallback until a marker is ever seen (hook
+absent, pre-`v0.4.0` session without the pane env, or non-tmux).
+
+**Correlation correction (learned during build):** the original plan resolved the
+session via `/proc/<pid>/environ` → `CLAUDE_CODE_SESSION_ID`. In practice the *main*
+claude PID's environ carries `CLAUDE_CONFIG_DIR` but **not** the session id (that var is
+injected only into claude's child processes). Pane-keying via the launcher-stamped env
+sidesteps this entirely and needs no `/proc` access (so it also works off-Linux).
+Residual caveat: a recycled tmux pane id could in principle replay a stale marker —
+bounded by `eventMaxAgeSeconds` (default 120) and consume-on-read.
+
+### Original design (retained for reference)
+
+Claude Code has a **`StopFailure` hook** that fires *only* when a turn ends due to an
+API error, with a typed `error_type` matcher (`overloaded`, `server_error`,
+`rate_limit`, `authentication_failed`, …). This is the zero-ambiguity signal: no
+scraping, no terminal-vs-transient guessing, no self-referential false positive.
+
+Constraint: `StopFailure` is **observability-only** — its output/exit code are ignored,
+and hooks cannot inject a prompt or run `/`-commands. So it can detect but not actuate.
+The daemon is the opposite (it owns the pane via `send-keys` but can't cleanly detect).
+Pair them:
+
+```
+StopFailure hook  ──writes marker (error_type, session_id, transcript_path)──▶  daemon
+                                                                                  │
+                                       maps session_id/pane ──▶ tmux send-keys ◀──┘
+```
+
+- Hook handler (`type: command`) reads JSON on stdin, appends a marker file under a
+  known dir (or a FIFO/socket). It does **not** retry.
+- Daemon watches for markers, maps to the pane (it already owns the pane; or resolves
+  via `CLAUDE_CODE_SESSION_ID`), applies the existing backoff + foreground-safety +
+  cap logic, and sends the retry.
+- Install per config dir — if you run more than one `CLAUDE_CONFIG_DIR`, repeat for each;
+  hooks live in each `settings.json` under `hooks.StopFailure`.
+
+**Verified against the installed v2.1.195 binary (2026-06).** `StopFailure` exists as a
+real event with a dedicated `executeStopFailureHooks` path (separate from normal `Stop`),
+and all nine matcher error types are present (`overloaded`, `server_error`, `rate_limit`,
+`authentication_failed`, `oauth_org_not_allowed`, `billing_error`, `invalid_request`,
+`model_not_found`, `max_output_tokens`). The payload is built as:
+
+```js
+hookInput = { hook_event_name: "StopFailure", error, error_details, last_assistant_message }
+//   the matcher filters on `error` (the type string)
+```
+
+plus the standard envelope (`session_id`, `transcript_path`, `cwd`). So a matcher of
+`overloaded|server_error|rate_limit` selects exactly the retryable classes, and the
+handler gets the error type for free — no scraping. **The blocker is cleared; this
+direction is ready to build.** It supersedes the scraper for the overload path; the
+scraper stays as a legacy fallback for users who won't install hooks. Remaining
+nice-to-have: a live forced-error run to capture the literal stdin JSON verbatim (the
+field names above are read from the binary, not from a captured invocation).
+
+## 2. JSONL-tail fallback (no hooks required)
+
+If hooks aren't installed, tail the session transcript instead of the terminal. Claude
+Code writes append-only JSONL at
+`$CLAUDE_CONFIG_DIR/projects/<cwd-slug>/<sessionId>.jsonl`. A turn that ends in a
+retryable API error is written as a `type:"assistant"` record with the structured field
+**`isApiErrorMessage: true`**. Fire only on that field in the **last** record — never
+substring-grep the body (the body contains `overloaded_error`/`API Error` as ordinary
+content in any session that discusses errors; grepping it reproduces the original bug).
+
+Pane→transcript mapping (verified): `pane → claude PID → /proc/<pid>/environ →
+$CLAUDE_CONFIG_DIR + CLAUDE_CODE_SESSION_ID` (filename == sessionId). Normal completion
+is `message.stop_reason ∈ {end_turn, tool_use, stop_sequence}`; the error path writes no
+successful assistant message. This is strictly lower-ambiguity than scraping and only
+slightly more plumbing.
+
+## 3. Backoff: full jitter for 529
+
+Current jitter is proportional (`base × (1 ± jitterPct%)`). For global-overload 529 the
+operational consensus is **full jitter** — `random(0, base)` — so a fleet of clients
+running this tool doesn't resynchronize into the same overload window. Single-client
+impact is small; ecosystem impact is real. Proposed: add `jitterMode: 'proportional' |
+'full'` (default `proportional` to preserve current behavior, or flip to `full` for the
+overload block specifically). Honor a `retry-after` header as a *floor* if/when we have
+access to it (we don't, via scraping — another point for §1/§2). Low risk, ~15 lines.
+
+## 4. Observability: log *why* **[done]**
+
+The original bug logged `Overload detected` with no reason; diagnosing it required
+reconstructing the pane. The monitor now logs the matched pattern and the offending
+line (`overloadMatch`). Keep this discipline for any future detector — a detector that
+can't say *why* it fired is undebuggable in the field.
+
+## 5. Operational lifecycle: `ps` / `stop`, and no pile-ups
+
+This session accumulated **four** detached `monitor.js` processes across launches, some
+watching reused pane IDs — diagnosing required `pgrep`/`kill` by hand. Gaps:
+
+- **No `claude-auto-retry ps` / `stop`.** Add both (list running monitors with pane +
+  watched PID + status from logs; stop one or all). Pure operability win.
+- **Pane-ID reuse.** tmux recycles pane IDs. A monitor whose pane closed and whose ID
+  was reassigned could `send-keys` into the wrong pane. The PID-liveness check bounds
+  this (monitor exits when its `claude` dies), but there's a window. Mitigation: each
+  tick, re-verify the watched PID still maps to the target pane before sending.
+- **Faster self-exit.** Monitor exits after 10 consecutive capture errors (~50s). Tighten,
+  or exit immediately when `capture-pane` reports the pane is gone.
+- **Single supervisor (larger):** replace per-launch detached forks with one supervisor
+  that maintains a pane→PID registry and dedupes. Eliminates pile-ups structurally.
+
+## 6. Send-keys safety: don't corrupt a half-typed prompt
+
+`send-keys <text> Enter` fires whenever the foreground check passes — even if the user
+is mid-typing in the prompt box. The foreground gate doesn't catch this. Cheap guard:
+before sending, confirm the input box is empty (the captured prompt line is just the
+prompt glyph). Imperfect via scraping; clean via the §1 architecture (act on the
+StopFailure event, when the turn has definitively ended).
+
+## 7. Confirm before acting (2-tick debounce)
+
+A capture taken mid-render could momentarily show a colon-form error before the retry
+suffix paints. The retry-suffix gate handles most of this; a belt-and-suspenders
+**N-consecutive-captures** confirmation before the first send would close the race
+entirely. Adds a small counter to state; ~10 lines. Worth it if §1 isn't adopted.
+
+## 8. Print-mode parity
+
+`launchPrintMode` retries on usage limits but not overload. A `-p` run that hits a
+sustained 529 exits non-zero with `API Error: …` on stderr (and, with
+`--output-format json`, `is_error:true` / `subtype:"error_during_execution"`). The
+wrapper could apply the same overload backoff in print mode by inspecting the exit
+code + stderr. Modest, self-contained.
+
+## 9. Golden-capture test corpus
+
+Current tests use synthetic strings. Capture **real** panes for each error type (529
+json + collapsed, 500, 503 edge, the transient retry frame, API-429) as golden files
+and assert detection against them. Makes the suite trustworthy against render drift,
+and gives a regression anchor when Claude Code changes its output.
+
+## Residual false positive (accepted, documented)
+
+Because detection string-matches the render, a live tail that literally contains
+`API Error: <code>` in prose or code (editing *this* repo's tests/README, or
+documenting Claude error handling) will fire. There is no way to both match the real
+terminal error and not match its literal text. Tail-anchoring bounds it to the last 12
+lines; the escape hatch is `overload.enabled: false` while developing on the tool. §1/§2
+remove this class entirely by keying on a structured field instead of the render.
+
+## Suggested order
+
+1. Verification spike for `StopFailure` (gates the whole §1 direction). Cheap, decisive.
+2. If it fires: build §1 (hook + marker + daemon actuator). If not: build §2 (JSONL tail).
+3. `ps`/`stop` + lifecycle hardening (§5) — independent, ship anytime.
+4. Full jitter (§3), 2-tick debounce (§7), print-mode parity (§8) — small, independent.
+5. Golden corpus (§9) alongside whichever detector becomes primary.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ When you disconnect (SSH drops, close terminal, laptop sleeps), **tmux keeps run
 - **Timezone-aware** — parses reset times with full IANA timezone support (including half-hour offsets)
 - **DST-safe** — iterative offset correction handles daylight saving transitions
 - **Safe send-keys** — verifies Claude is still the foreground process before injecting text
+- **Overload backoff** — detects sustained API 529/500/503 and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff-529--500--503))
 - **`--print` mode support** — buffers output, retries cleanly for piped/scripted usage
 - **Configurable** — retry count, wait margin, custom patterns, retry message
 - **Config validation** — bad config values fall back to safe defaults instead of crashing
@@ -121,6 +122,71 @@ Optional. Create `~/.claude-auto-retry.json`:
 | `customPatterns` | `[]` | Additional regex patterns to detect rate limits |
 
 All fields optional. Invalid values fall back to defaults automatically.
+
+## Overload backoff (529 / 500 / 503)
+
+Separate from subscription rate limits, this fork also detects **sustained API
+overload** — `API Error: 529 Overloaded`, `API Error: 500 / 500 Internal server
+error`, and `503` — and retries on an **exponential backoff** instead of waiting
+for a usage reset. The two paths never collide; usage limits always take
+precedence.
+
+> **Sustained only.** Claude Code already retries transient 5xx/529 internally
+> with its own backoff. This feature fires only when those internal retries are
+> exhausted and a *terminal* error is left in the pane. It should rarely trigger.
+> `500` is a default pattern because, unlike 529/503, a `500 Internal server
+> error` has been observed to halt a session without self-resuming.
+
+Configured under an `overload` block (shown with its defaults):
+
+```json
+{
+  "overload": {
+    "enabled": true,
+    "patterns": ["Overloaded", "API Error: 529", "529", "API Error: 500", "500 Internal server error", "Internal server error", "503", "status.claude.com"],
+    "backoffSeconds": [30, 60, 120, 240, 300],
+    "steadyStateSeconds": 300,
+    "jitterPct": 15,
+    "maxTotalWaitMinutes": 120,
+    "retryMessage": "Continue where you left off.",
+    "relaunchOnExit": false,
+    "relaunchCommand": "claude --continue"
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Turn the overload path on/off |
+| `patterns` | (see above) | Case-insensitive substrings that mark a terminal overload error |
+| `backoffSeconds` | `[30,60,120,240,300]` | Wait before each retry; index `i` for attempt `i` |
+| `steadyStateSeconds` | `300` | Wait once the `backoffSeconds` array is exhausted |
+| `jitterPct` | `15` | ±% jitter applied to every wait (clamped 0–100) |
+| `maxTotalWaitMinutes` | `120` | Cumulative-wait cap — give up loudly past this |
+| `retryMessage` | `"Continue where you left off."` | Sent to Claude on each retry |
+| `relaunchOnExit` | `false` | See the gating decision below |
+| `relaunchCommand` | `"claude --continue"` | Command used by `relaunchOnExit` |
+
+The waits go `30 → 60 → 120 → 240 → 300 → 300 …`, each with ±15% jitter, until the
+error clears (success) or the cumulative wait reaches `maxTotalWaitMinutes` (give
+up — the cap guards against hammering a genuinely-down endpoint or masking a real
+outage; check [status.claude.com](https://status.claude.com)).
+
+### Gating decision (alive-at-prompt vs exited-to-shell)
+
+A transient API error in interactive Claude Code surfaces inline and leaves the
+process **alive at its prompt** — it does not exit to the shell. So the default,
+robust behavior reuses the existing usage-limit mechanism: only retry when the
+foreground process is `claude`/`node` and the session is **idle, not working**
+(the `esc to interrupt` footer is absent). Retrying mid-internal-retry would
+double-drive the session, so that case is deferred, never sent.
+
+If a `500` ever *does* drop you to the shell, `send-keys` is correctly blocked by
+the foreground check (it never types into bash), and the tool logs
+`overload-exited-to-shell` rather than masking it. Auto-relaunch is **off by
+default** — blindly typing `claude --continue` into a shell the user may be using
+is worse than surfacing the stall. Set `relaunchOnExit: true` (and adjust
+`relaunchCommand`) only if you actually observe shell-exits on overload.
 
 ## CLI Commands
 
@@ -209,7 +275,7 @@ Contributions are welcome! Here's how to get started:
 ```bash
 git clone https://github.com/cheapestinference/claude-auto-retry.git
 cd claude-auto-retry
-npm test            # Run all 59 tests
+npm test            # Run all 128 tests
 npm link            # Install locally for testing
 ```
 
@@ -219,15 +285,15 @@ npm link            # Install locally for testing
 claude-auto-retry/
 ├── bin/cli.js              # CLI: install/uninstall/status/logs/version
 ├── src/
-│   ├── patterns.js         # Rate limit detection + ANSI stripping
+│   ├── patterns.js         # Rate limit + overload detection + ANSI stripping
 │   ├── time-parser.js      # Reset time parsing with timezone support
 │   ├── config.js           # Config loading + validation
 │   ├── logger.js           # File-based logging with rotation
 │   ├── tmux.js             # tmux command wrappers (execFile-based)
-│   ├── monitor.js          # Core monitoring loop + retry logic
+│   ├── monitor.js          # Core monitoring loop + retry logic (usage + overload paths)
 │   ├── launcher.js         # Process orchestration + signal forwarding
 │   └── wrapper.sh          # Shell function template
-├── test/                   # 59 tests across 7 test files
+├── test/                   # 128 tests across 8 test files
 ├── package.json
 ├── LICENSE
 └── README.md

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ When you disconnect (SSH drops, close terminal, laptop sleeps), **tmux keeps run
 - **Timezone-aware** — parses reset times with full IANA timezone support (including half-hour offsets)
 - **DST-safe** — iterative offset correction handles daylight saving transitions
 - **Safe send-keys** — verifies Claude is still the foreground process before injecting text
-- **Overload backoff** — detects sustained API 529/500/503 and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff-529--500--503))
+- **Overload backoff** — detects sustained API overload (`429/500/502/503/504/529`) and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff))
 - **`--print` mode support** — buffers output, retries cleanly for piped/scripted usage
 - **Configurable** — retry count, wait margin, custom patterns, retry message
 - **Config validation** — bad config values fall back to safe defaults instead of crashing
@@ -123,19 +123,34 @@ Optional. Create `~/.claude-auto-retry.json`:
 
 All fields optional. Invalid values fall back to defaults automatically.
 
-## Overload backoff (529 / 500 / 503)
+## Overload backoff
 
 Separate from subscription rate limits, this fork also detects **sustained API
-overload** — `API Error: 529 Overloaded`, `API Error: 500 / 500 Internal server
-error`, and `503` — and retries on an **exponential backoff** instead of waiting
-for a usage reset. The two paths never collide; usage limits always take
-precedence.
+overload** — Claude Code's own terminal `API Error: <code>` line for the retryable
+set (`429 / 500 / 502 / 503 / 504 / 529`, or an `overloaded_error` JSON body) — and
+retries on an **exponential backoff** instead of waiting for a usage reset. The two
+paths never collide; usage limits always take precedence.
 
 > **Sustained only.** Claude Code already retries transient 5xx/529 internally
 > with its own backoff. This feature fires only when those internal retries are
 > exhausted and a *terminal* error is left in the pane. It should rarely trigger.
-> `500` is a default pattern because, unlike 529/503, a `500 Internal server
-> error` has been observed to halt a session without self-resuming.
+
+> **Terminal vs. transient.** Claude Code renders an in-progress retry as the
+> *parens* form `API Error (529 …) · Retrying in 5s · attempt 3/10`, and the final
+> exhausted error as the *colon* form `API Error: 529 …`. Detection requires the
+> colon form **and** suppresses the `· Retrying…` / `attempt n/m` suffix, so the tool
+> never interrupts Claude's own backoff.
+
+> **Anchored, tail-only matching (why it won't fire on your code).** Patterns are
+> case-insensitive **regexes** matched against only the **last 12 lines** of the
+> pane — never the full scrollback. They are anchored to Claude Code's `API Error:
+> <code>` render, so a bare `503` in code you're editing (`res.status(503)`), a
+> port number, a quoted log, or a `status.claude.com` link in a comment will **not**
+> trip detection. The one residual: a live tail that literally contains
+> `API Error: 529` (e.g. editing this tool, or docs about Claude errors) will match —
+> set `"enabled": false` while doing that. (Earlier versions matched bare status
+> numbers across the whole capture, which injected spurious retries during ordinary
+> web-dev sessions.) For a structured, ambiguity-free trigger see `DESIGN-NOTES.md`.
 
 Configured under an `overload` block (shown with its defaults):
 
@@ -143,7 +158,7 @@ Configured under an `overload` block (shown with its defaults):
 {
   "overload": {
     "enabled": true,
-    "patterns": ["Overloaded", "API Error: 529", "529", "API Error: 500", "500 Internal server error", "Internal server error", "503", "status.claude.com"],
+    "patterns": ["API Error:\\s*(429|500|502|503|504|529)\\b", "overloaded_error", "temporarily limiting requests"],
     "backoffSeconds": [30, 60, 120, 240, 300],
     "steadyStateSeconds": 300,
     "jitterPct": 15,
@@ -158,7 +173,7 @@ Configured under an `overload` block (shown with its defaults):
 | Option | Default | Description |
 |--------|---------|-------------|
 | `enabled` | `true` | Turn the overload path on/off |
-| `patterns` | (see above) | Case-insensitive substrings that mark a terminal overload error |
+| `patterns` | (see above) | Case-insensitive **regexes** matching a terminal overload error in the pane tail (last 12 lines) |
 | `backoffSeconds` | `[30,60,120,240,300]` | Wait before each retry; index `i` for attempt `i` |
 | `steadyStateSeconds` | `300` | Wait once the `backoffSeconds` array is exhausted |
 | `jitterPct` | `15` | ±% jitter applied to every wait (clamped 0–100) |
@@ -171,6 +186,25 @@ The waits go `30 → 60 → 120 → 240 → 300 → 300 …`, each with ±15% ji
 error clears (success) or the cumulative wait reaches `maxTotalWaitMinutes` (give
 up — the cap guards against hammering a genuinely-down endpoint or masking a real
 outage; check [status.claude.com](https://status.claude.com)).
+
+### Event-driven detection (recommended — no scraping)
+
+The scraper above is a heuristic over terminal output. For an exact, ambiguity-free
+trigger, install the **`StopFailure` hook** — Claude Code fires it precisely when a
+turn ends in an API error, with a typed error class:
+
+```sh
+claude-auto-retry install-hook                  # into $CLAUDE_CONFIG_DIR or ~/.claude
+claude-auto-retry install-hook /path/to/config  # repeat per CLAUDE_CONFIG_DIR you use
+```
+
+This adds a `StopFailure` hook (matcher `overloaded|server_error|rate_limit`) that
+writes a pane-keyed marker the monitor consumes — no terminal scraping, so it cannot
+false-positive on code or scrollback. Sessions launched via the wrapper **after**
+installing the hook use it automatically; the first marker latches event mode and
+disables the scraper for that session. Sessions without the hook (or pre-install) fall
+back to the anchored scraper. Remove with `uninstall-hook`. See `DESIGN-NOTES.md` for
+the architecture.
 
 ### Gating decision (alive-at-prompt vs exited-to-shell)
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { execFileSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { writeStopFailureEvent, isRetryableError } from '../src/events.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -195,6 +196,68 @@ async function cmdLogs() {
   });
 }
 
+// --- StopFailure hook (event-driven overload trigger) ---
+
+const HOOK_MARKER = '_stopfailure-hook';
+
+function stopFailureHookEntry() {
+  // Matcher filters on the StopFailure error type; we want the retryable classes only.
+  return {
+    matcher: 'overloaded|server_error|rate_limit',
+    hooks: [{ type: 'command', command: `node ${__filename} ${HOOK_MARKER}`, timeout: 5 }],
+  };
+}
+
+function resolveConfigDir(arg) {
+  return arg || process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+}
+
+// Invoked BY Claude Code on a turn-ending API error. Reads the hook JSON on stdin and,
+// for a retryable error, writes a pane-keyed marker the monitor consumes. Must never
+// disrupt the session: StopFailure output/exit is ignored, and we swallow all errors.
+async function cmdStopFailureHook() {
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    const payload = JSON.parse(Buffer.concat(chunks).toString() || '{}');
+    const pane = process.env.CLAUDE_AUTO_RETRY_PANE;
+    if (pane && isRetryableError(payload.error)) {
+      await writeStopFailureEvent(pane, payload);
+    }
+  } catch { /* swallow — never break the host session */ }
+  process.exit(0);
+}
+
+async function cmdInstallHook() {
+  const settingsPath = join(resolveConfigDir(process.argv[3]), 'settings.json');
+  let settings = {};
+  try { settings = JSON.parse(await readFile(settingsPath, 'utf-8')); } catch { /* new file */ }
+  if (!settings.hooks || typeof settings.hooks !== 'object') settings.hooks = {};
+  const existing = Array.isArray(settings.hooks.StopFailure) ? settings.hooks.StopFailure : [];
+  // Idempotent: drop any prior entry pointing at our handler, then add the current one.
+  const kept = existing.filter((e) => !JSON.stringify(e).includes(HOOK_MARKER));
+  kept.push(stopFailureHookEntry());
+  settings.hooks.StopFailure = kept;
+  await mkdir(dirname(settingsPath), { recursive: true });
+  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  console.log(`StopFailure hook installed in ${settingsPath}`);
+  console.log('New Claude sessions launched via the wrapper will use event-driven detection.');
+}
+
+async function cmdUninstallHook() {
+  const settingsPath = join(resolveConfigDir(process.argv[3]), 'settings.json');
+  try {
+    const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+    if (Array.isArray(settings.hooks?.StopFailure)) {
+      settings.hooks.StopFailure = settings.hooks.StopFailure.filter((e) => !JSON.stringify(e).includes(HOOK_MARKER));
+      if (settings.hooks.StopFailure.length === 0) delete settings.hooks.StopFailure;
+      if (settings.hooks && Object.keys(settings.hooks).length === 0) delete settings.hooks;
+      await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+    }
+    console.log(`StopFailure hook removed from ${settingsPath}`);
+  } catch { console.log('No settings file to modify.'); }
+}
+
 async function cmdVersion() {
   try {
     const pkg = JSON.parse(await readFile(join(__dirname, '..', 'package.json'), 'utf-8'));
@@ -210,16 +273,23 @@ const command = process.argv[2];
 switch (command) {
   case 'install': await cmdInstall(); break;
   case 'uninstall': await cmdUninstall(); break;
+  case 'install-hook': await cmdInstallHook(); break;
+  case 'uninstall-hook': await cmdUninstallHook(); break;
+  case HOOK_MARKER: await cmdStopFailureHook(); break;
   case 'status': await cmdStatus(); break;
   case 'logs': await cmdLogs(); break;
   case 'version': case '--version': case '-v': await cmdVersion(); break;
   default:
     console.log('claude-auto-retry - Auto-retry Claude Code on subscription rate limits\n');
     console.log('Usage:');
-    console.log('  claude-auto-retry install     Install shell wrapper + tmux');
-    console.log('  claude-auto-retry uninstall   Remove shell wrapper');
-    console.log('  claude-auto-retry status      Show monitor status');
-    console.log('  claude-auto-retry logs        Tail today\'s log');
-    console.log('  claude-auto-retry version     Print version');
+    console.log('  claude-auto-retry install            Install shell wrapper + tmux');
+    console.log('  claude-auto-retry uninstall          Remove shell wrapper');
+    console.log('  claude-auto-retry install-hook [dir] Install the StopFailure hook (event-driven');
+    console.log('                                       overload detection) into <dir>/settings.json');
+    console.log('                                       (default: $CLAUDE_CONFIG_DIR or ~/.claude)');
+    console.log('  claude-auto-retry uninstall-hook [dir]  Remove the StopFailure hook');
+    console.log('  claude-auto-retry status             Show monitor status');
+    console.log('  claude-auto-retry logs               Tail today\'s log');
+    console.log('  claude-auto-retry version            Print version');
     break;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-auto-retry",
-  "version": "0.2.2",
-  "description": "Automatically retry Claude Code sessions when hitting Anthropic subscription rate limits",
+  "version": "0.3.0",
+  "description": "Automatically retry Claude Code sessions on subscription rate limits and sustained API overload (529/500/503) with exponential backoff",
   "type": "module",
   "bin": {
     "claude-auto-retry": "./bin/cli.js"
@@ -16,7 +16,7 @@
   "keywords": ["claude", "claude-code", "rate-limit", "retry", "tmux", "anthropic"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/cheapestinference/claude-auto-retry"
+    "url": "https://github.com/romerjon/claude-auto-retry"
   },
   "files": ["bin/", "src/", "LICENSE", "README.md"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-auto-retry",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Automatically retry Claude Code sessions on subscription rate limits and sustained API overload (529/500/503) with exponential backoff",
   "type": "module",
   "bin": {
@@ -16,7 +16,7 @@
   "keywords": ["claude", "claude-code", "rate-limit", "retry", "tmux", "anthropic"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/romerjon/claude-auto-retry"
+    "url": "https://github.com/cheapestinference/claude-auto-retry"
   },
   "files": ["bin/", "src/", "LICENSE", "README.md"]
 }

--- a/src/config.js
+++ b/src/config.js
@@ -7,15 +7,33 @@ import { homedir } from 'node:os';
 // *seconds* on an exponential backoff. See README "Overload backoff".
 export const DEFAULT_OVERLOAD = {
   enabled: true,
+  // Anchored to Claude Code's actual TERMINAL error render — NOT bare status numbers.
+  // A bare "503"/"529" matches ordinary code (res.status(503)), ports, byte counts and
+  // quoted logs, which is what caused false "Continue where you left off." injections.
+  // Matched as case-insensitive regexes against only the pane tail (see detectOverload).
+  //
+  // Claude Code (verified against the v2.1.x binary) has TWO render forms:
+  //   terminal (retries exhausted):  "API Error: 529 {…}"  / "API Error: 503 no healthy upstream"
+  //   transient (still retrying):     "API Error (529 …) · Retrying in 5s · attempt 3/10"
+  // We REQUIRE the colon form to skip the parens form, and the retry SUFFIX
+  // ("· Retrying in…" / "attempt n/m") is separately suppressed by the working gate
+  // in patterns.js — together they ensure we never interrupt Claude's own backoff.
   patterns: [
-    'Overloaded', 'API Error: 529', '529',
-    'API Error: 500', '500 Internal server error', 'Internal server error',
-    '503', 'status.claude.com',
+    // Terminal error line. Covers the full retryable set (429+5xx) in the colon form.
+    'API Error:\\s*(429|500|502|503|504|529)\\b',
+    // JSON error.type for a sustained overload (survives the collapsed non-JSON render).
+    'overloaded_error',
+    // API-level 429 uses a dedicated render with no 3-digit code in the generic slot:
+    //   "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited"
+    'temporarily limiting requests',
   ],
   backoffSeconds: [30, 60, 120, 240, 300],
   steadyStateSeconds: 300,
   jitterPct: 15,
   maxTotalWaitMinutes: 120,
+  // StopFailure event markers older than this are ignored (guards against a recycled
+  // tmux pane id replaying a stale failure, or acting on a marker left while down).
+  eventMaxAgeSeconds: 120,
   retryMessage: 'Continue where you left off.',
   // Gating: by default we only act when claude is alive at its prompt (the
   // foreground safety check passes). If a 500 ever drops you to the shell, the
@@ -54,8 +72,13 @@ function validateOverload(raw) {
 
   o.enabled = typeof o.enabled === 'boolean' ? o.enabled : DEFAULT_OVERLOAD.enabled;
 
+  // Patterns are case-insensitive regexes (see detectOverload). Keep only non-empty
+  // strings that actually compile, so a typo'd pattern can't crash the monitor tick.
   const pats = Array.isArray(o.patterns)
-    ? o.patterns.filter(p => typeof p === 'string' && p.length > 0)
+    ? o.patterns.filter(p => {
+        if (typeof p !== 'string' || p.length === 0) return false;
+        try { new RegExp(p); return true; } catch { return false; }
+      })
     : [];
   o.patterns = pats.length > 0 ? pats : [...DEFAULT_OVERLOAD.patterns];
 
@@ -67,6 +90,7 @@ function validateOverload(raw) {
   o.steadyStateSeconds = validNumber(o.steadyStateSeconds, 1, DEFAULT_OVERLOAD.steadyStateSeconds);
   o.jitterPct = clamp(o.jitterPct, 0, 100, DEFAULT_OVERLOAD.jitterPct);
   o.maxTotalWaitMinutes = validNumber(o.maxTotalWaitMinutes, 0.1, DEFAULT_OVERLOAD.maxTotalWaitMinutes);
+  o.eventMaxAgeSeconds = validNumber(o.eventMaxAgeSeconds, 1, DEFAULT_OVERLOAD.eventMaxAgeSeconds);
 
   if (typeof o.retryMessage !== 'string' || !o.retryMessage) {
     o.retryMessage = DEFAULT_OVERLOAD.retryMessage;

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,30 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
+// Transient API-error backoff (529 Overloaded / 500 / 503). Separate block from
+// the usage-limit knobs above: those wait in *hours* until a reset, these wait in
+// *seconds* on an exponential backoff. See README "Overload backoff".
+export const DEFAULT_OVERLOAD = {
+  enabled: true,
+  patterns: [
+    'Overloaded', 'API Error: 529', '529',
+    'API Error: 500', '500 Internal server error', 'Internal server error',
+    '503', 'status.claude.com',
+  ],
+  backoffSeconds: [30, 60, 120, 240, 300],
+  steadyStateSeconds: 300,
+  jitterPct: 15,
+  maxTotalWaitMinutes: 120,
+  retryMessage: 'Continue where you left off.',
+  // Gating: by default we only act when claude is alive at its prompt (the
+  // foreground safety check passes). If a 500 ever drops you to the shell, the
+  // send-keys is correctly blocked and nothing resumes; flip relaunchOnExit to
+  // re-enter via relaunchCommand. Off by default — never type into a shell the
+  // user may be using. See README "Gating decision".
+  relaunchOnExit: false,
+  relaunchCommand: 'claude --continue',
+};
+
 export const DEFAULT_CONFIG = {
   maxRetries: 5,
   pollIntervalSeconds: 5,
@@ -9,12 +33,49 @@ export const DEFAULT_CONFIG = {
   fallbackWaitHours: 5,
   retryMessage: 'Continue where you left off. The previous attempt was rate limited.',
   customPatterns: [],
+  overload: DEFAULT_OVERLOAD,
 };
 
 const CONFIG_PATH = join(homedir(), '.claude-auto-retry.json');
 
 function validNumber(val, min, fallback) {
   return typeof val === 'number' && Number.isFinite(val) && val >= min ? val : fallback;
+}
+
+function clamp(val, lo, hi, fallback) {
+  if (typeof val !== 'number' || !Number.isFinite(val)) return fallback;
+  return Math.min(hi, Math.max(lo, val));
+}
+
+function validateOverload(raw) {
+  // Shallow-merge so a partial user block keeps the documented defaults for the
+  // keys it omits (JSON.parse's spread would otherwise replace the whole block).
+  const o = { ...DEFAULT_OVERLOAD, ...(raw && typeof raw === 'object' ? raw : {}) };
+
+  o.enabled = typeof o.enabled === 'boolean' ? o.enabled : DEFAULT_OVERLOAD.enabled;
+
+  const pats = Array.isArray(o.patterns)
+    ? o.patterns.filter(p => typeof p === 'string' && p.length > 0)
+    : [];
+  o.patterns = pats.length > 0 ? pats : [...DEFAULT_OVERLOAD.patterns];
+
+  const backoff = Array.isArray(o.backoffSeconds)
+    ? o.backoffSeconds.filter(n => typeof n === 'number' && Number.isFinite(n) && n > 0)
+    : [];
+  o.backoffSeconds = backoff.length > 0 ? backoff : [...DEFAULT_OVERLOAD.backoffSeconds];
+
+  o.steadyStateSeconds = validNumber(o.steadyStateSeconds, 1, DEFAULT_OVERLOAD.steadyStateSeconds);
+  o.jitterPct = clamp(o.jitterPct, 0, 100, DEFAULT_OVERLOAD.jitterPct);
+  o.maxTotalWaitMinutes = validNumber(o.maxTotalWaitMinutes, 0.1, DEFAULT_OVERLOAD.maxTotalWaitMinutes);
+
+  if (typeof o.retryMessage !== 'string' || !o.retryMessage) {
+    o.retryMessage = DEFAULT_OVERLOAD.retryMessage;
+  }
+  o.relaunchOnExit = typeof o.relaunchOnExit === 'boolean' ? o.relaunchOnExit : DEFAULT_OVERLOAD.relaunchOnExit;
+  if (typeof o.relaunchCommand !== 'string' || !o.relaunchCommand) {
+    o.relaunchCommand = DEFAULT_OVERLOAD.relaunchCommand;
+  }
+  return o;
 }
 
 function validate(cfg) {
@@ -38,6 +99,7 @@ function validate(cfg) {
       delete cfg.foregroundCommands;
     }
   }
+  cfg.overload = validateOverload(cfg.overload);
   return cfg;
 }
 

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,59 @@
+// StopFailure event channel: the authoritative, scrape-free overload trigger.
+//
+// Claude Code's `StopFailure` hook fires only when a turn ends in an API error, with a
+// typed `error` (matcher-filtered to overloaded/server_error/rate_limit). The hook runs
+// as a CHILD of claude, so it inherits the env the launcher stamped onto claude —
+// including CLAUDE_AUTO_RETRY_PANE. It writes a marker keyed by that pane; the daemon,
+// which already knows its pane, reads it directly. No session-id plumbing needed (the
+// main claude PID's environ does not even carry CLAUDE_CODE_SESSION_ID).
+//
+// Markers are short-lived (consumed on action, ignored past eventMaxAge) so a recycled
+// tmux pane id can't replay a stale failure.
+
+import { mkdir, writeFile, readFile, unlink, rename } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+export const EVENTS_DIR = join(homedir(), '.claude-auto-retry', 'events');
+
+// Error types we treat as a retryable overload — mirrors the hook matcher. Anything else
+// (auth, billing, invalid_request, …) is permanent and must NOT drive a retry.
+const RETRYABLE = new Set(['overloaded', 'server_error', 'rate_limit']);
+
+export function isRetryableError(errorType) {
+  return typeof errorType === 'string' && RETRYABLE.has(errorType.toLowerCase());
+}
+
+// tmux pane ids look like "%2"; keep the marker filename to a safe charset.
+function fileFor(paneKey, dir) {
+  const safe = String(paneKey).replace(/[^A-Za-z0-9_-]/g, '_');
+  return join(dir, `${safe}.json`);
+}
+
+// Hook side: write a marker for the pane. Atomic (tmp + rename) so the daemon never
+// reads a half-written file.
+export async function writeStopFailureEvent(paneKey, payload, dir = EVENTS_DIR) {
+  if (!paneKey) return null;
+  const error = typeof payload?.error === 'string' ? payload.error : 'unknown';
+  await mkdir(dir, { recursive: true });
+  const file = fileFor(paneKey, dir);
+  const tmp = `${file}.${process.pid}.tmp`;
+  const body = JSON.stringify({ pane: String(paneKey), error, session_id: payload?.session_id ?? null, ts: Date.now() });
+  await writeFile(tmp, body);
+  await rename(tmp, file);
+  return file;
+}
+
+// Daemon side: return a fresh marker for the pane, or null (absent / unparseable / stale).
+export async function readStopFailureEvent(paneKey, maxAgeMs, dir = EVENTS_DIR) {
+  if (!paneKey) return null;
+  try {
+    const ev = JSON.parse(await readFile(fileFor(paneKey, dir), 'utf-8'));
+    if (typeof ev.ts !== 'number' || Date.now() - ev.ts > maxAgeMs) return null;
+    return ev;
+  } catch { return null; }
+}
+
+export async function clearStopFailureEvent(paneKey, dir = EVENTS_DIR) {
+  try { await unlink(fileFor(paneKey, dir)); } catch { /* already gone */ }
+}

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -31,9 +31,11 @@ async function launchInteractive(args) {
   const claudeBin = findClaudeBinary();
   const pane = getCurrentPane();
 
+  // CLAUDE_AUTO_RETRY_PANE is inherited by claude's child processes — notably the
+  // StopFailure hook, which writes a pane-keyed event marker the monitor consumes.
   const claude = spawn(claudeBin, args, {
     stdio: 'inherit',
-    env: { ...process.env, CLAUDE_AUTO_RETRY_ACTIVE: '1' },
+    env: { ...process.env, CLAUDE_AUTO_RETRY_ACTIVE: '1', ...(pane ? { CLAUDE_AUTO_RETRY_PANE: pane } : {}) },
   });
 
   // Check spawn succeeded before using PID

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,8 +1,9 @@
-import { stripAnsi, isRateLimited, findRateLimitMessage, detectOverload, isWorking } from './patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, detectOverload, overloadMatch, isWorking } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
 import { capturePane, sendKeys, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
+import { readStopFailureEvent, clearStopFailureEvent } from './events.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 const SHELL_COMMANDS = ['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'];
@@ -12,6 +13,10 @@ export function createMonitorState() {
     status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null,
     // Overload-retry sub-state, kept distinct from the usage-reset fields above.
     overloadAttempts: 0, overloadTotalWaitMs: 0, overloadWaitUntil: 0,
+    // Event-driven overload: eventMode latches true once a StopFailure marker is ever
+    // seen (proves the hook is live → stop trusting the scraper). viaEvent marks the
+    // current backoff window as event-triggered (edge: one send per failure).
+    eventMode: false, viaEvent: false,
   };
 }
 
@@ -37,6 +42,20 @@ function resetOverload(state) {
   state.overloadAttempts = 0;
   state.overloadTotalWaitMs = 0;
   state.overloadWaitUntil = 0;
+  state.viaEvent = false;
+}
+
+// Foreground safety: is claude/node the foreground process (safe to send-keys), or did
+// it exit to a shell / is some other app focused? Returns { ok, fg, isShell }.
+async function checkForeground(tmuxAdapter, pane, config) {
+  const isFg = await tmuxAdapter.isClaudeForeground();
+  if (isFg === true) return { ok: true, fg: null, isShell: false };
+  const fg = await tmuxAdapter.getPaneCommand(pane);
+  const fgCommands = config.foregroundCommands || DEFAULT_FOREGROUND_COMMANDS;
+  if (fgCommands.some(c => fg.toLowerCase().includes(c))) return { ok: true, fg, isShell: false };
+  const lc = (fg || '').toLowerCase();
+  const isShell = lc !== '' && SHELL_COMMANDS.some(s => lc === s || lc.includes(s));
+  return { ok: false, fg, isShell };
 }
 
 function enterUsageWait(state, stripped, config) {
@@ -118,6 +137,34 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     if (Date.now() < state.overloadWaitUntil) return 'overload-waiting';
     if (!isAlive()) return 'exit';
 
+    // Event-triggered window: a StopFailure marker put us here. Edge-triggered — send
+    // exactly once per failure, then return to monitoring to await the next marker. We
+    // do NOT re-check the scraper for "still overloaded" (the marker was authoritative).
+    if (state.viaEvent) {
+      // Self-recovery: Claude resumed during the backoff → don't interrupt it.
+      if (isWorking(stripped)) { resetOverload(state); state.status = 'monitoring'; return 'overload-cleared'; }
+      // A usage limit appearing mid-wait still takes precedence.
+      if (isRateLimited(stripped, config.customPatterns)) { resetOverload(state); return enterUsageWait(state, stripped, config); }
+
+      const foregroundOk = await checkForeground(tmuxAdapter, pane, config);
+      if (!foregroundOk.ok) {
+        state._lastForeground = foregroundOk.fg;
+        state.viaEvent = false; state.status = 'monitoring';
+        if (foregroundOk.isShell && overload.relaunchOnExit) {
+          state.overloadAttempts++;
+          await tmuxAdapter.sendKeys(pane, overload.relaunchCommand);
+          return 'overload-relaunched';
+        }
+        return foregroundOk.isShell ? 'overload-exited-to-shell' : 'skipped-not-claude';
+      }
+
+      state.overloadAttempts++;          // next failure backs off further
+      state.viaEvent = false;
+      state.status = 'monitoring';
+      await tmuxAdapter.sendKeys(pane, overload.retryMessage);
+      return 'overload-retried';
+    }
+
     const capMs = overload.maxTotalWaitMinutes * 60_000;
 
     // Usage-limit takes precedence: hand off to the (hours-scale) reset path.
@@ -193,10 +240,34 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     return enterUsageWait(state, stripped, config);
   }
 
-  if (overload && overload.enabled
-      && detectOverload(stripped, overload.patterns)
-      && !isWorking(stripped)) {
-    return enterOverload(state, overload, rand);
+  // Event-driven overload (authoritative; see DESIGN-NOTES §1). A StopFailure marker for
+  // this pane means the turn ended in a retryable API error — no scraping, no ambiguity.
+  // Latches eventMode so the scraper path is disabled once we know the hook is live.
+  if (overload && overload.enabled && tmuxAdapter.readEvent) {
+    const ev = await tmuxAdapter.readEvent();
+    if (ev) {
+      state.eventMode = true;
+      await tmuxAdapter.clearEvent();               // consume
+      if (isWorking(stripped)) { resetOverload(state); return 'overload-cleared'; } // self-recovered
+      const capMs = overload.maxTotalWaitMinutes * 60_000;
+      if (state.overloadTotalWaitMs >= capMs) return 'overload-gave-up';
+      const w = nextOverloadWaitMs(state.overloadAttempts, overload, rand);
+      state.overloadTotalWaitMs += w;
+      state.overloadWaitUntil = Date.now() + w;
+      state.status = 'overload';
+      state.viaEvent = true;
+      state._overloadMatch = { pattern: 'StopFailure', line: `error=${ev.error}` };
+      return 'overload-detected';
+    }
+  }
+
+  // Scraper fallback — only while eventMode hasn't latched (hook absent or not yet fired).
+  if (!state.eventMode && overload && overload.enabled && !isWorking(stripped)) {
+    const match = overloadMatch(stripped, overload.patterns);
+    if (match) {
+      state._overloadMatch = match;  // surfaced in the 'overload-detected' log line
+      return enterOverload(state, overload, rand);
+    }
   }
 
   return 'monitoring';
@@ -211,7 +282,15 @@ export async function startMonitor(pane, pid) {
 
   await logger.info(`Monitor started for pane ${pane} (claude PID: ${pid})`);
 
-  const tmuxAdapter = { capturePane, sendKeys, getPaneCommand, isClaudeForeground: () => isProcessForeground(pid) };
+  const eventMaxAgeMs = (config.overload?.eventMaxAgeSeconds || 120) * 1000;
+  const tmuxAdapter = {
+    capturePane, sendKeys, getPaneCommand,
+    isClaudeForeground: () => isProcessForeground(pid),
+    // Pane-keyed StopFailure markers (written by the hook). The daemon owns the pane,
+    // so this is a direct read — no session-id resolution needed.
+    readEvent: () => readStopFailureEvent(pane, eventMaxAgeMs),
+    clearEvent: () => clearStopFailureEvent(pane),
+  };
   const isAlive = () => { try { process.kill(pid, 0); return true; } catch { return false; } };
 
   const loop = async () => {
@@ -231,7 +310,9 @@ export async function startMonitor(pane, pid) {
       if (result === 'skipped-not-claude') await logger.warn(`Foreground is "${state._lastForeground}", not Claude. Skipping send-keys. (Add to foregroundCommands in ~/.claude-auto-retry.json if this is wrong)`);
       if (result === 'overload-detected') {
         const secs = Math.round((state.overloadWaitUntil - Date.now()) / 1000);
-        await logger.warn(`Overload/transient API error detected (sustained). Backing off ${secs}s before retry. NOTE: Claude Code retries 5xx/529 internally — this only fires on terminal overload.`);
+        const m = state._overloadMatch;
+        const why = m ? ` [matched /${m.pattern}/ in: "${m.line}"]` : '';
+        await logger.warn(`Overload/transient API error detected (sustained)${why}. Backing off ${secs}s before retry. NOTE: Claude Code retries 5xx/529 internally — this only fires on terminal overload.`);
       }
       if (result === 'overload-retried') {
         const secs = Math.round((state.overloadWaitUntil - Date.now()) / 1000);

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,20 +1,76 @@
-import { stripAnsi, isRateLimited, findRateLimitMessage } from './patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, detectOverload, isWorking } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
 import { capturePane, sendKeys, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
+const SHELL_COMMANDS = ['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'];
 
 export function createMonitorState() {
-  return { status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null };
+  return {
+    status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null,
+    // Overload-retry sub-state, kept distinct from the usage-reset fields above.
+    overloadAttempts: 0, overloadTotalWaitMs: 0, overloadWaitUntil: 0,
+  };
 }
 
-export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) {
+// --- Overload backoff schedule (pure, testable) ---
+// Wait backoffSeconds[i] for attempt i; once the array is exhausted, steadyStateSeconds.
+export function overloadBaseWaitMs(attemptIndex, overload) {
+  const { backoffSeconds, steadyStateSeconds } = overload;
+  const secs = attemptIndex < backoffSeconds.length ? backoffSeconds[attemptIndex] : steadyStateSeconds;
+  return secs * 1000;
+}
+
+export function applyJitter(ms, jitterPct, rand = Math.random) {
+  if (!jitterPct) return ms;
+  const factor = 1 + (rand() * 2 - 1) * (jitterPct / 100);  // ±jitterPct%
+  return Math.max(0, Math.round(ms * factor));
+}
+
+export function nextOverloadWaitMs(attemptIndex, overload, rand = Math.random) {
+  return applyJitter(overloadBaseWaitMs(attemptIndex, overload), overload.jitterPct, rand);
+}
+
+function resetOverload(state) {
+  state.overloadAttempts = 0;
+  state.overloadTotalWaitMs = 0;
+  state.overloadWaitUntil = 0;
+}
+
+function enterUsageWait(state, stripped, config) {
+  const message = findRateLimitMessage(stripped, config.customPatterns);
+  state.lastRateLimitMessage = message;
+  const parsed = message ? parseResetTime(message) : null;
+  state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
+  state.status = 'waiting';
+  return 'waiting';
+}
+
+function enterOverload(state, overload, rand) {
+  const capMs = overload.maxTotalWaitMinutes * 60_000;
+  resetOverload(state);
+  state.status = 'overload';
+  const w = nextOverloadWaitMs(0, overload, rand);
+  if (w > capMs) {
+    // Degenerate config (first backoff already exceeds the cap): force the cap to
+    // trip on the next tick rather than entering a real retry loop.
+    state.overloadTotalWaitMs = capMs;
+    state.overloadWaitUntil = 0;
+    return 'overload-detected';
+  }
+  state.overloadTotalWaitMs = w;
+  state.overloadWaitUntil = Date.now() + w;
+  return 'overload-detected';
+}
+
+export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, rand = Math.random) {
   if (!isAlive()) return 'exit';
 
   const raw = await tmuxAdapter.capturePane(pane, 20);
   const stripped = stripAnsi(raw);
+  const overload = config.overload;
 
   if (state.status === 'waiting') {
     if (Date.now() < state.waitUntil) return 'waiting';
@@ -58,13 +114,89 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive) 
     return 'retried';
   }
 
+  if (state.status === 'overload') {
+    if (Date.now() < state.overloadWaitUntil) return 'overload-waiting';
+    if (!isAlive()) return 'exit';
+
+    const capMs = overload.maxTotalWaitMinutes * 60_000;
+
+    // Usage-limit takes precedence: hand off to the (hours-scale) reset path.
+    if (isRateLimited(stripped, config.customPatterns)) {
+      resetOverload(state);
+      return enterUsageWait(state, stripped, config);
+    }
+
+    // Overload text gone → recovered. Back to plain monitoring.
+    if (!detectOverload(stripped, overload.patterns)) {
+      state.status = 'monitoring';
+      resetOverload(state);
+      return 'overload-cleared';
+    }
+
+    // Terminal-state gate: if Claude is actively working (its own internal retry
+    // or a fresh response is streaming), the error is NOT terminal. Defer without
+    // consuming an attempt so we never double-drive a live session.
+    if (isWorking(stripped)) {
+      state.overloadWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 2);
+      return 'overload-working';
+    }
+
+    // Mandatory cap: give up loudly rather than hammer a genuinely-down endpoint
+    // or mask a real outage. Long cooldown to avoid re-detecting the stale error.
+    if (state.overloadTotalWaitMs >= capMs) {
+      state.overloadWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      return 'overload-gave-up';
+    }
+
+    // Foreground safety, reused from the usage path: only act when claude/node is
+    // the foreground process. (See the gating decision in the README.)
+    const isFg = await tmuxAdapter.isClaudeForeground();
+    let foregroundOk = isFg === true;
+    let fg = null;
+    if (!foregroundOk) {
+      fg = await tmuxAdapter.getPaneCommand(pane);
+      const fgCommands = config.foregroundCommands || DEFAULT_FOREGROUND_COMMANDS;
+      foregroundOk = fgCommands.some(c => fg.toLowerCase().includes(c));
+    }
+
+    if (!foregroundOk) {
+      // Distinguish "claude exited to the shell" (error visible above a shell
+      // prompt) from "some other foreground app", for diagnostics + opt-in relaunch.
+      const lc = (fg || '').toLowerCase();
+      const isShell = lc !== '' && SHELL_COMMANDS.some(s => lc === s || lc.includes(s));
+      state._lastForeground = fg;
+      if (isShell && overload.relaunchOnExit) {
+        state.overloadAttempts++;
+        const w = nextOverloadWaitMs(state.overloadAttempts, overload, rand);
+        state.overloadTotalWaitMs += w;
+        state.overloadWaitUntil = Date.now() + w;
+        await tmuxAdapter.sendKeys(pane, overload.relaunchCommand);
+        return 'overload-relaunched';
+      }
+      state.overloadWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 6);
+      return isShell ? 'overload-exited-to-shell' : 'skipped-not-claude';
+    }
+
+    // Alive at the prompt → send the retry, then schedule the next backoff window.
+    // Increment + schedule BEFORE sendKeys so a send failure still consumes the slot.
+    state.overloadAttempts++;
+    const w = nextOverloadWaitMs(state.overloadAttempts, overload, rand);
+    state.overloadTotalWaitMs += w;
+    state.overloadWaitUntil = Date.now() + w;
+    await tmuxAdapter.sendKeys(pane, overload.retryMessage);
+    return 'overload-retried';
+  }
+
+  // --- monitoring ---
+  // Usage-limit (hours-scale reset) takes precedence over overload (seconds-scale).
   if (isRateLimited(stripped, config.customPatterns)) {
-    const message = findRateLimitMessage(stripped, config.customPatterns);
-    state.lastRateLimitMessage = message;
-    const parsed = message ? parseResetTime(message) : null;
-    state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
-    state.status = 'waiting';
-    return 'waiting';
+    return enterUsageWait(state, stripped, config);
+  }
+
+  if (overload && overload.enabled
+      && detectOverload(stripped, overload.patterns)
+      && !isWorking(stripped)) {
+    return enterOverload(state, overload, rand);
   }
 
   return 'monitoring';
@@ -97,6 +229,19 @@ export async function startMonitor(pane, pid) {
       if (result === 'user-continued') await logger.info('User already continued. Attempt counter reset.');
       if (result === 'max-retries') await logger.warn(`Max retries (${config.maxRetries}) reached. Monitor still active but will not send further retries until rate limit clears.`);
       if (result === 'skipped-not-claude') await logger.warn(`Foreground is "${state._lastForeground}", not Claude. Skipping send-keys. (Add to foregroundCommands in ~/.claude-auto-retry.json if this is wrong)`);
+      if (result === 'overload-detected') {
+        const secs = Math.round((state.overloadWaitUntil - Date.now()) / 1000);
+        await logger.warn(`Overload/transient API error detected (sustained). Backing off ${secs}s before retry. NOTE: Claude Code retries 5xx/529 internally — this only fires on terminal overload.`);
+      }
+      if (result === 'overload-retried') {
+        const secs = Math.round((state.overloadWaitUntil - Date.now()) / 1000);
+        await logger.info(`Overload retry sent (attempt ${state.overloadAttempts}). Next backoff ${secs}s. Cumulative wait ${Math.round(state.overloadTotalWaitMs / 1000)}s.`);
+      }
+      if (result === 'overload-working') await logger.info('Overload text present but Claude is working (internal retry/streaming). Deferring — not terminal.');
+      if (result === 'overload-cleared') await logger.info('Overload cleared. Resuming normal monitoring.');
+      if (result === 'overload-relaunched') await logger.warn(`Claude exited to shell on overload; relaunched via "${config.overload.relaunchCommand}" (relaunchOnExit on, attempt ${state.overloadAttempts}).`);
+      if (result === 'overload-exited-to-shell') await logger.warn(`Overload error left claude exited to the shell ("${state._lastForeground}"). Not auto-relaunching (relaunchOnExit off). Re-run "claude --continue" to resume, or set overload.relaunchOnExit:true.`);
+      if (result === 'overload-gave-up') await logger.warn(`Overload backoff cap reached (maxTotalWaitMinutes=${config.overload.maxTotalWaitMinutes}). Giving up — endpoint may be genuinely down (check status.claude.com). Will not retry until the error clears.`);
     } catch (err) {
       consecutiveErrors++;
       await logger.error(`Monitor tick error: ${err.message}`).catch(() => {});

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -72,27 +72,78 @@ export function isRateLimited(text, customPatterns = []) {
 
 // --- Overload / transient API error detection (distinct from usage limits) ---
 // Claude Code already retries 5xx/529 internally; this only fires on a *sustained*
-// terminal error left in the pane. Patterns are plain substrings (case-insensitive),
-// config-driven via the `overload.patterns` block. Kept entirely separate from the
-// usage-limit path above so the two never collide.
+// terminal error left in the pane. Patterns are case-insensitive regexes (same as
+// the usage-limit customPatterns), config-driven via `overload.patterns`. Kept
+// entirely separate from the usage-limit path above so the two never collide.
+//
+// Two guards keep this from firing on ordinary content (the historical bug: a bare
+// "503"/"529" in code under edit, an HTTP status in a quoted log, or "status.claude.com"
+// in a comment all looked identical to a live error):
+//   1. Patterns are ANCHORED to Claude Code's actual error render ("API Error: <code>"
+//      or the "overloaded_error" JSON type) — never a bare status number.
+//   2. Only the TAIL of the pane is inspected. A *terminal* error is the last thing
+//      Claude printed; the same digits sitting in scrollback the user scrolled past
+//      are not an error. Matching the full 20-line capture is what drove the false
+//      positives — a 503 far up the buffer kept re-triggering during unrelated work.
 
-// Active-work indicators in the Claude Code TUI footer. While any of these is on
-// screen, Claude is mid-flight (its own internal retry may be running), so an
-// overload line in the scrollback is NOT terminal — we must not drive the session.
+// A real terminal error sits just above the input box (~5-6 variable lines: box
+// borders + input row(s) + footer). A multi-line JSON error body adds a few more, so
+// its anchor line can land ~10 rows from the bottom. 12 covers that with margin while
+// still trimming the top ~8 lines of the 20-line capture (where stale scrollback lives).
+const OVERLOAD_TAIL_LINES = 12;
+
+// Indicators that Claude is mid-flight and the pane is NOT in a terminal error state.
+// Two kinds: the streaming footer, and Claude Code's OWN internal-retry indicator.
+// While either is on screen the request's retries are not exhausted — acting now would
+// interrupt Claude's backoff. The transient error render is "API Error (529 …) ·
+// Retrying in 5s · attempt 3/10"; the colon form can also carry the "· Retrying" suffix
+// until exhausted, so we gate on the suffix itself, not just the parens form.
 const WORKING_PATTERNS = [
   /esc to interrupt/i,        // the working/streaming footer ("… (esc to interrupt)")
   /\besc\b.*\binterrupt\b/i,  // tolerate reordering/spacing in the same footer
+  /Retrying in\b/i,           // internal-retry suffix — retries not yet exhausted
+  /\battempt\s+\d+\/\d+/i,    // "attempt 3/10" companion to the retry suffix
 ];
 
+function tail(text) {
+  return stripAnsi(text).split('\n').slice(-OVERLOAD_TAIL_LINES);
+}
+
+// Compile a config pattern (string → case-insensitive RegExp) once per call. Invalid
+// regexes are dropped rather than thrown (matches the usage-limit customPatterns path).
+function toRegexes(patterns) {
+  const out = [];
+  for (const p of patterns) {
+    if (p instanceof RegExp) { out.push(p); continue; }
+    if (typeof p !== 'string' || !p) continue;
+    try { out.push(new RegExp(p, 'i')); } catch { /* skip invalid */ }
+  }
+  return out;
+}
+
+// Returns { pattern, line } for the first overload pattern matching a tail line, else
+// null. Per-line (not whole-tail) so we can report WHICH line tripped it — invaluable
+// for diagnosing a future false positive (the original bug logged no reason at all).
+export function overloadMatch(text, patterns = []) {
+  if (!patterns || patterns.length === 0) return null;
+  const lines = tail(text);
+  if (!lines.join('').trim()) return null;
+  const regexes = toRegexes(patterns);
+  for (const line of lines) {
+    for (const r of regexes) {
+      if (r.test(line)) return { pattern: r.source, line: line.trim().slice(0, 200) };
+    }
+  }
+  return null;
+}
+
 export function detectOverload(text, patterns = []) {
-  if (!patterns || patterns.length === 0) return false;
-  const haystack = stripAnsi(text).toLowerCase();
-  return patterns.some(p => typeof p === 'string' && p && haystack.includes(p.toLowerCase()));
+  return overloadMatch(text, patterns) !== null;
 }
 
 export function isWorking(text) {
-  const stripped = stripAnsi(text);
-  return WORKING_PATTERNS.some(p => p.test(stripped));
+  const lines = tail(text);
+  return lines.some(line => WORKING_PATTERNS.some(p => p.test(line)));
 }
 
 export function findRateLimitMessage(text, customPatterns = []) {

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -70,6 +70,31 @@ export function isRateLimited(text, customPatterns = []) {
   return false;
 }
 
+// --- Overload / transient API error detection (distinct from usage limits) ---
+// Claude Code already retries 5xx/529 internally; this only fires on a *sustained*
+// terminal error left in the pane. Patterns are plain substrings (case-insensitive),
+// config-driven via the `overload.patterns` block. Kept entirely separate from the
+// usage-limit path above so the two never collide.
+
+// Active-work indicators in the Claude Code TUI footer. While any of these is on
+// screen, Claude is mid-flight (its own internal retry may be running), so an
+// overload line in the scrollback is NOT terminal — we must not drive the session.
+const WORKING_PATTERNS = [
+  /esc to interrupt/i,        // the working/streaming footer ("… (esc to interrupt)")
+  /\besc\b.*\binterrupt\b/i,  // tolerate reordering/spacing in the same footer
+];
+
+export function detectOverload(text, patterns = []) {
+  if (!patterns || patterns.length === 0) return false;
+  const haystack = stripAnsi(text).toLowerCase();
+  return patterns.some(p => typeof p === 'string' && p && haystack.includes(p.toLowerCase()));
+}
+
+export function isWorking(text) {
+  const stripped = stripAnsi(text);
+  return WORKING_PATTERNS.some(p => p.test(stripped));
+}
+
 export function findRateLimitMessage(text, customPatterns = []) {
   const lines = stripAnsi(text).split('\n');
 

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -1,0 +1,66 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  isRetryableError, writeStopFailureEvent, readStopFailureEvent, clearStopFailureEvent,
+} from '../src/events.js';
+
+describe('isRetryableError', () => {
+  it('accepts the retryable overload classes', () => {
+    for (const e of ['overloaded', 'server_error', 'rate_limit', 'OVERLOADED']) {
+      assert.equal(isRetryableError(e), true, e);
+    }
+  });
+  it('rejects permanent / unknown classes', () => {
+    for (const e of ['authentication_failed', 'billing_error', 'invalid_request', '', undefined, null, 42]) {
+      assert.equal(isRetryableError(e), false, String(e));
+    }
+  });
+});
+
+describe('StopFailure event markers', () => {
+  let dir;
+  before(async () => { dir = await mkdtemp(join(tmpdir(), 'car-ev-')); });
+  after(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('round-trips a pane-keyed marker', async () => {
+    await writeStopFailureEvent('%2', { error: 'overloaded', session_id: 'abc' }, dir);
+    const ev = await readStopFailureEvent('%2', 60_000, dir);
+    assert.equal(ev.error, 'overloaded');
+    assert.equal(ev.pane, '%2');
+    assert.equal(ev.session_id, 'abc');
+    assert.equal(typeof ev.ts, 'number');
+  });
+
+  it('sanitizes the pane id into the filename', async () => {
+    await writeStopFailureEvent('%7', { error: 'server_error' }, dir);
+    const files = await readdir(dir);
+    assert.ok(files.includes('_7.json'), files.join(','));
+  });
+
+  it('returns null for an absent marker', async () => {
+    assert.equal(await readStopFailureEvent('%99', 60_000, dir), null);
+  });
+
+  it('treats a marker past maxAge as stale', async () => {
+    await writeStopFailureEvent('%3', { error: 'overloaded' }, dir);
+    assert.equal(await readStopFailureEvent('%3', -1, dir), null);  // negative age → always stale
+  });
+
+  it('ignores an unparseable marker file', async () => {
+    await writeFile(join(dir, '_4.json'), 'not json');
+    assert.equal(await readStopFailureEvent('%4', 60_000, dir), null);
+  });
+
+  it('clear() consumes the marker', async () => {
+    await writeStopFailureEvent('%5', { error: 'rate_limit' }, dir);
+    await clearStopFailureEvent('%5', dir);
+    assert.equal(await readStopFailureEvent('%5', 60_000, dir), null);
+  });
+
+  it('write is a no-op without a pane key', async () => {
+    assert.equal(await writeStopFailureEvent('', { error: 'overloaded' }, dir), null);
+  });
+});

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { detectOverload, isWorking } from '../src/patterns.js';
+import { detectOverload, overloadMatch, isWorking } from '../src/patterns.js';
 import { loadConfig, DEFAULT_CONFIG, DEFAULT_OVERLOAD } from '../src/config.js';
 import {
   createMonitorState, processOneTick,
@@ -9,13 +9,15 @@ import {
 
 const PATS = DEFAULT_OVERLOAD.patterns;
 
-function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
+function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true, event = null) {
   const t = {
-    _sent: [],
+    _sent: [], _event: event, _cleared: false,
     capturePane: async () => paneContent,
     getPaneCommand: async () => paneCommand,
     sendKeys: async (_p, text) => { t._sent.push(text); },
     isClaudeForeground: async () => claudeForeground,
+    readEvent: async () => t._event,
+    clearEvent: async () => { t._event = null; t._cleared = true; },
   };
   return t;
 }
@@ -28,24 +30,64 @@ function cfg(overrides = {}) {
 const NO_JITTER = () => 0.5; // factor = 1 + (0.5*2-1)*pct = 1 (no shift)
 
 describe('detectOverload', () => {
-  it('matches "Overloaded"', () => assert.equal(detectOverload('⚠ Overloaded', PATS), true));
   it('matches "API Error: 529"', () => assert.equal(detectOverload('API Error: 529 Overloaded', PATS), true));
-  it('matches bare 529', () => assert.equal(detectOverload('got a 529 back', PATS), true));
-  it('matches "500 Internal server error"', () => assert.equal(detectOverload('500 Internal server error · try again', PATS), true));
-  it('matches "API Error: 500"', () => assert.equal(detectOverload('API Error: 500 {"type":"error"}', PATS), true));
-  it('matches 503', () => assert.equal(detectOverload('503 Service Unavailable', PATS), true));
-  it('matches status.claude.com hint', () => assert.equal(detectOverload('see status.claude.com', PATS), true));
+  it('matches "API Error: 500 Internal server error"', () => assert.equal(detectOverload('API Error: 500 Internal server error', PATS), true));
+  it('matches "API Error: 503 no healthy upstream" (plain-text edge body)', () => assert.equal(detectOverload('API Error: 503 no healthy upstream', PATS), true));
+  it('matches "API Error: 502"', () => assert.equal(detectOverload('API Error: 502 Bad Gateway', PATS), true));
+  it('matches "API Error: 504"', () => assert.equal(detectOverload('API Error: 504 Gateway Timeout', PATS), true));
+  it('matches the overloaded_error JSON type', () => assert.equal(detectOverload('API Error: 529 {"type":"error","error":{"type":"overloaded_error"}}', PATS), true));
+  it('matches the dedicated API-429 render (no 3-digit code in the slot)', () => assert.equal(detectOverload('API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited', PATS), true));
+  it('tolerates missing space after the colon', () => assert.equal(detectOverload('API Error:529', PATS), true));
   it('is case-insensitive', () => assert.equal(detectOverload('api error: 529 OVERLOADED', PATS), true));
   it('detects through ANSI codes', () => assert.equal(detectOverload('\x1b[31mAPI Error: 529\x1b[0m \x1b[1mOverloaded\x1b[0m', PATS), true));
   it('returns false for normal output', () => assert.equal(detectOverload('Here is the code you asked for', PATS), false));
   it('returns false for empty patterns', () => assert.equal(detectOverload('API Error: 529', []), false));
   it('returns false for empty text', () => assert.equal(detectOverload('', PATS), false));
+
+  // --- Regression: the exact false positives that injected "Continue where you left
+  //     off." into live sessions. None of these are a terminal API error. ---
+  it('does NOT match a bare status number ("got a 529 back")', () => assert.equal(detectOverload('got a 529 back', PATS), false));
+  it('does NOT match Express code under edit (res.status(503))', () => assert.equal(detectOverload('      res.status(503).json({ status: "degraded", db: "down" });', PATS), false));
+  it('does NOT match a Dockerfile HEALTHCHECK with 503/500 in a comment', () => assert.equal(detectOverload('# 500 Internal server error / 503 ... liveness check (200 even if DB down)', PATS), false));
+  it('does NOT match a "status.claude.com" mention in prose/comments', () => assert.equal(detectOverload('see status.claude.com for incidents', PATS), false));
+  it('does NOT match a bare "500 Internal server error" without the API Error frame', () => assert.equal(detectOverload('500 Internal server error · try again', PATS), false));
+
+  // --- Terminal vs transient: the parens form means Claude is STILL retrying. Acting
+  //     on it would interrupt Claude's own backoff. Only the colon form is terminal. ---
+  it('does NOT match the transient parens retry form', () => assert.equal(detectOverload('API Error (529 {"type":"error"}) · Retrying in 5s · attempt 3/10', PATS), false));
+
+  // --- Tail-anchoring: an error that has scrolled up out of the live tail is no
+  //     longer terminal (clean tail, an old status code sitting up in scrollback). ---
+  it('does NOT match an API error buried above the 12-line tail', () => {
+    const pane = ['API Error: 529 Overloaded', ...Array(15).fill('● Deleted workflow TEMP_fx_verify'), 'done.'].join('\n');
+    assert.equal(detectOverload(pane, PATS), false);
+  });
+  it('matches an API error sitting in the live tail', () => {
+    const pane = ['some earlier output', 'more output', 'API Error: 529 Overloaded'].join('\n');
+    assert.equal(detectOverload(pane, PATS), true);
+  });
+});
+
+describe('overloadMatch (observability)', () => {
+  it('reports the matched pattern and offending line', () => {
+    const m = overloadMatch('thinking…\nAPI Error: 529 Overloaded', PATS);
+    assert.ok(m && /429\|500/.test(m.pattern));
+    assert.equal(m.line, 'API Error: 529 Overloaded');
+  });
+  it('returns null when nothing matches', () => assert.equal(overloadMatch('res.status(503)', PATS), null));
+  it('truncates a very long offending line to 200 chars', () => {
+    const m = overloadMatch('API Error: 500 ' + 'x'.repeat(500), PATS);
+    assert.ok(m && m.line.length <= 200);
+  });
 });
 
 describe('isWorking', () => {
   it('detects the working footer', () => assert.equal(isWorking('Cogitating… (esc to interrupt)'), true));
   it('detects esc/interrupt through ANSI', () => assert.equal(isWorking('\x1b[2mesc to interrupt\x1b[0m'), true));
   it('returns false at an idle prompt', () => assert.equal(isWorking('│ > '), false));
+  // Claude's internal-retry indicator means retries are NOT exhausted → not terminal.
+  it('treats the "Retrying in" suffix as still-working', () => assert.equal(isWorking('API Error: 529 Overloaded · Retrying in 5s · attempt 3/10'), true));
+  it('treats an "attempt n/m" indicator as still-working', () => assert.equal(isWorking('thinking… attempt 2/10'), true));
 });
 
 describe('DEFAULT_OVERLOAD config', () => {
@@ -56,7 +98,9 @@ describe('DEFAULT_OVERLOAD config', () => {
     assert.equal(DEFAULT_CONFIG.overload.jitterPct, 15);
     assert.equal(DEFAULT_CONFIG.overload.maxTotalWaitMinutes, 120);
     assert.equal(DEFAULT_CONFIG.overload.relaunchOnExit, false);
-    assert.ok(DEFAULT_CONFIG.overload.patterns.includes('Overloaded'));
+    assert.ok(DEFAULT_CONFIG.overload.patterns.includes('overloaded_error'));
+    // Defaults must never carry a bare status number — that's the false-positive class.
+    assert.ok(!DEFAULT_CONFIG.overload.patterns.some(p => /^\d+$/.test(p)));
   });
 });
 
@@ -144,6 +188,14 @@ describe('processOneTick — overload path', () => {
     assert.equal(s.status, 'monitoring');
   });
 
+  it('does NOT enter overload while Claude is still internally retrying (colon form + suffix)', async () => {
+    const t = mockTmux('API Error: 529 {"type":"error"} · Retrying in 5s · attempt 3/10');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'monitoring');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+
   it('does NOT retry a non-target error', async () => {
     const t = mockTmux('Here is the answer to your question. Done.');
     const s = createMonitorState();
@@ -222,6 +274,69 @@ describe('processOneTick — overload path', () => {
     assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'waiting');
     assert.equal(s.status, 'waiting');
     assert.equal(s.overloadAttempts, 0);
+  });
+});
+
+describe('processOneTick — StopFailure event path (authoritative)', () => {
+  const ev = { error: 'overloaded', ts: Date.now() };
+
+  it('enters overload from a StopFailure marker with NO scraper match', async () => {
+    const t = mockTmux('working on a /health endpoint res.status(503)', 'node', true, ev);
+    const s = createMonitorState();
+    const r = await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
+    assert.equal(r, 'overload-detected');
+    assert.equal(s.eventMode, true);    // latched
+    assert.equal(s.viaEvent, true);
+    assert.equal(t._cleared, true);     // marker consumed
+    assert.equal(t._sent.length, 0);    // no send yet — backoff first
+    assert.ok(near(s.overloadWaitUntil - Date.now(), 30_000));
+  });
+
+  it('sends exactly once after the window, then returns to monitoring (edge-triggered)', async () => {
+    const t = mockTmux('idle prompt', 'node', true, null);
+    const s = createMonitorState();
+    s.status = 'overload'; s.viaEvent = true; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    const r = await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
+    assert.equal(r, 'overload-retried');
+    assert.equal(t._sent[0], DEFAULT_OVERLOAD.retryMessage);
+    assert.equal(s.status, 'monitoring');   // back to waiting for the next failure
+    assert.equal(s.viaEvent, false);
+    assert.equal(s.overloadAttempts, 1);
+  });
+
+  it('cancels the send if Claude self-recovered during the backoff', async () => {
+    const t = mockTmux('Thinking… (esc to interrupt)', 'node', true, null);
+    const s = createMonitorState();
+    s.status = 'overload'; s.viaEvent = true; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-cleared');
+    assert.equal(t._sent.length, 0);
+    assert.equal(s.status, 'monitoring');
+  });
+
+  it('treats an event as self-recovered if Claude is already working at detection', async () => {
+    const t = mockTmux('Cogitating… (esc to interrupt)', 'node', true, ev);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-cleared');
+    assert.equal(t._cleared, true);
+    assert.equal(s.status, 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('once eventMode is latched, the scraper path is disabled', async () => {
+    const t = mockTmux('API Error: 529 Overloaded', 'node', true, null);  // scraper WOULD match
+    const s = createMonitorState();
+    s.eventMode = true;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('does not send into a shell on an event (foreground gate still applies)', async () => {
+    const t = mockTmux('user@host:~$', 'bash', false, null);
+    const s = createMonitorState();
+    s.status = 'overload'; s.viaEvent = true; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-exited-to-shell');
+    assert.equal(t._sent.length, 0);
+    assert.equal(s.status, 'monitoring');
   });
 });
 

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -1,0 +1,271 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectOverload, isWorking } from '../src/patterns.js';
+import { loadConfig, DEFAULT_CONFIG, DEFAULT_OVERLOAD } from '../src/config.js';
+import {
+  createMonitorState, processOneTick,
+  overloadBaseWaitMs, applyJitter, nextOverloadWaitMs,
+} from '../src/monitor.js';
+
+const PATS = DEFAULT_OVERLOAD.patterns;
+
+function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
+  const t = {
+    _sent: [],
+    capturePane: async () => paneContent,
+    getPaneCommand: async () => paneCommand,
+    sendKeys: async (_p, text) => { t._sent.push(text); },
+    isClaudeForeground: async () => claudeForeground,
+  };
+  return t;
+}
+
+// Deterministic config: zero jitter so scheduled waits are exact.
+function cfg(overrides = {}) {
+  return { ...DEFAULT_CONFIG, overload: { ...DEFAULT_OVERLOAD, jitterPct: 0, ...overrides } };
+}
+
+const NO_JITTER = () => 0.5; // factor = 1 + (0.5*2-1)*pct = 1 (no shift)
+
+describe('detectOverload', () => {
+  it('matches "Overloaded"', () => assert.equal(detectOverload('⚠ Overloaded', PATS), true));
+  it('matches "API Error: 529"', () => assert.equal(detectOverload('API Error: 529 Overloaded', PATS), true));
+  it('matches bare 529', () => assert.equal(detectOverload('got a 529 back', PATS), true));
+  it('matches "500 Internal server error"', () => assert.equal(detectOverload('500 Internal server error · try again', PATS), true));
+  it('matches "API Error: 500"', () => assert.equal(detectOverload('API Error: 500 {"type":"error"}', PATS), true));
+  it('matches 503', () => assert.equal(detectOverload('503 Service Unavailable', PATS), true));
+  it('matches status.claude.com hint', () => assert.equal(detectOverload('see status.claude.com', PATS), true));
+  it('is case-insensitive', () => assert.equal(detectOverload('api error: 529 OVERLOADED', PATS), true));
+  it('detects through ANSI codes', () => assert.equal(detectOverload('\x1b[31mAPI Error: 529\x1b[0m \x1b[1mOverloaded\x1b[0m', PATS), true));
+  it('returns false for normal output', () => assert.equal(detectOverload('Here is the code you asked for', PATS), false));
+  it('returns false for empty patterns', () => assert.equal(detectOverload('API Error: 529', []), false));
+  it('returns false for empty text', () => assert.equal(detectOverload('', PATS), false));
+});
+
+describe('isWorking', () => {
+  it('detects the working footer', () => assert.equal(isWorking('Cogitating… (esc to interrupt)'), true));
+  it('detects esc/interrupt through ANSI', () => assert.equal(isWorking('\x1b[2mesc to interrupt\x1b[0m'), true));
+  it('returns false at an idle prompt', () => assert.equal(isWorking('│ > '), false));
+});
+
+describe('DEFAULT_OVERLOAD config', () => {
+  it('is present on DEFAULT_CONFIG with expected shape', () => {
+    assert.equal(DEFAULT_CONFIG.overload.enabled, true);
+    assert.deepEqual(DEFAULT_CONFIG.overload.backoffSeconds, [30, 60, 120, 240, 300]);
+    assert.equal(DEFAULT_CONFIG.overload.steadyStateSeconds, 300);
+    assert.equal(DEFAULT_CONFIG.overload.jitterPct, 15);
+    assert.equal(DEFAULT_CONFIG.overload.maxTotalWaitMinutes, 120);
+    assert.equal(DEFAULT_CONFIG.overload.relaunchOnExit, false);
+    assert.ok(DEFAULT_CONFIG.overload.patterns.includes('Overloaded'));
+  });
+});
+
+async function loadFrom(obj) {
+  const { writeFile, unlink } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const f = join(tmpdir(), `car-ovl-${Date.now()}-${Math.round(Math.random() * 1e6)}.json`);
+  await writeFile(f, JSON.stringify(obj));
+  try { return await loadConfig(f); } finally { await unlink(f); }
+}
+
+describe('overload config validation', () => {
+  it('merges a partial overload block onto defaults', async () => {
+    const c = await loadFrom({ overload: { maxTotalWaitMinutes: 30 } });
+    assert.equal(c.overload.maxTotalWaitMinutes, 30);
+    assert.deepEqual(c.overload.backoffSeconds, DEFAULT_OVERLOAD.backoffSeconds);
+    assert.equal(c.overload.enabled, true);
+  });
+  it('clamps jitterPct to 0..100', async () => {
+    assert.equal((await loadFrom({ overload: { jitterPct: 999 } })).overload.jitterPct, 100);
+    assert.equal((await loadFrom({ overload: { jitterPct: -5 } })).overload.jitterPct, 0);
+  });
+  it('falls back on empty/invalid backoffSeconds', async () => {
+    assert.deepEqual((await loadFrom({ overload: { backoffSeconds: [] } })).overload.backoffSeconds, DEFAULT_OVERLOAD.backoffSeconds);
+    assert.deepEqual((await loadFrom({ overload: { backoffSeconds: 'soon' } })).overload.backoffSeconds, DEFAULT_OVERLOAD.backoffSeconds);
+  });
+  it('drops non-positive backoff entries but keeps valid ones', async () => {
+    assert.deepEqual((await loadFrom({ overload: { backoffSeconds: [10, -1, 0, 20] } })).overload.backoffSeconds, [10, 20]);
+  });
+  it('falls back on bad maxTotalWaitMinutes', async () => {
+    assert.equal((await loadFrom({ overload: { maxTotalWaitMinutes: -1 } })).overload.maxTotalWaitMinutes, DEFAULT_OVERLOAD.maxTotalWaitMinutes);
+  });
+  it('filters non-string patterns and falls back when none valid', async () => {
+    assert.deepEqual((await loadFrom({ overload: { patterns: ['Boom', 42, ''] } })).overload.patterns, ['Boom']);
+    assert.deepEqual((await loadFrom({ overload: { patterns: [1, 2] } })).overload.patterns, DEFAULT_OVERLOAD.patterns);
+  });
+  it('coerces non-boolean enabled/relaunchOnExit to defaults', async () => {
+    const c = await loadFrom({ overload: { enabled: 'yes', relaunchOnExit: 1 } });
+    assert.equal(c.overload.enabled, true);
+    assert.equal(c.overload.relaunchOnExit, false);
+  });
+});
+
+describe('overload backoff schedule (pure)', () => {
+  it('follows 30/60/120/240/300 then steady 300', () => {
+    const o = DEFAULT_OVERLOAD;
+    assert.deepEqual([0, 1, 2, 3, 4, 5, 6].map(i => overloadBaseWaitMs(i, o) / 1000),
+      [30, 60, 120, 240, 300, 300, 300]);
+  });
+  it('applyJitter stays within ±jitterPct', () => {
+    for (let i = 0; i < 200; i++) {
+      const out = applyJitter(100_000, 15);
+      assert.ok(out >= 85_000 && out <= 115_000, `out=${out}`);
+    }
+  });
+  it('applyJitter with pct=0 is exact', () => assert.equal(applyJitter(120_000, 0), 120_000));
+  it('applyJitter is symmetric at rand extremes', () => {
+    assert.equal(applyJitter(100_000, 10, () => 0), 90_000);   // rand=0 → -10%
+    assert.equal(applyJitter(100_000, 10, () => 1), 110_000);  // rand=1 → +10%
+    assert.equal(applyJitter(100_000, 10, () => 0.5), 100_000);
+  });
+  it('nextOverloadWaitMs composes base + jitter', () => {
+    assert.equal(nextOverloadWaitMs(0, { ...DEFAULT_OVERLOAD, jitterPct: 0 }), 30_000);
+  });
+});
+
+const near = (actual, expectedMs) => Math.abs(actual - expectedMs) < 2000;
+
+describe('processOneTick — overload path', () => {
+  it('enters overload (not usage-wait) on a 529', async () => {
+    const t = mockTmux('API Error: 529 Overloaded');
+    const s = createMonitorState();
+    const r = await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
+    assert.equal(r, 'overload-detected');
+    assert.equal(s.status, 'overload');
+    assert.ok(near(s.overloadWaitUntil - Date.now(), 30_000));
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('does NOT enter overload while Claude is working', async () => {
+    const t = mockTmux('API Error: 529 Overloaded\n· Cogitating… (esc to interrupt)');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'monitoring');
+    assert.equal(s.status, 'monitoring');
+  });
+
+  it('does NOT retry a non-target error', async () => {
+    const t = mockTmux('Here is the answer to your question. Done.');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('usage-limit takes precedence over a co-present overload pattern', async () => {
+    const t = mockTmux('5-hour limit reached - resets 3pm (UTC)\nAPI Error: 529 Overloaded');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'waiting');
+    assert.equal(s.status, 'waiting');
+  });
+
+  it('sends the overload retry when the backoff window expires', async () => {
+    const t = mockTmux('API Error: 529 Overloaded');
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    const r = await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
+    assert.equal(r, 'overload-retried');
+    assert.equal(t._sent.length, 1);
+    assert.equal(t._sent[0], DEFAULT_OVERLOAD.retryMessage);
+    assert.equal(s.overloadAttempts, 1);
+    assert.ok(near(s.overloadWaitUntil - Date.now(), 60_000)); // next backoff = index 1
+  });
+
+  it('walks the full 30→60→120→240→300→300 schedule across retries', async () => {
+    const t = mockTmux('API Error: 529 Overloaded');
+    const s = createMonitorState();
+    // tick 1: detect → first 30s window
+    await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
+    const seen = [Math.round((s.overloadWaitUntil - Date.now()) / 1000)];
+    for (let i = 0; i < 5; i++) {
+      s.overloadWaitUntil = Date.now() - 1;                       // force expiry
+      await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
+      seen.push(Math.round((s.overloadWaitUntil - Date.now()) / 1000));
+    }
+    assert.deepEqual(seen, [30, 60, 120, 240, 300, 300]);
+    assert.equal(t._sent.length, 5);
+  });
+
+  it('defers (overload-working) if Claude resumes work during the wait', async () => {
+    const t = mockTmux('API Error: 529 Overloaded\nThinking… (esc to interrupt)');
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-working');
+    assert.equal(t._sent.length, 0);
+    assert.equal(s.overloadAttempts, 0); // no attempt consumed
+  });
+
+  it('clears back to monitoring when the overload text is gone', async () => {
+    const t = mockTmux('All good, here is your refactor.');
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadAttempts = 2; s.overloadTotalWaitMs = 90_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-cleared');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(s.overloadAttempts, 0);
+  });
+
+  it('gives up at the maxTotalWait cap', async () => {
+    const t = mockTmux('API Error: 529 Overloaded');
+    const c = cfg({ backoffSeconds: [30, 60], maxTotalWaitMinutes: 0.75 }); // cap = 45s
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', c, () => true, NO_JITTER), 'overload-detected'); // +30s (total 30)
+    s.overloadWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', c, () => true, NO_JITTER), 'overload-retried');   // +60s (total 90 > cap)
+    s.overloadWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', c, () => true, NO_JITTER), 'overload-gave-up');
+    assert.equal(t._sent.length, 1);
+  });
+
+  it('switches to the usage path if a usage limit appears mid-overload', async () => {
+    const t = mockTmux('5-hour limit reached - resets 3pm (UTC)');
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadAttempts = 1; s.overloadTotalWaitMs = 60_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'waiting');
+    assert.equal(s.status, 'waiting');
+    assert.equal(s.overloadAttempts, 0);
+  });
+});
+
+describe('processOneTick — overload gating (exited-to-shell vs alive)', () => {
+  it('does NOT send-keys when foreground is a shell; reports exited-to-shell (relaunch off)', async () => {
+    const t = mockTmux('API Error: 500 Internal server error\nuser@host:~$', 'bash', false);
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-exited-to-shell');
+    assert.equal(t._sent.length, 0);
+    assert.equal(s._lastForeground, 'bash');
+  });
+
+  it('relaunches via claude --continue when relaunchOnExit is on and foreground is a shell', async () => {
+    const t = mockTmux('API Error: 500 Internal server error\nuser@host:~$', 'bash', false);
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    const c = cfg({ relaunchOnExit: true });
+    assert.equal(await processOneTick(s, t, '%0', c, () => true, NO_JITTER), 'overload-relaunched');
+    assert.equal(t._sent.length, 1);
+    assert.equal(t._sent[0], 'claude --continue');
+    assert.equal(s.overloadAttempts, 1);
+  });
+
+  it('skips (not exited-to-shell) when some other app is foreground', async () => {
+    const t = mockTmux('API Error: 503', 'vim', false);
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'skipped-not-claude');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('retries normally when claude is alive at the prompt (foreground check passes)', async () => {
+    const t = mockTmux('API Error: 500 Internal server error', 'node', true);
+    const s = createMonitorState();
+    s.status = 'overload'; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-retried');
+    assert.equal(t._sent.length, 1);
+  });
+
+  it('disabled overload block is ignored entirely', async () => {
+    const t = mockTmux('API Error: 529 Overloaded');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg({ enabled: false }), () => true, NO_JITTER), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+});


### PR DESCRIPTION
Integrates #20 by @romerjon (overload detection + exponential backoff) on top of the merged fixes, resolving conflicts with the menu handler (#26) and send-keys/detection (#22). No logic changed from #20 — only conflict resolution so the overload path and the /rate-limit-options menu coexist. npm test: 187/187 pass. All overload design/code by @romerjon; merging this closes #20.