### PR TITLE
fix(events): don't route rate_limit (session/usage limit) through the overload path

### DIFF
--- a/DESIGN-NOTES.md
+++ b/DESIGN-NOTES.md
@@ -24,9 +24,11 @@ move is to stop using the scrape as the *trigger*.
   suffix on the colon form). Acting on the transient form interrupts Claude's *own*
   backoff. **[done]** — we require the colon form and suppress the retry suffix via the
   working gate.
-- **Error → HTTP status → retryability.** Retryable: `429 rate_limit_error`,
-  `500 api_error`, `504 timeout_error`, `529 overloaded_error`, plus edge `502/503`
+- **Error → HTTP status → retryability.** Retryable (seconds-scale): `500 api_error`,
+  `504 timeout_error`, `529 overloaded_error`, plus edge `502/503`
   (no JSON body — plain text/HTML from Cloudflare/envoy, e.g. `503 no healthy upstream`).
+  `429 rate_limit_error` is NOT event-retryable: on a subscription it is the session/usage
+  limit — an hours-scale wait owned by the scraper usage path, not a seconds-scale retry.
   Never retry: `400/401/402/403/404/413`. The official SDK retry set is `408/409/429 +
   all 5xx`. **[done]** — default patterns cover `429|500|502|503|504|529` + `overloaded_error`.
 - **API-429 has no 3-digit code in the slot.** It renders
@@ -43,8 +45,10 @@ move is to stop using the scrape as the *trigger*.
 **Implemented.** The launcher stamps `CLAUDE_AUTO_RETRY_PANE` onto claude's env; the
 `StopFailure` hook (`claude-auto-retry _stopfailure-hook`, installed via
 `install-hook`) runs as a claude child, inherits that var, and writes a pane-keyed
-marker under `~/.claude-auto-retry/events/` for retryable error types
-(`overloaded|server_error|rate_limit`). The monitor reads the marker for its own pane
+marker under `~/.claude-auto-retry/events/` for the transient-overload error types
+(`overloaded|server_error` — `rate_limit` is deliberately excluded: it is the hours-scale
+session/usage limit, owned by the scraper usage path; see src/events.js). The monitor
+reads the marker for its own pane
 each tick; the first marker latches `eventMode`, which disables the scraper for that
 session. Edge-triggered: one backoff-then-send per failure, then back to monitoring;
 self-recovery and foreground/shell gates still apply; the cumulative cap is shared with
