### PR TITLE
feat(tmux): add status bar indicator for monitor state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the `API Error` render (mentioning the phrases in conversation can't
   trigger it), and the retry budget is kept across working ticks so a sticky
   flag stays bounded (#33).
+- tmux status bar indicator: the monitor now writes a per-pane status snapshot to
+  `~/.claude-auto-retry/status/<pane>.json` on every poll tick, and a new
+  `claude-auto-retry-tmux-status` script renders it as a status-bar segment
+  (`🟢AR` monitoring, `⏳AR 1h30m` waiting on a reset, `🟠AR 45s` overload backoff,
+  `🔴AR` gave up). Dependency-free POSIX shell; hides itself if a pane has no
+  monitor or its status file is stale (staleness is derived from the monitor's
+  actual poll interval, not a fixed constant).
 
 ### Fixed
 - `rate_limit` StopFailure events are no longer routed through the seconds-scale

--- a/README.md
+++ b/README.md
@@ -312,27 +312,60 @@ Usage limits always take precedence; the safeguard path only acts when Claude is
 (no `esc to interrupt` footer) and the foreground process is `claude`/`node`.
 ## tmux status bar indicator
 
-The monitor writes a small JSON snapshot to `~/.claude-auto-retry/status/<pane>.json`
-on every poll tick, so you can tell at a glance — without checking logs — whether a
-pane is being watched, waiting out a usage-limit reset, or backing off from overload.
+The monitor writes a small JSON snapshot per pane on every poll tick, so you can tell
+at a glance — without checking logs — whether a pane is being watched, waiting out a
+usage-limit reset, backing off from overload or a safeguard flag, or has given up.
 
 Add a segment to `status-right` (or `status-left`) in `~/.tmux.conf` that shells out to
-the bundled reader script, passing the current pane id:
+the bundled reader script, passing the current pane id **and** the server's socket path:
 
 ```tmux
 set -g status-interval 5
-set -g status-right "#(claude-auto-retry-tmux-status '#{pane_id}') | %Y-%m-%d %H:%M"
+set -g status-right "#(~/.local/lib/node_modules/claude-auto-retry/bin/tmux-status.sh '#{pane_id}' '#{socket_path}') | %Y-%m-%d %H:%M"
 ```
 
-`tmux` substitutes `#{pane_id}` with the *attached client's current pane* before running
-the command, so the segment always reflects whichever pane you're looking at. It prints:
+**Use an absolute path, not the bare command name.** `#()` commands run inside the tmux
+*server's* own environment, not the environment of whichever shell you attached from —
+if the server was started before your shell rc added `npm`/`nvm`'s bin directory to
+`PATH` (e.g. tmux auto-started at login, or by another program), the bare command name
+resolves to nothing and the segment stays permanently blank with no error anywhere.
+Find your actual install path with `which claude-auto-retry-tmux-status` (run it in a
+normal shell, then hardcode that path in `.tmux.conf`) if it differs from the example
+above. If you use nvm and switch Node versions, re-check the path.
+
+`tmux` substitutes `#{pane_id}` and `#{socket_path}` itself before running the command
+(these are tmux format variables, resolved at expansion time — not environment
+variables the script has to go looking for), so the segment always reflects whichever
+pane you're looking at, correctly scoped to the tmux server it belongs to. The
+`socket_path` argument matters if you ever run more than one tmux server on the same
+machine (e.g. `tmux -L work`, `tmux -L personal`, or two users' default servers on a
+shared host): pane ids like `%2` are only unique *within* a server, so without it two
+different servers' `%2` panes would render each other's status. It's technically
+optional (older single-argument configs still work, falling back to a shared key), but
+pass it unless you're certain you'll only ever run one tmux server.
+
+It prints:
 
 | Pane state | Indicator |
 |------------|-----------|
 | Actively monitoring | `🟢AR` |
 | Waiting on a usage-limit reset | `⏳AR 1h30m` |
 | Backing off from overload | `🟠AR 45s` |
-| No monitor for this pane, or the status file is stale (>30s — the monitor process died without cleaning up) | *(nothing)* |
+| Retrying past a safeguard/AUP false-positive | `🛡AR 8s` |
+| Given up — max retries/backoff cap reached; no further automatic action on this pane | `🔴AR` |
+| No monitor for this pane, or the status file is stale (monitor process died without cleaning up) | *(nothing)* |
+
+`🔴AR` overrides whatever the underlying status would otherwise render. Several
+give-up paths intentionally leave the monitor's internal status at whatever it was
+when it stopped acting (so the scraper/event logic doesn't re-detect its own stale
+error next tick) — without an explicit `gaveUp` flag in the snapshot, the status bar
+would keep showing a live `🟢`/`⏳`/`🟠` indicator for a monitor that will not act
+again on this pane until the underlying condition clears on its own.
+
+Staleness is derived from each snapshot's own `pollIntervalSeconds` (age > 2× the
+monitor's configured poll interval) rather than a fixed constant, so a healthy monitor
+running with a longer `pollIntervalSeconds` doesn't have its segment blank out for a
+large fraction of every tick.
 
 The script (`bin/tmux-status.sh`) is pure POSIX shell with no dependencies (no `jq`,
 no `node`), so it's cheap to run every few seconds from every attached client.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ When you disconnect (SSH drops, close terminal, laptop sleeps), **tmux keeps run
 - **Safe send-keys** — verifies Claude is still the foreground process before injecting text
 - **Overload backoff** — detects sustained API overload (`429/500/502/503/504/529`) and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff))
 - **Safeguard retry** — auto-continues past an AUP-safeguard false-positive (often transient), capped at a few tries so a sticky flag can't loop ([details](#safeguard-retry))
