### PR TITLE
fix(monitor): stop usage-retry from spamming a resumed/working session

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -7,6 +7,10 @@ import { readStopFailureEvent, clearStopFailureEvent } from './events.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 const SHELL_COMMANDS = ['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'];
+// Only a usage-limit banner in the live tail counts — quoted limit text in scrollback
+// (a conversation about limits) or a banner the session already scrolled past is not the
+// current state and must not drive a retry. Matches the overload path's tail discipline.
+const RATE_LIMIT_TAIL_LINES = 12;
 
 export function createMonitorState() {
   return {
@@ -136,9 +140,13 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     if (Date.now() < state.waitUntil) return 'waiting';
     if (!isAlive()) return 'exit';
 
-    // Always check if rate limit cleared FIRST — even when maxRetries
-    // exhausted, the user (or time passing) may have resolved it.
-    if (!isRateLimited(stripped, config.customPatterns)) {
+    // Stop driving the session if the limit cleared OR Claude has already resumed and
+    // is working again. Without the isWorking gate the usage path re-sends the retry
+    // message every poll (up to maxRetries) while the limit banner lingers in the
+    // captured scrollback after a successful resume — spamming an actively-working
+    // session (and a banner re-printed by another process keeps it "rate-limited" the
+    // whole time). isWorking ⇒ the session continued; never inject into it.
+    if (!isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES) || isWorking(stripped)) {
       state.status = 'monitoring'; state.attempts = 0;
       return 'user-continued';
     }
@@ -185,7 +193,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
       // Self-recovery: Claude resumed during the backoff → don't interrupt it.
       if (isWorking(stripped)) { resetOverload(state); state.status = 'monitoring'; return 'overload-cleared'; }
       // A usage limit appearing mid-wait still takes precedence.
-      if (isRateLimited(stripped, config.customPatterns)) { resetOverload(state); return enterUsageWait(state, stripped, config); }
+      if (isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) { resetOverload(state); return enterUsageWait(state, stripped, config); }
 
       const foregroundOk = await checkForeground(tmuxAdapter, pane, config);
       if (!foregroundOk.ok) {
@@ -209,7 +217,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     const capMs = overload.maxTotalWaitMinutes * 60_000;
 
     // Usage-limit takes precedence: hand off to the (hours-scale) reset path.
-    if (isRateLimited(stripped, config.customPatterns)) {
+    if (isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) {
       resetOverload(state);
       return enterUsageWait(state, stripped, config);
     }
@@ -277,7 +285,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
 
   // --- monitoring ---
   // Usage-limit (hours-scale reset) takes precedence over overload (seconds-scale).
-  if (isRateLimited(stripped, config.customPatterns)) {
+  if (isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) {
     return enterUsageWait(state, stripped, config);
   }
 

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -99,7 +99,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
   // Enter here confirms the highlighted default, which on some Claude Code versions
   // is "Upgrade your plan". Navigate to "Stop and wait for limit to reset" wherever
   // it sits, confirm it, then enter the normal (hours-scale) wait state.
-  if (tmuxAdapter.sendKey && isRateLimitOptionsPrompt(stripped)
+  if (tmuxAdapter.sendKey && isRateLimitOptionsPrompt(stripped, RATE_LIMIT_TAIL_LINES)
       && Date.now() >= (state._menuCooldownUntil || 0)) {
     const cooldown = config.pollIntervalSeconds * 1000 * 2;
 
@@ -113,7 +113,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
       return 'skipped-not-claude';
     }
 
-    const steps = menuStepsToWaitOption(stripped);
+    const steps = menuStepsToWaitOption(stripped, RATE_LIMIT_TAIL_LINES);
     if (steps === null) {
       // Layout unreadable — refuse to press Enter (could confirm "Upgrade").
       state._menuCooldownUntil = Date.now() + cooldown;

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -49,8 +49,14 @@ function hasNearbyMatch(lines, idx, patterns) {
   return false;
 }
 
-export function isRateLimited(text, customPatterns = []) {
-  const lines = stripAnsi(text).split('\n');
+// tailLines > 0 restricts detection to the last N lines of the pane. A live usage-limit
+// banner sits at the prompt (the last thing printed); the same words quoted in scrollback
+// — a conversation discussing limits, a stale banner the session already moved past — are
+// NOT the current state and must not drive a retry. 0 = scan everything (print mode, where
+// the input is captured process output, not a scrolling TUI).
+export function isRateLimited(text, customPatterns = [], tailLines = 0) {
+  let lines = stripAnsi(text).split('\n');
+  if (tailLines > 0) lines = lines.slice(-tailLines);
 
   // Custom patterns: check full text (user controls their own regex)
   if (customPatterns.length > 0) {

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -90,8 +90,13 @@ const MENU_CURSOR = '❯';
 const WAIT_OPTION_REGEX = /stop and wait for limit to reset/i;
 const MENU_OPTION_REGEX = /^\s*❯?\s*\d+\.\s/;
 
-export function isRateLimitOptionsPrompt(text) {
-  const t = stripAnsi(text);
+// tailLines > 0 restricts to the last N lines: a LIVE menu sits at the prompt, so the
+// same menu text quoted in scrollback (a conversation about limits) must not make us
+// drive arrow keys + Enter into whatever is actually on screen.
+export function isRateLimitOptionsPrompt(text, tailLines = 0) {
+  let lines = stripAnsi(text).split('\n');
+  if (tailLines > 0) lines = lines.slice(-tailLines);
+  const t = lines.join('\n');
   return /what do you want to do\?/i.test(t)
     && WAIT_OPTION_REGEX.test(t)
     && (/enter to confirm/i.test(t) || /esc to cancel/i.test(t) || t.includes(MENU_CURSOR));
@@ -101,8 +106,11 @@ export function isRateLimitOptionsPrompt(text) {
 // option steps: positive => press Down N times, negative => Up, 0 => already there.
 // Returns null when the layout can't be read (no cursor or option not found); the
 // caller MUST NOT press Enter in that case, to avoid confirming the wrong option.
-export function menuStepsToWaitOption(text) {
-  const optionLines = stripAnsi(text).split('\n').filter(l => MENU_OPTION_REGEX.test(l));
+// tailLines mirrors isRateLimitOptionsPrompt so option counting ignores quoted menus.
+export function menuStepsToWaitOption(text, tailLines = 0) {
+  let lines = stripAnsi(text).split('\n');
+  if (tailLines > 0) lines = lines.slice(-tailLines);
+  const optionLines = lines.filter(l => MENU_OPTION_REGEX.test(l));
   if (optionLines.length === 0) return null;
   const cursorPos = optionLines.findIndex(l => l.includes(MENU_CURSOR));
   const waitPos = optionLines.findIndex(l => WAIT_OPTION_REGEX.test(l));

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -74,6 +74,17 @@ describe('processOneTick', () => {
     assert.notEqual(s.status, 'waiting');
   });
 
+  // --- Regression: a menu only quoted in scrollback is NOT the live prompt. Driving
+  //     arrow keys + Enter on it would act on whatever is actually on screen. ---
+  it('does NOT drive a /rate-limit-options menu only quoted above the live tail', async () => {
+    const pane = [...MENU_UPGRADE_FIRST.split('\n'), ...Array(12).fill('● unrelated work below the quoted menu'), '❯ '].join('\n');
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    const r = await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true);
+    assert.notEqual(r, 'menu-confirmed');
+    assert.equal(t._keys.length, 0);   // no arrow/Enter keys driven
+  });
+
   it('refuses to press Enter when the menu layout is unreadable (#19)', async () => {
     // Cursor marker absent → we cannot tell which option is highlighted.
     const noCursor = ['What do you want to do?', '  1. Upgrade your plan', '  2. Stop and wait for limit to reset', 'Enter to confirm'].join('\n');

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -106,6 +106,38 @@ describe('processOneTick', () => {
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
     assert.ok(s.waitUntil > Date.now());
   });
+
+  // --- Regression: do not spam an already-resumed session. The usage path used to
+  //     re-send every poll (up to maxRetries) while the limit banner lingered in
+  //     scrollback after a successful resume — observed live as 5 injections into a
+  //     working session. The isWorking gate stops the moment Claude resumes. ---
+  it('does NOT re-send once Claude has resumed and is working', async () => {
+    const t = mockTmux('5-hour limit reached - resets 3pm (UTC)\n· Doing… (esc to interrupt)');
+    const s = createMonitorState();
+    s.waitUntil = Date.now() - 1000; s.status = 'waiting'; s.attempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'user-continued');
+    assert.equal(t._sent.length, 0);          // never injects into the working session
+    assert.equal(s.status, 'monitoring');
+    assert.equal(s.attempts, 0);
+  });
+
+  // --- Regression: self-referential false positive. A limit banner only quoted in
+  //     scrollback (a conversation discussing limits, a stale banner scrolled past) is
+  //     NOT the live state. Tail-anchoring stops it from driving a retry. ---
+  it('does NOT enter a wait for a limit banner buried above the live tail', async () => {
+    const pane = ['You hit your session limit · resets 3pm (UTC)', ...Array(15).fill('● working on unrelated code'), '❯ '].join('\n');
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'monitoring');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+  it('still enters a wait when the limit banner is in the live tail', async () => {
+    const pane = ['earlier output', 'more output', "You've hit your session limit · resets 3pm (UTC)"].join('\n');
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+  });
   it('retries when Claude process is in foreground (fixes macOS zsh issue)', async () => {
     const t = mockTmux('5-hour limit reached - resets 3pm (UTC)', 'zsh', true);
     const s = createMonitorState();


### PR DESCRIPTION
Two related defects in the usage-limit retry path, both observed live — after a session limit reset, the monitor injected **5 spurious `Continue…` messages into an actively-working session**.

**1. No `isWorking` gate.** After a successful resume, the limit banner can linger in the captured scrollback (and a banner re-printed by another process keeps it visible the whole time), so the `'waiting'` path kept re-sending the retry message every poll up to `maxRetries` — driving a session that had already resumed. Fix: if the limit cleared **or** Claude is working again, stop and reset. The overload path already had this guard; this brings the usage path in line.

**2. Whole-capture matching.** `isRateLimited` matched the banner *anywhere* in the 20-line capture, so limit text merely **quoted in scrollback** (e.g. a conversation about rate limits, or a stale banner the session scrolled past) triggered a false wait/retry. `isRateLimited` now takes an optional `tailLines` arg; the monitor's *action* decisions only consider the live tail (last 12 lines), mirroring the overload path's tail-anchoring. Print mode keeps the full scan (captured process output, not a scrolling TUI).

+3 regression tests (191 total, zero deps).