@@ -97,7 +101,8 @@ hookInput = { hook_event_name: "StopFailure", error, error_details, last_assista
 ```
 
 plus the standard envelope (`session_id`, `transcript_path`, `cwd`). So a matcher of
-`overloaded|server_error|rate_limit` selects exactly the retryable classes, and the
+`overloaded|server_error` selects exactly the transient-overload classes (`rate_limit`
+is excluded — a session/usage limit is not an overload; see src/events.js), and the
 handler gets the error type for free — no scraping. **The blocker is cleared; this
 direction is ready to build.** It supersedes the scraper for the overload path; the
 scraper stays as a legacy fallback for users who won't install hooks. Remaining

--- a/README.md
+++ b/README.md
@@ -198,13 +198,19 @@ claude-auto-retry install-hook                  # into $CLAUDE_CONFIG_DIR or ~/.
 claude-auto-retry install-hook /path/to/config  # repeat per CLAUDE_CONFIG_DIR you use
 ```
 
-This adds a `StopFailure` hook (matcher `overloaded|server_error|rate_limit`) that
-writes a pane-keyed marker the monitor consumes — no terminal scraping, so it cannot
+This adds a `StopFailure` hook (matcher `overloaded|server_error`) that writes a
+pane-keyed marker the monitor consumes — no terminal scraping, so it cannot
 false-positive on code or scrollback. Sessions launched via the wrapper **after**
 installing the hook use it automatically; the first marker latches event mode and
 disables the scraper for that session. Sessions without the hook (or pre-install) fall
 back to the anchored scraper. Remove with `uninstall-hook`. See `DESIGN-NOTES.md` for
 the architecture.
+
+> **Why not `rate_limit`?** The event path handles only *transient overloads*
+> (seconds-scale backoff). A `rate_limit` is the subscription **session/usage limit** —
+> an hours-scale wait until a printed reset time — so it's handled by the usage-wait
+> path above, not the overload path. Routing it through the hook would fire premature
+> retries against a session that's simply out of quota.
 
 ### Gating decision (alive-at-prompt vs exited-to-shell)
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -201,9 +201,11 @@ async function cmdLogs() {
 const HOOK_MARKER = '_stopfailure-hook';
 
 function stopFailureHookEntry() {
-  // Matcher filters on the StopFailure error type; we want the retryable classes only.
+  // Matcher filters on the StopFailure error type; only the transient-overload classes.
+  // rate_limit is intentionally omitted — a session/usage limit is an hours-scale wait
+  // owned by the scraper usage path, not a seconds-scale event retry (see src/events.js).
   return {
-    matcher: 'overloaded|server_error|rate_limit',
+    matcher: 'overloaded|server_error',
     hooks: [{ type: 'command', command: `node ${__filename} ${HOOK_MARKER}`, timeout: 5 }],
   };
 }

--- a/src/events.js
+++ b/src/events.js
@@ -22,9 +22,11 @@ export const EVENTS_DIR = join(homedir(), '.claude-auto-retry', 'events');
 // Routing it here made the monitor fire futile "Continue" retries into a session-limited
 // pane and fight the (correct) scraper usage-wait path. Session/usage limits are owned by
 // the scraper usage path (it reliably reads the persistent "…resets <time>" banner and
-// waits); a genuinely transient API 429 is still caught by the overload scraper's
-// "temporarily limiting requests" pattern. Permanent errors (auth/billing/invalid) never
-// retry.
+// waits); a genuinely transient API 429 is caught by the overload scraper's "temporarily
+// limiting requests" pattern — but only while the scraper is active (it is disabled once
+// eventMode latches), so API-key sessions in event mode currently get no retry for that
+// case. A known, accepted gap: rare, and strictly better than misrouting session limits.
+// Permanent errors (auth/billing/invalid) never retry.
 const RETRYABLE = new Set(['overloaded', 'server_error']);
 
 export function isRetryableError(errorType) {

--- a/src/events.js
+++ b/src/events.js
@@ -1,7 +1,7 @@
 // StopFailure event channel: the authoritative, scrape-free overload trigger.
 //
 // Claude Code's `StopFailure` hook fires only when a turn ends in an API error, with a
-// typed `error` (matcher-filtered to overloaded/server_error/rate_limit). The hook runs
+// typed `error` (matcher-filtered to overloaded/server_error). The hook runs
 // as a CHILD of claude, so it inherits the env the launcher stamped onto claude —
 // including CLAUDE_AUTO_RETRY_PANE. It writes a marker keyed by that pane; the daemon,
 // which already knows its pane, reads it directly. No session-id plumbing needed (the
@@ -16,9 +16,16 @@ import { homedir } from 'node:os';
 
 export const EVENTS_DIR = join(homedir(), '.claude-auto-retry', 'events');
 
-// Error types we treat as a retryable overload — mirrors the hook matcher. Anything else
-// (auth, billing, invalid_request, …) is permanent and must NOT drive a retry.
-const RETRYABLE = new Set(['overloaded', 'server_error', 'rate_limit']);
+// Error types the event path treats as a *transient overload* (seconds-scale backoff).
+// NOTE: `rate_limit` is deliberately EXCLUDED. For a subscription it is the session/usage
+// limit — an HOURS-scale wait until a printed reset time, not a seconds-scale retry.
+// Routing it here made the monitor fire futile "Continue" retries into a session-limited
+// pane and fight the (correct) scraper usage-wait path. Session/usage limits are owned by
+// the scraper usage path (it reliably reads the persistent "…resets <time>" banner and
+// waits); a genuinely transient API 429 is still caught by the overload scraper's
+// "temporarily limiting requests" pattern. Permanent errors (auth/billing/invalid) never
+// retry.
+const RETRYABLE = new Set(['overloaded', 'server_error']);
 
 export function isRetryableError(errorType) {
   return typeof errorType === 'string' && RETRYABLE.has(errorType.toLowerCase());

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -3,7 +3,7 @@ import { parseResetTime, calculateWaitMs } from './time-parser.js';
 import { capturePane, sendKeys, sendKey, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
-import { readStopFailureEvent, clearStopFailureEvent } from './events.js';
+import { readStopFailureEvent, clearStopFailureEvent, isRetryableError } from './events.js';
 
 const DEFAULT_FOREGROUND_COMMANDS = ['node', 'claude', 'npx', 'tsx', 'bun', 'deno'];
 const SHELL_COMMANDS = ['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'];
@@ -295,6 +295,16 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
   if (overload && overload.enabled && tmuxAdapter.readEvent) {
     const ev = await tmuxAdapter.readEvent();
     if (ev) {
+      // Consume-side guard: trust no writer. The hook entry in settings.json freezes the
+      // cli.js path + matcher at install time, so an OLDER hook binary (whose matcher and
+      // RETRYABLE set still include rate_limit) can keep writing markers after an upgrade.
+      // Consume-and-ignore anything non-retryable, and do NOT latch eventMode off it —
+      // a misclassified marker must not start a backoff nor disable the scraper paths.
+      if (!isRetryableError(ev.error)) {
+        await tmuxAdapter.clearEvent();             // consume so it can't re-fire
+        state._ignoredEventError = ev.error;
+        return 'event-ignored';
+      }
       state.eventMode = true;
       await tmuxAdapter.clearEvent();               // consume
       if (isWorking(stripped)) { resetOverload(state); return 'overload-cleared'; } // self-recovered
@@ -363,6 +373,7 @@ export async function startMonitor(pane, pid) {
       if (result === 'user-continued') await logger.info('User already continued. Attempt counter reset.');
       if (result === 'max-retries') await logger.warn(`Max retries (${config.maxRetries}) reached. Monitor still active but will not send further retries until rate limit clears.`);
       if (result === 'skipped-not-claude') await logger.warn(`Foreground is "${state._lastForeground}", not Claude. Skipping send-keys. (Add to foregroundCommands in ~/.claude-auto-retry.json if this is wrong)`);
+      if (result === 'event-ignored') await logger.warn(`Ignored StopFailure marker with non-retryable error="${state._ignoredEventError}". If this is "rate_limit", an outdated hook is installed — re-run "claude-auto-retry install-hook".`);
       if (result === 'overload-detected') {
         const secs = Math.round((state.overloadWaitUntil - Date.now()) / 1000);
         const m = state._overloadMatch;

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -8,10 +8,16 @@ import {
 } from '../src/events.js';
 
 describe('isRetryableError', () => {
-  it('accepts the retryable overload classes', () => {
-    for (const e of ['overloaded', 'server_error', 'rate_limit', 'OVERLOADED']) {
+  it('accepts the transient-overload classes', () => {
+    for (const e of ['overloaded', 'server_error', 'OVERLOADED']) {
       assert.equal(isRetryableError(e), true, e);
     }
+  });
+  it('rejects rate_limit (a session/usage limit is an hours-scale wait, not an overload)', () => {
+    // Regression: routing rate_limit through the event/overload path made the monitor
+    // fire futile seconds-scale "Continue" retries into a session-limited pane and fight
+    // the scraper usage-wait path. Session limits are owned by the scraper usage path.
+    assert.equal(isRetryableError('rate_limit'), false);
   });
   it('rejects permanent / unknown classes', () => {
     for (const e of ['authentication_failed', 'billing_error', 'invalid_request', '', undefined, null, 42]) {

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -322,6 +322,23 @@ describe('processOneTick — StopFailure event path (authoritative)', () => {
     assert.equal(t._sent.length, 0);
   });
 
+  it('consumes-and-ignores a non-retryable marker (e.g. rate_limit from an outdated hook) without latching eventMode', async () => {
+    // Regression: settings.json freezes the hook's cli.js path + matcher at install time,
+    // so an old hook binary can still write rate_limit markers after an upgrade. The
+    // daemon must not enter overload backoff off it, and must NOT latch eventMode (that
+    // would disable the scraper paths off a misclassified event).
+    for (const bad of ['rate_limit', 'billing_error', 'invalid_request']) {
+      const t = mockTmux('idle prompt', 'node', true, { error: bad, ts: Date.now() });
+      const s = createMonitorState();
+      const r = await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
+      assert.equal(r, 'event-ignored', bad);
+      assert.equal(s.eventMode, false, bad);   // NOT latched
+      assert.equal(s.status, 'monitoring', bad);
+      assert.equal(t._cleared, true, bad);     // consumed so it can't re-fire
+      assert.equal(t._sent.length, 0, bad);
+    }
+  });
+
   it('once eventMode is latched, the scraper path is disabled', async () => {
     const t = mockTmux('API Error: 529 Overloaded', 'node', true, null);  // scraper WOULD match
     const s = createMonitorState();


### PR DESCRIPTION
A live session-limit incident exposed a misclassification in the `StopFailure` event path.

**Symptom (from a real monitor log):** the hook fired `error=rate_limit`; the monitor treated it as a transient **overload** and ran the seconds-scale backoff loop — injecting ~5 futile `Continue` retries (with negative backoffs, `Next backoff -3s`) into a genuinely session-limited pane — while the **scraper usage path had correctly computed an ~8744s (~2.4h) wait** to the printed `resets 6:30pm` reset. The two paths fought; the session only recovered at the real reset.

```
StopFailure error=rate_limit → OVERLOAD backoff 30s        ← wrong path
Overload retry sent (attempt 1)                            ← futile "Continue" into a session limit
Rate limit detected: "…session limit · resets 6:30pm". Waiting 8744s   ← correct behavior
Overload retry sent (attempt 2). Next backoff -3s          ← fighting
```

**Root cause:** `rate_limit` is ambiguous. For a subscription it's the **hours-scale session/usage limit**, not a seconds-scale transient. It shouldn't go through the event/overload path at all.

**Fix:** drop `rate_limit` from the `StopFailure` classifier (`src/events.js`) and the hook matcher (`bin/cli.js`), now `overloaded|server_error` only. Session/usage limits are owned by the **scraper usage-wait path** — it reliably reads the persistent `…resets <time>` banner and waits for the reset (proven correct in the same log). A genuinely transient API 429 is still caught by the overload scraper's `temporarily limiting requests` pattern.

+1 regression test (193 total, zero deps). Existing installs should re-run `claude-auto-retry install-hook` to update the matcher.