+- **tmux status bar indicator** — see at a glance whether a pane is being monitored, waiting on a reset, backing off from overload, or has given up ([details](#tmux-status-bar-indicator))
 - **`--print` mode support** — buffers output, retries cleanly for piped/scripted usage
 - **Configurable** — retry count, wait margin, custom patterns, retry message
 - **Config validation** — bad config values fall back to safe defaults instead of crashing
@@ -309,6 +310,34 @@ Configured under a `safeguard` block (defaults shown):
 
 Usage limits always take precedence; the safeguard path only acts when Claude is idle
 (no `esc to interrupt` footer) and the foreground process is `claude`/`node`.
+## tmux status bar indicator
+
+The monitor writes a small JSON snapshot to `~/.claude-auto-retry/status/<pane>.json`
+on every poll tick, so you can tell at a glance — without checking logs — whether a
+pane is being watched, waiting out a usage-limit reset, or backing off from overload.
+
+Add a segment to `status-right` (or `status-left`) in `~/.tmux.conf` that shells out to
+the bundled reader script, passing the current pane id:
+
+```tmux
+set -g status-interval 5
+set -g status-right "#(claude-auto-retry-tmux-status '#{pane_id}') | %Y-%m-%d %H:%M"
+```
+
+`tmux` substitutes `#{pane_id}` with the *attached client's current pane* before running
+the command, so the segment always reflects whichever pane you're looking at. It prints:
+
+| Pane state | Indicator |
+|------------|-----------|
+| Actively monitoring | `🟢AR` |
+| Waiting on a usage-limit reset | `⏳AR 1h30m` |
+| Backing off from overload | `🟠AR 45s` |
+| No monitor for this pane, or the status file is stale (>30s — the monitor process died without cleaning up) | *(nothing)* |
+
+The script (`bin/tmux-status.sh`) is pure POSIX shell with no dependencies (no `jq`,
+no `node`), so it's cheap to run every few seconds from every attached client.
+`status-interval` defaults to 15s in tmux; dropping it to `5` (matching the monitor's
+default `pollIntervalSeconds`) keeps the overload countdown responsive.
 
 ## CLI Commands
 

--- a/README.md
+++ b/README.md
@@ -340,9 +340,10 @@ pane you're looking at, correctly scoped to the tmux server it belongs to. The
 `socket_path` argument matters if you ever run more than one tmux server on the same
 machine (e.g. `tmux -L work`, `tmux -L personal`, or two users' default servers on a
 shared host): pane ids like `%2` are only unique *within* a server, so without it two
-different servers' `%2` panes would render each other's status. It's technically
-optional (older single-argument configs still work, falling back to a shared key), but
-pass it unless you're certain you'll only ever run one tmux server.
+different servers' `%2` panes would render each other's status. Always pass it: the
+monitor keys each status file by the socket path it inherits from `$TMUX`, so a
+single-argument config looks under a shared `default` key the monitor never writes to,
+and the segment simply stays blank.
 
 It prints:
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,6 +7,7 @@ import { homedir } from 'node:os';
 import { execFileSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { writeStopFailureEvent, isRetryableError } from '../src/events.js';
+import { sweepStaleStatus } from '../src/status-file.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -160,6 +161,10 @@ async function cmdUninstall() {
   const bashrc = join(homedir(), '.bashrc');
   const zshrc = join(homedir(), '.zshrc');
   for (const rc of [bashrc, zshrc]) { await removeWrapper(rc); }
+  // Best-effort GC of tmux-status snapshot files left behind by monitors that died
+  // without cleaning up (SIGKILL, host sleep/crash) — see src/status-file.js. Failure
+  // here must never block the uninstall itself.
+  await sweepStaleStatus().catch(() => {});
   console.log('Shell function removed. Restart your shell to complete.');
 }
 

--- a/bin/tmux-status.sh
+++ b/bin/tmux-status.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# tmux status-bar segment for claude-auto-retry.
+# Usage in ~/.tmux.conf: #(~/.local/lib/node_modules/claude-auto-retry/bin/tmux-status.sh '#{pane_id}')
+#
+# Prints nothing if the pane has no monitor, or the monitor's status file is stale
+# (monitor process died without cleaning up — e.g. `kill -9`, machine sleep during a
+# tmux-server-less state). Kept dependency-free (no jq/node) so this can run every
+# few seconds from every attached client without noticeable cost.
+
+pane="$1"
+[ -z "$pane" ] && exit 0
+
+safe=$(printf '%s' "$pane" | tr -c 'A-Za-z0-9_-' '_')
+file="$HOME/.claude-auto-retry/status/${safe}.json"
+[ -f "$file" ] || exit 0
+
+json=$(cat "$file" 2>/dev/null) || exit 0
+status=$(printf '%s' "$json" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+updated=$(printf '%s' "$json" | grep -o '"updatedAt":[0-9]*' | head -1 | grep -o '[0-9]*')
+[ -z "$status" ] || [ -z "$updated" ] && exit 0
+
+now=$(date +%s)
+age=$(( now - updated ))
+# Stale = monitor crashed/orphaned without cleanup. Hide rather than show a stuck icon.
+[ "$age" -gt 30 ] && exit 0
+
+case "$status" in
+  waiting)
+    waitUntil=$(printf '%s' "$json" | grep -o '"waitUntil":[0-9]*' | head -1 | grep -o '[0-9]*')
+    remain=$(( waitUntil - now ))
+    [ "$remain" -lt 0 ] && remain=0
+    if [ "$remain" -ge 3600 ]; then
+      printf '⏳AR %dh%02dm' $(( remain / 3600 )) $(( (remain % 3600) / 60 ))
+    else
+      printf '⏳AR %dm' $(( remain / 60 ))
+    fi
+    ;;
+  overload)
+    overloadWaitUntil=$(printf '%s' "$json" | grep -o '"overloadWaitUntil":[0-9]*' | head -1 | grep -o '[0-9]*')
+    remain=$(( overloadWaitUntil - now ))
+    [ "$remain" -lt 0 ] && remain=0
+    printf '🟠AR %ds' "$remain"
+    ;;
+  monitoring)
+    printf '🟢AR'
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/bin/tmux-status.sh
+++ b/bin/tmux-status.sh
@@ -7,9 +7,10 @@
 #   #(~/.local/lib/node_modules/claude-auto-retry/bin/tmux-status.sh '#{pane_id}' '#{socket_path}')
 #
 # The 2nd arg (tmux's own #{socket_path} format variable) disambiguates panes across
-# independent tmux servers (`tmux -L work` vs `tmux -L personal` can each have a "%2").
-# It's optional for backward compatibility with an older single-arg tmux.conf snippet,
-# but omitting it re-introduces the cross-server collision — pass it if you can.
+# independent tmux servers (`tmux -L work` vs `tmux -L personal` can each have a "%2")
+# and is effectively required: the monitor keys its status files by the socket path it
+# inherits from $TMUX, so a single-arg invocation looks under a "default" key the monitor
+# never writes to and the segment just stays blank. Always pass '#{socket_path}'.
 #
 # Prints nothing if the pane has no monitor, or the monitor's status file is stale
 # (monitor process died without cleaning up — e.g. `kill -9`, machine sleep during a

