### PR TITLE
fix(monitor): foreground-guard the /rate-limit-options menu handler

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -97,8 +97,19 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
   // it sits, confirm it, then enter the normal (hours-scale) wait state.
   if (tmuxAdapter.sendKey && isRateLimitOptionsPrompt(stripped)
       && Date.now() >= (state._menuCooldownUntil || 0)) {
-    const steps = menuStepsToWaitOption(stripped);
     const cooldown = config.pollIntervalSeconds * 1000 * 2;
+
+    // Foreground safety: never send arrow/Enter keys unless Claude/node is the
+    // foreground process. Otherwise, if the user switched the pane to another app
+    // while the menu was up, we'd drive that app's UI instead.
+    const fgOk = await checkForeground(tmuxAdapter, pane, config);
+    if (!fgOk.ok) {
+      state._lastForeground = fgOk.fg;
+      state._menuCooldownUntil = Date.now() + cooldown;
+      return 'skipped-not-claude';
+    }
+
+    const steps = menuStepsToWaitOption(stripped);
     if (steps === null) {
       // Layout unreadable — refuse to press Enter (could confirm "Upgrade").
       state._menuCooldownUntil = Date.now() + cooldown;

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -65,6 +65,15 @@ describe('processOneTick', () => {
     assert.equal(s.status, 'waiting');
   });
 
+  it('does not drive the menu when Claude is not in the foreground (#19 safety)', async () => {
+    // Menu is up, but some other app (vim) is focused and the process isn't fg.
+    const t = mockTmux(MENU_UPGRADE_FIRST, 'vim', false);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'skipped-not-claude');
+    assert.equal(t._keys.length, 0);   // pressed no menu keys
+    assert.notEqual(s.status, 'waiting');
+  });
+
   it('refuses to press Enter when the menu layout is unreadable (#19)', async () => {
     // Cursor marker absent → we cannot tell which option is highlighted.
     const noCursor = ['What do you want to do?', '  1. Upgrade your plan', '  2. Stop and wait for limit to reset', 'Enter to confirm'].join('\n');


### PR DESCRIPTION
The menu handler (#26) sent menu keys without the foreground safety check the retry/overload paths use. If the user focused another app in the pane while the menu was up, we'd drive that app. Gate menu navigation behind `checkForeground()`; skip (`skipped-not-claude`) with a cooldown when Claude isn't foreground.

Found during runtime verification. `npm test` → 188/188 (1 new test).