--- a/bin/tmux-status.sh
+++ b/bin/tmux-status.sh
@@ -1,6 +1,15 @@
-#!/usr/bin/env bash
-# tmux status-bar segment for claude-auto-retry.
-# Usage in ~/.tmux.conf: #(~/.local/lib/node_modules/claude-auto-retry/bin/tmux-status.sh '#{pane_id}')
+#!/bin/sh
+# tmux status-bar segment for claude-auto-retry. Pure POSIX (no bashisms) so it runs
+# on dependency-light hosts (Alpine/busybox) too — matching the "dependency-free" claim,
+# hence #!/bin/sh rather than #!/usr/bin/env bash.
+#
+# Usage in ~/.tmux.conf (see README "tmux status bar indicator" for the full recipe):
+#   #(~/.local/lib/node_modules/claude-auto-retry/bin/tmux-status.sh '#{pane_id}' '#{socket_path}')
+#
+# The 2nd arg (tmux's own #{socket_path} format variable) disambiguates panes across
+# independent tmux servers (`tmux -L work` vs `tmux -L personal` can each have a "%2").
+# It's optional for backward compatibility with an older single-arg tmux.conf snippet,
+# but omitting it re-introduces the cross-server collision — pass it if you can.
 #
 # Prints nothing if the pane has no monitor, or the monitor's status file is stale
 # (monitor process died without cleaning up — e.g. `kill -9`, machine sleep during a
@@ -8,10 +17,12 @@
 # few seconds from every attached client without noticeable cost.
 
 pane="$1"
+socket="${2:-default}"
 [ -z "$pane" ] && exit 0
 
-safe=$(printf '%s' "$pane" | tr -c 'A-Za-z0-9_-' '_')
-file="$HOME/.claude-auto-retry/status/${safe}.json"
+safe_socket=$(printf '%s' "$socket" | tr -c 'A-Za-z0-9_-' '_')
+safe_pane=$(printf '%s' "$pane" | tr -c 'A-Za-z0-9_-' '_')
+file="$HOME/.claude-auto-retry/status/${safe_socket}_${safe_pane}.json"
 [ -f "$file" ] || exit 0
 
 json=$(cat "$file" 2>/dev/null) || exit 0
@@ -21,8 +32,29 @@ updated=$(printf '%s' "$json" | grep -o '"updatedAt":[0-9]*' | head -1 | grep -o
 
 now=$(date +%s)
 age=$(( now - updated ))
-# Stale = monitor crashed/orphaned without cleanup. Hide rather than show a stuck icon.
-[ "$age" -gt 30 ] && exit 0
+
+# Staleness scales with the monitor's own poll interval (written into every snapshot)
+# instead of a fixed constant — a configurable pollIntervalSeconds far above the old
+# hardcoded 30s would otherwise make a perfectly healthy monitor's segment blank out for
+# a large fraction of every tick. Falls back to 15s (-> 30s stale threshold, matching the
+# tool's pre-fix behavior) for older status files written before this field existed.
+# Floored at 10s so very low configured intervals don't flicker on ordinary scheduling
+# jitter (tmux capture-pane + a Node event-loop tick occasionally running a beat late).
+interval=$(printf '%s' "$json" | grep -o '"pollIntervalSeconds":[0-9]*' | head -1 | grep -o '[0-9]*')
+[ -z "$interval" ] && interval=15
+staleAfter=$(( interval * 2 ))
+[ "$staleAfter" -lt 10 ] && staleAfter=10
+[ "$age" -gt "$staleAfter" ] && exit 0
+
+# gaveUp overrides the normal per-status rendering: several terminal give-up paths leave
+# `status` at whatever it was when the monitor stopped acting (waiting/overload/monitoring
+# all keep ticking their live icon otherwise), which reads as a healthy monitor. A single
+# explicit flag is a lot more honest than reverse-engineering "given up" from timestamps.
+gaveUp=$(printf '%s' "$json" | grep -o '"gaveUp":true')
+if [ -n "$gaveUp" ]; then
+  printf '🔴AR'
+  exit 0
+fi
 
 case "$status" in
   waiting)
@@ -40,6 +72,12 @@ case "$status" in
     remain=$(( overloadWaitUntil - now ))
     [ "$remain" -lt 0 ] && remain=0
     printf '🟠AR %ds' "$remain"
+    ;;
+  safeguard)
+    safeguardWaitUntil=$(printf '%s' "$json" | grep -o '"safeguardWaitUntil":[0-9]*' | head -1 | grep -o '[0-9]*')
+    remain=$(( safeguardWaitUntil - now ))
+    [ "$remain" -lt 0 ] && remain=0
+    printf '🛡AR %ds' "$remain"
     ;;
   monitoring)
     printf '🟢AR'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Automatically retry Claude Code sessions on subscription rate limits and sustained API overload (529/500/503) with exponential backoff",
   "type": "module",
   "bin": {
-    "claude-auto-retry": "./bin/cli.js"
+    "claude-auto-retry": "./bin/cli.js",
+    "claude-auto-retry-tmux-status": "./bin/tmux-status.sh"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/src/events.js
+++ b/src/events.js
@@ -13,6 +13,7 @@
 import { mkdir, writeFile, readFile, unlink, rename } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { sanitizeKey } from './pane-key.js';
 
 export const EVENTS_DIR = join(homedir(), '.claude-auto-retry', 'events');
 
@@ -35,8 +36,7 @@ export function isRetryableError(errorType) {
 
 // tmux pane ids look like "%2"; keep the marker filename to a safe charset.
 function fileFor(paneKey, dir) {
-  const safe = String(paneKey).replace(/[^A-Za-z0-9_-]/g, '_');
-  return join(dir, `${safe}.json`);
+  return join(dir, `${sanitizeKey(paneKey)}.json`);
 }
 
 // Hook side: write a marker for the pane. Atomic (tmp + rename) so the daemon never

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -4,6 +4,7 @@ import { capturePane, sendKeys, sendKey, getPaneCommand, isProcessForeground } f
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { readStopFailureEvent, clearStopFailureEvent, isRetryableError } from './events.js';
+import { writeStatus, clearStatus } from './status-file.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 const SHELL_COMMANDS = ['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'];
@@ -429,7 +430,21 @@ export async function startMonitor(pane, pid) {
       const result = await processOneTick(state, tmuxAdapter, pane, config, isAlive);
       consecutiveErrors = 0;
 
-      if (result === 'exit') { await logger.info('Claude exited. Monitor shutting down.'); process.exit(0); }
+      if (result === 'exit') {
+        await clearStatus(pane).catch(() => {});
+        await logger.info('Claude exited. Monitor shutting down.');
+        process.exit(0);
+      }
+
+      // Published for external consumers (e.g. a tmux status-bar segment) — best-effort,
+      // never let a write failure interrupt the monitor loop.
+      await writeStatus(pane, {
+        status: state.status,
+        waitUntil: Math.floor(state.waitUntil / 1000),
+        overloadWaitUntil: Math.floor(state.overloadWaitUntil / 1000),
+        attempts: state.attempts,
+        overloadAttempts: state.overloadAttempts,
+      }).catch(() => {});
       if (result === 'waiting' && state.lastRateLimitMessage) {
         const secs = Math.round((state.waitUntil - Date.now()) / 1000);
         await logger.info(`Rate limit detected: "${state.lastRateLimitMessage}". Waiting ${secs}s...`);
@@ -472,6 +487,7 @@ export async function startMonitor(pane, pid) {
       consecutiveErrors++;
       await logger.error(`Monitor tick error: ${err.message}`).catch(() => {});
       if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        await clearStatus(pane).catch(() => {});
         await logger.error(`${MAX_CONSECUTIVE_ERRORS} consecutive errors. Pane likely destroyed. Exiting.`).catch(() => {});
         process.exit(1);
       }

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -4,7 +4,7 @@ import { capturePane, sendKeys, sendKey, getPaneCommand, isProcessForeground } f
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { readStopFailureEvent, clearStopFailureEvent, isRetryableError } from './events.js';
-import { writeStatus, clearStatus } from './status-file.js';
+import { writeStatus, clearStatus, sweepStaleStatus } from './status-file.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 const SHELL_COMMANDS = ['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'];
@@ -50,12 +50,14 @@ function resetOverload(state) {
   state.overloadTotalWaitMs = 0;
   state.overloadWaitUntil = 0;
   state.viaEvent = false;
+  state._gaveUp = false;
 }
 
 function resetSafeguard(state) {
   state.safeguardAttempts = 0;
   state.safeguardWaitUntil = 0;
   state._safeguardGaveUp = false;
+  state._gaveUp = false;
 }
 
 // Foreground safety: is claude/node the foreground process (safe to send-keys), or did
@@ -77,6 +79,7 @@ function enterUsageWait(state, stripped, config) {
   const parsed = message ? parseResetTime(message) : null;
   state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
   state.status = 'waiting';
+  state._gaveUp = false;
   return 'waiting';
 }
 
@@ -156,14 +159,18 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // session (and a banner re-printed by another process keeps it "rate-limited" the
     // whole time). isWorking ⇒ the session continued; never inject into it.
     if (!isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES) || isWorking(stripped)) {
-      state.status = 'monitoring'; state.attempts = 0;
+      state.status = 'monitoring'; state.attempts = 0; state._gaveUp = false;
       return 'user-continued';
     }
 
     if (state.attempts >= config.maxRetries) {
-      // Stay in 'waiting' to avoid re-detecting the stale rate limit
-      // on the next tick and creating an infinite max-retries loop.
+      // Stay in 'waiting' to avoid re-detecting the stale rate limit on the next tick
+      // and creating an infinite max-retries loop. This IS a give-up (no further
+      // retries will be sent while the banner persists) even though `status` stays
+      // 'waiting' — flagged so external consumers (tmux status bar) don't render a
+      // perpetually-resetting countdown for a monitor that has stopped acting.
       state.waitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      state._gaveUp = true;
       return 'max-retries';
     }
 
@@ -250,6 +257,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // or mask a real outage. Long cooldown to avoid re-detecting the stale error.
     if (state.overloadTotalWaitMs >= capMs) {
       state.overloadWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      state._gaveUp = true;
       return 'overload-gave-up';
     }
 
@@ -320,6 +328,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // the stale error every tick.
     if (state.safeguardAttempts >= safeguard.maxRetries) {
       state.safeguardWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      state._gaveUp = true;
       // Give up LOUDLY — once. Subsequent holds are silent or the warn re-logs ~1/min
       // for as long as the sticky banner sits at the prompt.
       if (state._safeguardGaveUp) return 'safeguard-holding';
@@ -368,7 +377,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
       await tmuxAdapter.clearEvent();               // consume
       if (isWorking(stripped)) { resetOverload(state); return 'overload-cleared'; } // self-recovered
       const capMs = overload.maxTotalWaitMinutes * 60_000;
-      if (state.overloadTotalWaitMs >= capMs) return 'overload-gave-up';
+      if (state.overloadTotalWaitMs >= capMs) { state._gaveUp = true; return 'overload-gave-up'; }
       const w = nextOverloadWaitMs(state.overloadAttempts, overload, rand);
       state.overloadTotalWaitMs += w;
       state.overloadWaitUntil = Date.now() + w;
@@ -414,6 +423,24 @@ export async function startMonitor(pane, pid) {
 
   await logger.info(`Monitor started for pane ${pane} (claude PID: ${pid})`);
 
+  // Best-effort GC of status files left behind by monitors that died without cleaning up
+  // (SIGKILL, host sleep/crash). Runs once per monitor start, not per tick.
+  sweepStaleStatus().catch(() => {});
+
+  let shuttingDown = false;
+  const shutdown = (signal) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    // Best-effort: fire the unlink and exit without waiting on the promise. Signal
+    // handlers are not the place to await — a hung filesystem must not block the
+    // process from actually terminating on SIGTERM/SIGINT.
+    clearStatus(pane).catch(() => {}).finally(() => {
+      process.exit(signal === 'SIGINT' ? 130 : 143);
+    });
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
   const eventMaxAgeMs = (config.overload?.eventMaxAgeSeconds || 120) * 1000;
   const tmuxAdapter = {
     capturePane, sendKeys, sendKey, getPaneCommand,
@@ -437,13 +464,22 @@ export async function startMonitor(pane, pid) {
       }
 
       // Published for external consumers (e.g. a tmux status-bar segment) — best-effort,
-      // never let a write failure interrupt the monitor loop.
+      // never let a write failure interrupt the monitor loop. pollIntervalSeconds travels
+      // with every snapshot so the reader can derive its own staleness threshold instead
+      // of assuming a fixed interval (a configured pollIntervalSeconds far above the old
+      // hardcoded 30s stale-check would otherwise make a healthy monitor's segment blank
+      // out for a large fraction of every tick). gaveUp flags the terminal states where
+      // `status` alone doesn't tell a reader the monitor has stopped acting.
       await writeStatus(pane, {
         status: state.status,
         waitUntil: Math.floor(state.waitUntil / 1000),
         overloadWaitUntil: Math.floor(state.overloadWaitUntil / 1000),
+        safeguardWaitUntil: Math.floor(state.safeguardWaitUntil / 1000),
         attempts: state.attempts,
         overloadAttempts: state.overloadAttempts,
+        safeguardAttempts: state.safeguardAttempts,
+        pollIntervalSeconds: config.pollIntervalSeconds,
+        gaveUp: !!state._gaveUp,
       }).catch(() => {});
       if (result === 'waiting' && state.lastRateLimitMessage) {
         const secs = Math.round((state.waitUntil - Date.now()) / 1000);

--- a/src/pane-key.js
+++ b/src/pane-key.js
@@ -1,0 +1,10 @@
+// Shared filename-sanitizer for pane-keyed marker/status files.
+//
+// tmux pane ids (e.g. "%2") and other free-form keys derived from them need to become
+// safe filename components. Previously this one-line rule was copy-pasted into
+// events.js, status-file.js, and the `tr` call in bin/tmux-status.sh — three places
+// that all had to be kept in sync by hand. Centralizing the JS-side copies here so
+// there is exactly one definition to update.
+export function sanitizeKey(key) {
+  return String(key).replace(/[^A-Za-z0-9_-]/g, '_');
+}

--- a/src/status-file.js
+++ b/src/status-file.js
@@ -1,0 +1,50 @@
+// Per-pane status channel for external consumers (tmux status bar, etc).
+//
+// The monitor's state lives in-memory inside a detached, unref'd process — nothing
+// outside it can see whether a given pane is being watched, waiting on a rate-limit
+// reset, or backing off from overload. This writes a small JSON snapshot per pane on
+// every tick so a cheap shell script (see bin/tmux-status.sh) can render an indicator
+// without talking to the monitor process directly.
+//
+// Timestamps are epoch SECONDS, not ms — bash readers on macOS can't do `date +%s%3N`
+// (BSD date has no %N), so seconds keeps the reader script portable and dependency-free.
+//
+// Mirrors the pane-keyed write/read/clear shape of events.js (StopFailure markers).
+
+import { mkdir, writeFile, readFile, unlink, rename } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+export const STATUS_DIR = join(homedir(), '.claude-auto-retry', 'status');
+
+// tmux pane ids look like "%2"; keep the filename to a safe charset.
+function fileFor(paneKey, dir) {
+  const safe = String(paneKey).replace(/[^A-Za-z0-9_-]/g, '_');
+  return join(dir, `${safe}.json`);
+}
+
+// Atomic (tmp + rename) so a reader never sees a half-written file. updatedAt is always
+// stamped here (not caller-supplied) so staleness checks reflect the actual write time.
+export async function writeStatus(paneKey, data, dir = STATUS_DIR) {
+  if (!paneKey) return null;
+  await mkdir(dir, { recursive: true });
+  const file = fileFor(paneKey, dir);
+  const tmp = `${file}.${process.pid}.tmp`;
+  const body = JSON.stringify({ ...data, updatedAt: Math.floor(Date.now() / 1000) });
+  await writeFile(tmp, body);
+  await rename(tmp, file);
+  return file;
+}
+
+export async function readStatus(paneKey, dir = STATUS_DIR) {
+  if (!paneKey) return null;
+  try {
+    return JSON.parse(await readFile(fileFor(paneKey, dir), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export async function clearStatus(paneKey, dir = STATUS_DIR) {
+  try { await unlink(fileFor(paneKey, dir)); } catch { /* already gone */ }
+}

--- a/src/status-file.js
+++ b/src/status-file.js
@@ -12,7 +12,7 @@
 // Mirrors the pane-keyed write/read/clear shape of events.js (StopFailure markers), and
 // shares its filename sanitizer (see pane-key.js).
 
-import { mkdir, writeFile, readFile, unlink, rename, readdir } from 'node:fs/promises';
+import { mkdir, writeFile, readFile, unlink, rename, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { sanitizeKey } from './pane-key.js';
@@ -96,18 +96,30 @@ export async function sweepStaleStatus(dir = STATUS_DIR, maxAgeSeconds = 300) {
   const now = Math.floor(Date.now() / 1000);
   let removed = 0;
   for (const name of entries) {
-    if (!name.endsWith('.json')) continue;
     const file = join(dir, name);
-    try {
-      const data = JSON.parse(await readFile(file, 'utf-8'));
-      if (typeof data.updatedAt !== 'number' || now - data.updatedAt > maxAgeSeconds) {
-        await unlink(file);
-        removed++;
+    if (name.endsWith('.json')) {
+      try {
+        const data = JSON.parse(await readFile(file, 'utf-8'));
+        if (typeof data.updatedAt !== 'number' || now - data.updatedAt > maxAgeSeconds) {
+          await unlink(file);
+          removed++;
+        }
+      } catch {
+        // Unparseable/corrupt snapshot — it can never become valid on its own; remove it.
+        try { await unlink(file); removed++; } catch { /* already gone */ }
       }
-    } catch {
-      // Unparseable/half-written leftover (e.g. an orphaned .tmp file from a crash
-      // mid-rename) — it can never become valid on its own; remove it too.
-      try { await unlink(file); removed++; } catch { /* already gone */ }
+    } else if (name.endsWith('.tmp')) {
+      // Orphaned atomic-write temp (`<pane>.json.<pid>.tmp`) left when writeStatus died
+      // between writeFile and rename. Its body may be half-written, so age it by mtime
+      // rather than a parsed updatedAt — and only sweep ones older than maxAgeSeconds so a
+      // live writeStatus mid-rename (tmp exists for microseconds) is never yanked out.
+      try {
+        const { mtimeMs } = await stat(file);
+        if (now - Math.floor(mtimeMs / 1000) > maxAgeSeconds) {
+          await unlink(file);
+          removed++;
+        }
+      } catch { /* already gone */ }
     }
   }
   return removed;

--- a/src/status-file.js
+++ b/src/status-file.js
@@ -2,32 +2,60 @@
 //
 // The monitor's state lives in-memory inside a detached, unref'd process — nothing
 // outside it can see whether a given pane is being watched, waiting on a rate-limit
-// reset, or backing off from overload. This writes a small JSON snapshot per pane on
-// every tick so a cheap shell script (see bin/tmux-status.sh) can render an indicator
-// without talking to the monitor process directly.
+// reset, backing off from overload, or has given up. This writes a small JSON snapshot
+// per pane on every tick so a cheap shell script (see bin/tmux-status.sh) can render an
+// indicator without talking to the monitor process directly.
 //
 // Timestamps are epoch SECONDS, not ms — bash readers on macOS can't do `date +%s%3N`
 // (BSD date has no %N), so seconds keeps the reader script portable and dependency-free.
 //
-// Mirrors the pane-keyed write/read/clear shape of events.js (StopFailure markers).
+// Mirrors the pane-keyed write/read/clear shape of events.js (StopFailure markers), and
+// shares its filename sanitizer (see pane-key.js).
 
-import { mkdir, writeFile, readFile, unlink, rename } from 'node:fs/promises';
+import { mkdir, writeFile, readFile, unlink, rename, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { sanitizeKey } from './pane-key.js';
 
 export const STATUS_DIR = join(homedir(), '.claude-auto-retry', 'status');
 
-// tmux pane ids look like "%2"; keep the filename to a safe charset.
-function fileFor(paneKey, dir) {
-  const safe = String(paneKey).replace(/[^A-Za-z0-9_-]/g, '_');
-  return join(dir, `${safe}.json`);
+// tmux pane ids (e.g. "%2") are only unique *within one tmux server* — `tmux -L work`
+// and `tmux -L personal` (or two independent default servers on a shared host) can each
+// have a "%2", and without disambiguation both would collide on the same status file.
+//
+// tmux sets TMUX="<socket_path>,<server_pid>,<session_id>" for every process running
+// inside a session; its first field is exactly the value tmux's own `#{socket_path}`
+// format variable resolves to for that server. The monitor is forked from a process
+// running inside the pane it's watching, so it reliably inherits this. The reader script
+// can't rely on its own $TMUX (a status-bar `#()` command runs in the tmux *server's*
+// environment, not a client's — see the README PATH caveat), so it instead receives
+// `#{socket_path}` as an explicit argument, which resolves to the same value.
+function socketIdFromEnv(env = process.env) {
+  const tmuxEnv = env.TMUX || '';
+  return tmuxEnv.split(',')[0] || 'default';
+}
+
+function fileFor(paneKey, dir, socketId = socketIdFromEnv()) {
+  const key = `${sanitizeKey(socketId)}_${sanitizeKey(paneKey)}`;
+  return join(dir, `${key}.json`);
+}
+
+// Hoisted: mkdir(recursive) is idempotent but still a syscall on every call. A monitor
+// ticks every pollIntervalSeconds (5s by default) for its entire lifetime, so memoize
+// the directory-creation promise per directory instead of re-running it every tick.
+let ensuredDir = null;
+function ensureDir(dir) {
+  if (!ensuredDir || ensuredDir.dir !== dir) {
+    ensuredDir = { dir, promise: mkdir(dir, { recursive: true }) };
+  }
+  return ensuredDir.promise;
 }
 
 // Atomic (tmp + rename) so a reader never sees a half-written file. updatedAt is always
 // stamped here (not caller-supplied) so staleness checks reflect the actual write time.
 export async function writeStatus(paneKey, data, dir = STATUS_DIR) {
   if (!paneKey) return null;
-  await mkdir(dir, { recursive: true });
+  await ensureDir(dir);
   const file = fileFor(paneKey, dir);
   const tmp = `${file}.${process.pid}.tmp`;
   const body = JSON.stringify({ ...data, updatedAt: Math.floor(Date.now() / 1000) });
@@ -36,10 +64,10 @@ export async function writeStatus(paneKey, data, dir = STATUS_DIR) {
   return file;
 }
 
-export async function readStatus(paneKey, dir = STATUS_DIR) {
+export async function readStatus(paneKey, dir = STATUS_DIR, socketId = undefined) {
   if (!paneKey) return null;
   try {
-    return JSON.parse(await readFile(fileFor(paneKey, dir), 'utf-8'));
+    return JSON.parse(await readFile(fileFor(paneKey, dir, socketId), 'utf-8'));
   } catch {
     return null;
   }
@@ -47,4 +75,40 @@ export async function readStatus(paneKey, dir = STATUS_DIR) {
 
 export async function clearStatus(paneKey, dir = STATUS_DIR) {
   try { await unlink(fileFor(paneKey, dir)); } catch { /* already gone */ }
+}
+
+// Best-effort GC for status files left behind by monitors that died without a chance to
+// run their own cleanup (SIGKILL, host sleep/crash, `tmux kill-server`). Independent of
+// bin/tmux-status.sh's own staleness check (which only *hides* a stale segment) — this
+// actually deletes the file, so the status dir doesn't grow forever over a machine's
+// lifetime (tmux pane ids increment monotonically per server and are never reused).
+//
+// maxAgeSeconds is intentionally generous (default 5 minutes) — comfortably above any
+// sane pollIntervalSeconds so a live monitor's own file is never swept out from under it.
+// Called best-effort on monitor startup and from `claude-auto-retry uninstall`.
+export async function sweepStaleStatus(dir = STATUS_DIR, maxAgeSeconds = 300) {
+  let entries;
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return 0; // directory doesn't exist yet — nothing to sweep
+  }
+  const now = Math.floor(Date.now() / 1000);
+  let removed = 0;
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    const file = join(dir, name);
+    try {
+      const data = JSON.parse(await readFile(file, 'utf-8'));
+      if (typeof data.updatedAt !== 'number' || now - data.updatedAt > maxAgeSeconds) {
+        await unlink(file);
+        removed++;
+      }
+    } catch {
+      // Unparseable/half-written leftover (e.g. an orphaned .tmp file from a crash
+      // mid-rename) — it can never become valid on its own; remove it too.
+      try { await unlink(file); removed++; } catch { /* already gone */ }
+    }
+  }
+  return removed;
 }

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -201,13 +201,17 @@ describe('processOneTick', () => {
     // Should stay in 'waiting' to avoid re-detection loop
     assert.equal(s.status, 'waiting');
     assert.ok(s.waitUntil > Date.now());
+    // Flagged so external consumers (tmux status bar) don't render a perpetually
+    // resetting countdown for a monitor that will not send further retries.
+    assert.equal(s._gaveUp, true);
   });
   it('resets from max-retries when rate limit clears', async () => {
     const t = mockTmux('Claude is working normally');
     const s = createMonitorState();
-    s.waitUntil = Date.now() - 1000; s.status = 'waiting'; s.attempts = 10;
+    s.waitUntil = Date.now() - 1000; s.status = 'waiting'; s.attempts = 10; s._gaveUp = true;
     // Rate limit cleared → should detect user-continued before max-retries check
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'user-continued');
     assert.equal(s.attempts, 0);
+    assert.equal(s._gaveUp, false);
   });
 });

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -265,6 +265,7 @@ describe('processOneTick — overload path', () => {
     s.overloadWaitUntil = Date.now() - 1;
     assert.equal(await processOneTick(s, t, '%0', c, () => true, NO_JITTER), 'overload-gave-up');
     assert.equal(t._sent.length, 1);
+    assert.equal(s._gaveUp, true, 'give-up must be flagged for external consumers (e.g. tmux status bar)');
   });
 
   it('switches to the usage path if a usage limit appears mid-overload', async () => {
@@ -354,6 +355,20 @@ describe('processOneTick — StopFailure event path (authoritative)', () => {
     assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'overload-exited-to-shell');
     assert.equal(t._sent.length, 0);
     assert.equal(s.status, 'monitoring');
+  });
+
+  it('flags gaveUp when a fresh event arrives already past the cap, even though status stays "monitoring"', async () => {
+    // Regression: this path returns from within the (idle) 'monitoring' branch and never
+    // assigns state.status, so a naive reader would see status:'monitoring' (green/live)
+    // for a monitor that has permanently stopped acting on this pane's failures.
+    const t = mockTmux('idle prompt', 'node', true, ev);
+    const s = createMonitorState();
+    const c = cfg({ maxTotalWaitMinutes: 0.5 }); // cap = 30s
+    s.overloadTotalWaitMs = 30_000; // already at/over the cap before this tick
+    const r = await processOneTick(s, t, '%0', c, () => true, NO_JITTER);
+    assert.equal(r, 'overload-gave-up');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(s._gaveUp, true);
   });
 });
 

--- a/test/pane-key.test.js
+++ b/test/pane-key.test.js
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeKey } from '../src/pane-key.js';
+
+describe('sanitizeKey', () => {
+  it('passes through an already-safe key unchanged', () => {
+    assert.equal(sanitizeKey('abc-123_XYZ'), 'abc-123_XYZ');
+  });
+
+  it('replaces tmux pane-id punctuation with underscores', () => {
+    assert.equal(sanitizeKey('%2'), '_2');
+  });
+
+  it('replaces path separators (e.g. a socket path) with underscores', () => {
+    assert.equal(sanitizeKey('/tmp/tmux-1000/default'), '_tmp_tmux-1000_default');
+  });
+
+  it('coerces non-string input via String()', () => {
+    assert.equal(sanitizeKey(42), '42');
+  });
+});

--- a/test/safeguard.test.js
+++ b/test/safeguard.test.js
@@ -133,6 +133,7 @@ describe('processOneTick — safeguard path', () => {
     s.safeguardWaitUntil = Date.now() - 1;
     assert.equal(await processOneTick(s, t, '%0', c, () => true), 'safeguard-gave-up');
     assert.equal(t._sent.length, 2);
+    assert.equal(s._gaveUp, true, 'give-up must be flagged for external consumers (e.g. tmux status bar)');
   });
 
   it('clears back to monitoring when the flag is gone', async () => {

--- a/test/status-file.test.js
+++ b/test/status-file.test.js
@@ -1,14 +1,20 @@
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeStatus, readStatus, clearStatus } from '../src/status-file.js';
+import { writeStatus, readStatus, clearStatus, sweepStaleStatus } from '../src/status-file.js';
 
 describe('per-pane status file', () => {
   let dir;
+  let originalTmux;
   before(async () => { dir = await mkdtemp(join(tmpdir(), 'car-status-')); });
   after(async () => { await rm(dir, { recursive: true, force: true }); });
+  beforeEach(() => { originalTmux = process.env.TMUX; delete process.env.TMUX; });
+  afterEach(() => {
+    if (originalTmux === undefined) delete process.env.TMUX;
+    else process.env.TMUX = originalTmux;
+  });
 
   it('round-trips a pane-keyed status snapshot', async () => {
     await writeStatus('%2', { status: 'monitoring', waitUntil: 0, overloadWaitUntil: 0, attempts: 0, overloadAttempts: 0 }, dir);
@@ -24,10 +30,11 @@ describe('per-pane status file', () => {
     assert.ok(s.updatedAt >= before_, 'updatedAt should be a real current-time stamp, not the caller value');
   });
 
-  it('sanitizes the pane id into the filename', async () => {
+  it('sanitizes the pane id into the filename, prefixed by a socket key', async () => {
     await writeStatus('%7', { status: 'monitoring' }, dir);
     const files = await readdir(dir);
-    assert.ok(files.includes('_7.json'), files.join(','));
+    // No TMUX env in this test (see beforeEach) -> falls back to the 'default' socket key.
+    assert.ok(files.includes('default__7.json'), files.join(','));
   });
 
   it('returns null for an absent pane', async () => {
@@ -35,7 +42,7 @@ describe('per-pane status file', () => {
   });
 
   it('ignores an unparseable status file', async () => {
-    await writeFile(join(dir, '_4.json'), 'not json');
+    await writeFile(join(dir, 'default__4.json'), 'not json');
     assert.equal(await readStatus('%4', dir), null);
   });
 
@@ -59,5 +66,67 @@ describe('per-pane status file', () => {
     const s = await readStatus('%6', dir);
     assert.equal(s.status, 'waiting');
     assert.equal(s.waitUntil, 12345);
+  });
+
+  describe('cross-server pane-id disambiguation', () => {
+    it('keys the same pane id differently under different TMUX socket paths', async () => {
+      process.env.TMUX = '/tmp/tmux-1000/work,111,0';
+      await writeStatus('%2', { status: 'monitoring' }, dir);
+
+      process.env.TMUX = '/tmp/tmux-1000/personal,222,0';
+      await writeStatus('%2', { status: 'waiting', waitUntil: 999 }, dir);
+
+      process.env.TMUX = '/tmp/tmux-1000/work,111,0';
+      const workStatus = await readStatus('%2', dir);
+      assert.equal(workStatus.status, 'monitoring', 'the "work" server\'s pane %2 must not see "personal"\'s write');
+
+      process.env.TMUX = '/tmp/tmux-1000/personal,222,0';
+      const personalStatus = await readStatus('%2', dir);
+      assert.equal(personalStatus.status, 'waiting');
+      assert.equal(personalStatus.waitUntil, 999);
+    });
+
+    it('falls back to a stable "default" socket key when TMUX is unset', async () => {
+      delete process.env.TMUX;
+      await writeStatus('%8', { status: 'monitoring' }, dir);
+      const files = await readdir(dir);
+      assert.ok(files.includes('default__8.json'), files.join(','));
+    });
+  });
+
+  describe('sweepStaleStatus', () => {
+    it('removes files older than maxAgeSeconds and leaves fresh ones', async () => {
+      const sweepDir = await mkdtemp(join(tmpdir(), 'car-status-sweep-'));
+      try {
+        await writeFile(join(sweepDir, 'default__old.json'), JSON.stringify({ status: 'monitoring', updatedAt: Math.floor(Date.now() / 1000) - 1000 }));
+        await writeStatus('%fresh', { status: 'monitoring' }, sweepDir);
+
+        const removed = await sweepStaleStatus(sweepDir, 300);
+        assert.equal(removed, 1);
+
+        const files = await readdir(sweepDir);
+        assert.equal(files.length, 1);
+        assert.ok(files[0].endsWith('__fresh.json'), files.join(','));
+      } finally {
+        await rm(sweepDir, { recursive: true, force: true });
+      }
+    });
+
+    it('removes unparseable leftovers (e.g. an orphaned .tmp file)', async () => {
+      const sweepDir = await mkdtemp(join(tmpdir(), 'car-status-sweep-'));
+      try {
+        await writeFile(join(sweepDir, 'default__orphan.json'), 'not json');
+        const removed = await sweepStaleStatus(sweepDir, 300);
+        assert.equal(removed, 1);
+        assert.deepEqual(await readdir(sweepDir), []);
+      } finally {
+        await rm(sweepDir, { recursive: true, force: true });
+      }
+    });
+
+    it('is a no-op (returns 0) when the status directory does not exist yet', async () => {
+      const missing = join(tmpdir(), 'car-status-does-not-exist-' + Date.now());
+      assert.equal(await sweepStaleStatus(missing, 300), 0);
+    });
   });
 });

--- a/test/status-file.test.js
+++ b/test/status-file.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, readdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readdir, writeFile, utimes } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { writeStatus, readStatus, clearStatus, sweepStaleStatus } from '../src/status-file.js';
@@ -112,13 +112,45 @@ describe('per-pane status file', () => {
       }
     });
 
-    it('removes unparseable leftovers (e.g. an orphaned .tmp file)', async () => {
+    it('removes an unparseable .json snapshot', async () => {
       const sweepDir = await mkdtemp(join(tmpdir(), 'car-status-sweep-'));
       try {
         await writeFile(join(sweepDir, 'default__orphan.json'), 'not json');
         const removed = await sweepStaleStatus(sweepDir, 300);
         assert.equal(removed, 1);
         assert.deepEqual(await readdir(sweepDir), []);
+      } finally {
+        await rm(sweepDir, { recursive: true, force: true });
+      }
+    });
+
+    it('sweeps an orphaned .tmp file (crash between writeFile and rename)', async () => {
+      const sweepDir = await mkdtemp(join(tmpdir(), 'car-status-sweep-'));
+      try {
+        // A real atomic-write temp is named "<pane>.json.<pid>.tmp" and may be
+        // half-written. Age it past the threshold via an explicit past mtime.
+        const orphan = join(sweepDir, 'default__2.json.9999.tmp');
+        await writeFile(orphan, '{"status":"monito');
+        const past = new Date((Math.floor(Date.now() / 1000) - 1000) * 1000);
+        await utimes(orphan, past, past);
+
+        const removed = await sweepStaleStatus(sweepDir, 300);
+        assert.equal(removed, 1);
+        assert.deepEqual(await readdir(sweepDir), []);
+      } finally {
+        await rm(sweepDir, { recursive: true, force: true });
+      }
+    });
+
+    it('leaves a fresh .tmp alone (a live writeStatus may be mid-rename)', async () => {
+      const sweepDir = await mkdtemp(join(tmpdir(), 'car-status-sweep-'));
+      try {
+        // Just-created temp with a current mtime — a concurrent writeStatus could be
+        // about to rename it into place, so the sweep must not race it away.
+        await writeFile(join(sweepDir, 'default__3.json.1234.tmp'), '{"status":"mon');
+        const removed = await sweepStaleStatus(sweepDir, 300);
+        assert.equal(removed, 0);
+        assert.deepEqual(await readdir(sweepDir), ['default__3.json.1234.tmp']);
       } finally {
         await rm(sweepDir, { recursive: true, force: true });
       }

--- a/test/status-file.test.js
+++ b/test/status-file.test.js
@@ -1,0 +1,63 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeStatus, readStatus, clearStatus } from '../src/status-file.js';
+
+describe('per-pane status file', () => {
+  let dir;
+  before(async () => { dir = await mkdtemp(join(tmpdir(), 'car-status-')); });
+  after(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('round-trips a pane-keyed status snapshot', async () => {
+    await writeStatus('%2', { status: 'monitoring', waitUntil: 0, overloadWaitUntil: 0, attempts: 0, overloadAttempts: 0 }, dir);
+    const s = await readStatus('%2', dir);
+    assert.equal(s.status, 'monitoring');
+    assert.equal(typeof s.updatedAt, 'number');
+  });
+
+  it('stamps updatedAt in epoch seconds, overwriting any caller-supplied value', async () => {
+    const before_ = Math.floor(Date.now() / 1000);
+    await writeStatus('%2', { status: 'monitoring', updatedAt: 1 }, dir);
+    const s = await readStatus('%2', dir);
+    assert.ok(s.updatedAt >= before_, 'updatedAt should be a real current-time stamp, not the caller value');
+  });
+
+  it('sanitizes the pane id into the filename', async () => {
+    await writeStatus('%7', { status: 'monitoring' }, dir);
+    const files = await readdir(dir);
+    assert.ok(files.includes('_7.json'), files.join(','));
+  });
+
+  it('returns null for an absent pane', async () => {
+    assert.equal(await readStatus('%99', dir), null);
+  });
+
+  it('ignores an unparseable status file', async () => {
+    await writeFile(join(dir, '_4.json'), 'not json');
+    assert.equal(await readStatus('%4', dir), null);
+  });
+
+  it('clear() removes the status file', async () => {
+    await writeStatus('%5', { status: 'waiting' }, dir);
+    await clearStatus('%5', dir);
+    assert.equal(await readStatus('%5', dir), null);
+  });
+
+  it('clear() on an absent pane is a no-op', async () => {
+    await assert.doesNotReject(clearStatus('%no-such-pane', dir));
+  });
+
+  it('write is a no-op without a pane key', async () => {
+    assert.equal(await writeStatus('', { status: 'monitoring' }, dir), null);
+  });
+
+  it('overwrites a previous snapshot for the same pane', async () => {
+    await writeStatus('%6', { status: 'monitoring' }, dir);
+    await writeStatus('%6', { status: 'waiting', waitUntil: 12345 }, dir);
+    const s = await readStatus('%6', dir);
+    assert.equal(s.status, 'waiting');
+    assert.equal(s.waitUntil, 12345);
+  });
+});


### PR DESCRIPTION
## Summary

- The monitor's `monitoring`/`waiting`/`overload` state lives entirely in-memory inside a detached, unref'd process — there's no way to tell from outside whether a given pane is currently being watched, without tailing logs.
- This adds a per-pane status snapshot (`~/.claude-auto-retry/status/<pane>.json`), written on every poll tick, and a dependency-free `bin/tmux-status.sh` reader that renders it as a tmux status-bar segment:
  - actively monitoring → `🟢AR`
  - waiting on a usage-limit reset → `⏳AR 1h30m`
  - backing off from overload → `🟠AR 45s`
  - no monitor for the pane, or a stale file (monitor died without cleanup, >30s old) → nothing
- New script is registered as `claude-auto-retry-tmux-status` in `package.json` bin, so it lands on `PATH` after a normal `npm i -g`.
- Mirrors the existing pane-keyed write/read/clear shape from `events.js` (StopFailure markers) for consistency.
- Docs: new "tmux status bar indicator" README section + CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `npm test` — all 201 tests pass (9 new in `test/status-file.test.js`, covering round-trip, sanitized filenames, absent/corrupt files, overwrite, and the no-op-without-a-pane-key guard)
- [x] Manually verified end-to-end against a real tmux pane + a live `startMonitor` process: status file appears, `tmux-status.sh` renders the correct icon for `monitoring`/`waiting`/`overload`, and both missing and stale (>30s) files render blank
- [x] Confirmed `git diff --cached --summary` preserves the executable bit on `bin/tmux-status.sh` (`100755`)