### PR TITLE
feat(safeguard): bounded auto-retry past AUP-safeguard false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,9 @@ repeats — but only up to `maxRetries` times, then **gives up loudly** (logged)
 than looping. A sticky flag means the content/model combination is genuinely blocked;
 switch models with `/model` or rephrase.
 
-Detection is tail-anchored (last 12 pane lines) like the overload path, so the phrase
-appearing in scrollback or in a conversation *about* safeguards won't trigger it.
+Detection is tail-anchored (last 12 pane lines) like the overload path, and a match
+additionally requires the `API Error` render line nearby — so the phrases appearing in
+scrollback or in a conversation *about* safeguards won't trigger it.
 
 Configured under a `safeguard` block (defaults shown):
 
@@ -261,7 +262,7 @@ Configured under a `safeguard` block (defaults shown):
 | Option | Default | Description |
 |--------|---------|-------------|
 | `enabled` | `true` | Turn the safeguard-retry path on/off |
-| `patterns` | (see above) | Case-insensitive regexes marking the safeguard render (matched in the pane tail) |
+| `patterns` | (see above) | Case-insensitive regexes marking the safeguard render (matched in the pane tail, near an `API Error` line) |
 | `maxRetries` | `3` | Re-send attempts before giving up — kept small; retrying a sticky flag won't help |
 | `retryDelaySeconds` | `8` | Wait between re-sends |
 | `retryMessage` | `"continue"` | Message sent to nudge past the flag |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ When you disconnect (SSH drops, close terminal, laptop sleeps), **tmux keeps run
 - **DST-safe** — iterative offset correction handles daylight saving transitions
 - **Safe send-keys** — verifies Claude is still the foreground process before injecting text
 - **Overload backoff** — detects sustained API overload (`429/500/502/503/504/529`) and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff))
+- **Safeguard retry** — auto-continues past an AUP-safeguard false-positive (often transient), capped at a few tries so a sticky flag can't loop ([details](#safeguard-retry))
 - **`--print` mode support** — buffers output, retries cleanly for piped/scripted usage
 - **Configurable** — retry count, wait margin, custom patterns, retry message
 - **Config validation** — bad config values fall back to safe defaults instead of crashing
@@ -221,6 +222,52 @@ the foreground check (it never types into bash), and the tool logs
 default** — blindly typing `claude --continue` into a shell the user may be using
 is worse than surfacing the stall. Set `relaunchOnExit: true` (and adjust
 `relaunchCommand`) only if you actually observe shell-exits on overload.
+
+## Safeguard retry
+
+A third failure mode, separate from usage limits and 5xx overloads: the model's
+**safeguards flag your message** and Claude Code can't respond. It renders like:
+
+```
+● API Error: Fable 5's safeguards flagged this message (…/legal/aup). They may flag
+  safe, normal content as well. … Claude Code can't respond to this request with Fable 5.
+  Double press esc to edit your last message, or try a different model with /model.
+```
+
+These flags are **often false positives** (the message says so) and semi-random, so an
+immediate re-send frequently clears them. When the tool sees this render at an idle
+prompt, it sends a short retry message (`continue` by default), waits a few seconds, and
+repeats — but only up to `maxRetries` times, then **gives up loudly** (logged) rather
+than looping. A sticky flag means the content/model combination is genuinely blocked;
+switch models with `/model` or rephrase.
+
+Detection is tail-anchored (last 12 pane lines) like the overload path, so the phrase
+appearing in scrollback or in a conversation *about* safeguards won't trigger it.
+
+Configured under a `safeguard` block (defaults shown):
+
+```json
+{
+  "safeguard": {
+    "enabled": true,
+    "patterns": ["safeguards flagged this message", "can't respond to this request with", "legal/aup"],
+    "maxRetries": 3,
+    "retryDelaySeconds": 8,
+    "retryMessage": "continue"
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Turn the safeguard-retry path on/off |
+| `patterns` | (see above) | Case-insensitive regexes marking the safeguard render (matched in the pane tail) |
+| `maxRetries` | `3` | Re-send attempts before giving up — kept small; retrying a sticky flag won't help |
+| `retryDelaySeconds` | `8` | Wait between re-sends |
+| `retryMessage` | `"continue"` | Message sent to nudge past the flag |
+
+Usage limits always take precedence; the safeguard path only acts when Claude is idle
+(no `esc to interrupt` footer) and the foreground process is `claude`/`node`.
 
 ## CLI Commands
 

--- a/src/config.js
+++ b/src/config.js
@@ -44,6 +44,24 @@ export const DEFAULT_OVERLOAD = {
   relaunchCommand: 'claude --continue',
 };
 
+// Safeguard / AUP false-positive retry. Distinct from usage limits (hours) and overload
+// (5xx, exponential): the model's safeguards flag a message — often a false positive, so
+// an immediate re-send usually clears it. Bounded by maxRetries so a *sticky* flag can't
+// loop forever. See README "Safeguard retry".
+export const DEFAULT_SAFEGUARD = {
+  enabled: true,
+  // Anchored, case-insensitive regexes matched against the pane tail (see detectSafeguard).
+  // Match the stable phrases of the safeguard render, not the model name (which varies).
+  patterns: [
+    "safeguards flagged this message",
+    "can't respond to this request with",   // "Claude Code can't respond to this request with <model>"
+    "legal/aup",                             // the AUP link Anthropic includes
+  ],
+  maxRetries: 3,          // small — if it keeps flagging, retrying won't help
+  retryDelaySeconds: 8,   // brief pause between re-sends (semi-random flag; quick retry helps)
+  retryMessage: 'continue',
+};
+
 export const DEFAULT_CONFIG = {
   maxRetries: 5,
   pollIntervalSeconds: 5,
@@ -52,6 +70,7 @@ export const DEFAULT_CONFIG = {
   retryMessage: 'Continue where you left off. The previous attempt was rate limited.',
   customPatterns: [],
   overload: DEFAULT_OVERLOAD,
+  safeguard: DEFAULT_SAFEGUARD,
 };
 
 const CONFIG_PATH = join(homedir(), '.claude-auto-retry.json');
@@ -102,6 +121,24 @@ function validateOverload(raw) {
   return o;
 }
 
+function validateSafeguard(raw) {
+  const s = { ...DEFAULT_SAFEGUARD, ...(raw && typeof raw === 'object' ? raw : {}) };
+  s.enabled = typeof s.enabled === 'boolean' ? s.enabled : DEFAULT_SAFEGUARD.enabled;
+  const pats = Array.isArray(s.patterns)
+    ? s.patterns.filter(p => {
+        if (typeof p !== 'string' || p.length === 0) return false;
+        try { new RegExp(p); return true; } catch { return false; }
+      })
+    : [];
+  s.patterns = pats.length > 0 ? pats : [...DEFAULT_SAFEGUARD.patterns];
+  s.maxRetries = validNumber(s.maxRetries, 1, DEFAULT_SAFEGUARD.maxRetries);
+  s.retryDelaySeconds = validNumber(s.retryDelaySeconds, 1, DEFAULT_SAFEGUARD.retryDelaySeconds);
+  if (typeof s.retryMessage !== 'string' || !s.retryMessage) {
+    s.retryMessage = DEFAULT_SAFEGUARD.retryMessage;
+  }
+  return s;
+}
+
 function validate(cfg) {
   cfg.maxRetries = validNumber(cfg.maxRetries, 1, DEFAULT_CONFIG.maxRetries);
   cfg.pollIntervalSeconds = validNumber(cfg.pollIntervalSeconds, 1, DEFAULT_CONFIG.pollIntervalSeconds);
@@ -124,6 +161,7 @@ function validate(cfg) {
     }
   }
   cfg.overload = validateOverload(cfg.overload);
+  cfg.safeguard = validateSafeguard(cfg.safeguard);
   return cfg;
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -50,8 +50,10 @@ export const DEFAULT_OVERLOAD = {
 // loop forever. See README "Safeguard retry".
 export const DEFAULT_SAFEGUARD = {
   enabled: true,
-  // Anchored, case-insensitive regexes matched against the pane tail (see detectSafeguard).
-  // Match the stable phrases of the safeguard render, not the model name (which varies).
+  // Case-insensitive regexes matched against the pane tail; a match only counts with an
+  // `API Error` line nearby (see safeguardMatch) so quoting/discussing these phrases in
+  // conversation can't trigger a retry. Match the stable phrases of the render, not the
+  // model name (which varies).
   patterns: [
     "safeguards flagged this message",
     "can't respond to this request with",   // "Claude Code can't respond to this request with <model>"

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -54,6 +54,7 @@ function resetOverload(state) {
 function resetSafeguard(state) {
   state.safeguardAttempts = 0;
   state.safeguardWaitUntil = 0;
+  state._safeguardGaveUp = false;
 }
 
 // Foreground safety: is claude/node the foreground process (safe to send-keys), or did
@@ -299,7 +300,15 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     if (isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) {
       resetSafeguard(state); return enterUsageWait(state, stripped, config);
     }
-    if (isWorking(stripped)) { resetSafeguard(state); state.status = 'monitoring'; return 'safeguard-cleared'; }
+    // In flight (our retry, or the user typing continued things). Defer WITHOUT consuming
+    // or resetting — a tick landing mid-retry must not zero the counter, or a sticky flag
+    // re-enters with a fresh budget and the maxRetries bound never trips (verified: it
+    // retried indefinitely). Mirrors the overload branch. Recovery is decided at the next
+    // idle tick: flag gone -> cleared; flag still there -> the count stands.
+    if (isWorking(stripped)) {
+      state.safeguardWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 2);
+      return 'safeguard-working';
+    }
 
     // Flag gone → recovered.
     if (!detectSafeguard(stripped, safeguard.patterns)) {
@@ -310,6 +319,10 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // the stale error every tick.
     if (state.safeguardAttempts >= safeguard.maxRetries) {
       state.safeguardWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      // Give up LOUDLY — once. Subsequent holds are silent or the warn re-logs ~1/min
+      // for as long as the sticky banner sits at the prompt.
+      if (state._safeguardGaveUp) return 'safeguard-holding';
+      state._safeguardGaveUp = true;
       return 'safeguard-gave-up';
     }
 

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,4 +1,4 @@
-import { stripAnsi, isRateLimited, findRateLimitMessage, isRateLimitOptionsPrompt, menuStepsToWaitOption, detectOverload, overloadMatch, isWorking } from './patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, isRateLimitOptionsPrompt, menuStepsToWaitOption, detectOverload, overloadMatch, detectSafeguard, safeguardMatch, isWorking } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
 import { capturePane, sendKeys, sendKey, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
@@ -21,6 +21,8 @@ export function createMonitorState() {
     // seen (proves the hook is live → stop trusting the scraper). viaEvent marks the
     // current backoff window as event-triggered (edge: one send per failure).
     eventMode: false, viaEvent: false,
+    // Safeguard/AUP false-positive retry sub-state (bounded, seconds-scale).
+    safeguardAttempts: 0, safeguardWaitUntil: 0,
   };
 }
 
@@ -47,6 +49,11 @@ function resetOverload(state) {
   state.overloadTotalWaitMs = 0;
   state.overloadWaitUntil = 0;
   state.viaEvent = false;
+}
+
+function resetSafeguard(state) {
+  state.safeguardAttempts = 0;
+  state.safeguardWaitUntil = 0;
 }
 
 // Foreground safety: is claude/node the foreground process (safe to send-keys), or did
@@ -283,6 +290,44 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     return 'overload-retried';
   }
 
+  if (state.status === 'safeguard') {
+    if (Date.now() < state.safeguardWaitUntil) return 'safeguard-waiting';
+    if (!isAlive()) return 'exit';
+    const safeguard = config.safeguard;
+
+    // A usage limit or Claude resuming takes precedence / means recovery.
+    if (isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) {
+      resetSafeguard(state); return enterUsageWait(state, stripped, config);
+    }
+    if (isWorking(stripped)) { resetSafeguard(state); state.status = 'monitoring'; return 'safeguard-cleared'; }
+
+    // Flag gone → recovered.
+    if (!detectSafeguard(stripped, safeguard.patterns)) {
+      resetSafeguard(state); state.status = 'monitoring'; return 'safeguard-cleared';
+    }
+
+    // Sticky flag: give up loudly rather than loop. Long cooldown so we don't re-detect
+    // the stale error every tick.
+    if (state.safeguardAttempts >= safeguard.maxRetries) {
+      state.safeguardWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      return 'safeguard-gave-up';
+    }
+
+    // Foreground safety: only send when claude/node is foreground.
+    const fg = await checkForeground(tmuxAdapter, pane, config);
+    if (!fg.ok) {
+      state._lastForeground = fg.fg;
+      state.safeguardWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 6);
+      return 'skipped-not-claude';
+    }
+
+    // Increment + schedule BEFORE send so a send failure still consumes the slot.
+    state.safeguardAttempts++;
+    state.safeguardWaitUntil = Date.now() + (safeguard.retryDelaySeconds * 1000);
+    await tmuxAdapter.sendKeys(pane, safeguard.retryMessage);
+    return 'safeguard-retried';
+  }
+
   // --- monitoring ---
   // Usage-limit (hours-scale reset) takes precedence over overload (seconds-scale).
   if (isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) {
@@ -316,6 +361,20 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     if (match) {
       state._overloadMatch = match;  // surfaced in the 'overload-detected' log line
       return enterOverload(state, overload, rand);
+    }
+  }
+
+  // Safeguard/AUP false-positive: enter a bounded, seconds-scale retry loop. Independent
+  // of the overload path (different render, different recovery). Only when Claude is idle.
+  const safeguard = config.safeguard;
+  if (safeguard && safeguard.enabled && !isWorking(stripped)) {
+    const match = safeguardMatch(stripped, safeguard.patterns);
+    if (match) {
+      resetSafeguard(state);
+      state.status = 'safeguard';
+      state.safeguardWaitUntil = Date.now() + (safeguard.retryDelaySeconds * 1000);
+      state._safeguardMatch = match;
+      return 'safeguard-detected';
     }
   }
 
@@ -378,6 +437,13 @@ export async function startMonitor(pane, pid) {
       if (result === 'overload-relaunched') await logger.warn(`Claude exited to shell on overload; relaunched via "${config.overload.relaunchCommand}" (relaunchOnExit on, attempt ${state.overloadAttempts}).`);
       if (result === 'overload-exited-to-shell') await logger.warn(`Overload error left claude exited to the shell ("${state._lastForeground}"). Not auto-relaunching (relaunchOnExit off). Re-run "claude --continue" to resume, or set overload.relaunchOnExit:true.`);
       if (result === 'overload-gave-up') await logger.warn(`Overload backoff cap reached (maxTotalWaitMinutes=${config.overload.maxTotalWaitMinutes}). Giving up — endpoint may be genuinely down (check status.claude.com). Will not retry until the error clears.`);
+      if (result === 'safeguard-detected') {
+        const m = state._safeguardMatch;
+        await logger.warn(`Safeguard/AUP flag detected${m ? ` [matched /${m.pattern}/ in: "${m.line}"]` : ''} — often a false positive. Will retry up to ${config.safeguard.maxRetries}x every ${config.safeguard.retryDelaySeconds}s.`);
+      }
+      if (result === 'safeguard-retried') await logger.info(`Safeguard retry sent (attempt ${state.safeguardAttempts}/${config.safeguard.maxRetries}).`);
+      if (result === 'safeguard-cleared') await logger.info('Safeguard flag cleared. Resuming normal monitoring.');
+      if (result === 'safeguard-gave-up') await logger.warn(`Safeguard flag persisted after ${config.safeguard.maxRetries} retries. Giving up — the flag is likely sticky for this content/model; try /model to switch models or rephrase. Will not retry until it clears.`);
     } catch (err) {
       consecutiveErrors++;
       await logger.error(`Monitor tick error: ${err.message}`).catch(() => {});

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -189,6 +189,32 @@ export function detectOverload(text, patterns = []) {
   return overloadMatch(text, patterns) !== null;
 }
 
+// --- Safeguard / AUP false-positive detection ---
+// A distinct failure mode from usage limits and 5xx overloads: the model's safeguards
+// flag the message (often a false positive — the error itself says it "may flag safe,
+// normal content"). It renders like:
+//   ● API Error: Fable 5's safeguards flagged this message (…/legal/aup). … Claude Code
+//     can't respond to this request with Fable 5.
+//     Double press esc to edit your last message, or try a different model with /model.
+// Because the flag is semi-random, an immediate re-send frequently clears it — but it
+// must be capped so a *sticky* flag doesn't loop forever. Tail-anchored like the others.
+export function safeguardMatch(text, patterns = []) {
+  if (!patterns || patterns.length === 0) return null;
+  const lines = tail(text);
+  if (!lines.join('').trim()) return null;
+  const regexes = toRegexes(patterns);
+  for (const line of lines) {
+    for (const r of regexes) {
+      if (r.test(line)) return { pattern: r.source, line: line.trim().slice(0, 200) };
+    }
+  }
+  return null;
+}
+
+export function detectSafeguard(text, patterns = []) {
+  return safeguardMatch(text, patterns) !== null;
+}
+
 export function isWorking(text) {
   const lines = tail(text);
   return lines.some(line => WORKING_PATTERNS.some(p => p.test(line)));

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -198,14 +198,23 @@ export function detectOverload(text, patterns = []) {
 //     Double press esc to edit your last message, or try a different model with /model.
 // Because the flag is semi-random, an immediate re-send frequently clears it — but it
 // must be capped so a *sticky* flag doesn't loop forever. Tail-anchored like the others.
+// Anchor: a REAL flag always renders as an `API Error:` line. Requiring it nearby (same
+// wrap-tolerant window isRateLimited uses for limit/resets pairing) keeps the phrases
+// from firing on ordinary conversation — Claude quoting the AUP link or discussing
+// safeguard errors at an idle prompt must not trigger a retry. (DEFAULT_OVERLOAD learned
+// this the hard way; see its comment about bare status numbers.)
+const SAFEGUARD_ANCHOR = [/\bAPI Error\b/i];
+
 export function safeguardMatch(text, patterns = []) {
   if (!patterns || patterns.length === 0) return null;
   const lines = tail(text);
   if (!lines.join('').trim()) return null;
   const regexes = toRegexes(patterns);
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
     for (const r of regexes) {
-      if (r.test(line)) return { pattern: r.source, line: line.trim().slice(0, 200) };
+      if (r.test(lines[i]) && hasNearbyMatch(lines, i, SAFEGUARD_ANCHOR)) {
+        return { pattern: r.source, line: lines[i].trim().slice(0, 200) };
+      }
     }
   }
   return null;

--- a/test/safeguard.test.js
+++ b/test/safeguard.test.js
@@ -1,0 +1,167 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectSafeguard, safeguardMatch, isWorking } from '../src/patterns.js';
+import { loadConfig, DEFAULT_CONFIG, DEFAULT_SAFEGUARD } from '../src/config.js';
+import { createMonitorState, processOneTick } from '../src/monitor.js';
+
+const PATS = DEFAULT_SAFEGUARD.patterns;
+
+function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
+  const t = {
+    _sent: [],
+    capturePane: async () => paneContent,
+    getPaneCommand: async () => paneCommand,
+    sendKeys: async (_p, text) => { t._sent.push(text); },
+    sendKey: async () => {},
+    isClaudeForeground: async () => claudeForeground,
+  };
+  return t;
+}
+
+function cfg(overrides = {}) {
+  return { ...DEFAULT_CONFIG, safeguard: { ...DEFAULT_SAFEGUARD, ...overrides } };
+}
+
+// The real render, verbatim-ish.
+const FLAG = [
+  '❯ continue',
+  '',
+  "● API Error: Fable 5's safeguards flagged this message (https://www.anthropic.com/legal/aup). They may flag safe, normal content as well. Claude Code can't respond to this request with Fable 5.",
+  '  Double press esc to edit your last message, or try a different model with /model.',
+  '  Request ID: req_011Ccfhw8avogXF48ed42Xjt',
+  '❯ ',
+].join('\n');
+
+describe('detectSafeguard', () => {
+  it('matches the safeguards-flagged render', () => assert.equal(detectSafeguard(FLAG, PATS), true));
+  it('matches the "can\'t respond to this request with" phrasing', () =>
+    assert.equal(detectSafeguard("Claude Code can't respond to this request with Opus 4.8.", PATS), true));
+  it('matches the AUP link', () => assert.equal(detectSafeguard('see https://www.anthropic.com/legal/aup', PATS), true));
+  it('is case-insensitive', () => assert.equal(detectSafeguard('SAFEGUARDS FLAGGED THIS MESSAGE', PATS), true));
+  it('returns false for normal output', () => assert.equal(detectSafeguard('Here is the refactor you asked for.', PATS), false));
+  it('returns false for empty patterns/text', () => {
+    assert.equal(detectSafeguard(FLAG, []), false);
+    assert.equal(detectSafeguard('', PATS), false);
+  });
+  it('does NOT fire on the phrase quoted far up in scrollback (tail-anchored)', () => {
+    const pane = ['discussing safeguards flagged this message', ...Array(15).fill('● unrelated work'), '❯ '].join('\n');
+    assert.equal(detectSafeguard(pane, PATS), false);
+  });
+  it('reports the matched pattern + line', () => {
+    const m = safeguardMatch(FLAG, PATS);
+    assert.ok(m && /safeguards flagged/.test(m.pattern));
+    assert.ok(m.line.length <= 200);
+  });
+});
+
+describe('safeguard config validation', () => {
+  async function loadFrom(obj) {
+    const { writeFile, unlink } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const f = join(tmpdir(), `car-sg-${Date.now()}-${Math.round(Math.random() * 1e6)}.json`);
+    await writeFile(f, JSON.stringify(obj));
+    try { return await loadConfig(f); } finally { await unlink(f); }
+  }
+  it('is present on DEFAULT_CONFIG with a small retry cap', () => {
+    assert.equal(DEFAULT_CONFIG.safeguard.enabled, true);
+    assert.equal(DEFAULT_CONFIG.safeguard.maxRetries, 3);
+    assert.ok(DEFAULT_CONFIG.safeguard.patterns.includes('safeguards flagged this message'));
+  });
+  it('merges a partial block onto defaults', async () => {
+    const c = await loadFrom({ safeguard: { maxRetries: 1 } });
+    assert.equal(c.safeguard.maxRetries, 1);
+    assert.deepEqual(c.safeguard.patterns, DEFAULT_SAFEGUARD.patterns);
+  });
+  it('falls back on bad values', async () => {
+    const c = await loadFrom({ safeguard: { maxRetries: -1, retryDelaySeconds: 0, patterns: [42] } });
+    assert.equal(c.safeguard.maxRetries, DEFAULT_SAFEGUARD.maxRetries);
+    assert.equal(c.safeguard.retryDelaySeconds, DEFAULT_SAFEGUARD.retryDelaySeconds);
+    assert.deepEqual(c.safeguard.patterns, DEFAULT_SAFEGUARD.patterns);
+  });
+});
+
+const near = (actual, expectedMs) => Math.abs(actual - expectedMs) < 2000;
+
+describe('processOneTick — safeguard path', () => {
+  it('enters the safeguard wait on detection (no send yet)', async () => {
+    const t = mockTmux(FLAG);
+    const s = createMonitorState();
+    const r = await processOneTick(s, t, '%0', cfg(), () => true);
+    assert.equal(r, 'safeguard-detected');
+    assert.equal(s.status, 'safeguard');
+    assert.equal(t._sent.length, 0);
+    assert.ok(near(s.safeguardWaitUntil - Date.now(), DEFAULT_SAFEGUARD.retryDelaySeconds * 1000));
+  });
+
+  it('sends the retry once the delay elapses', async () => {
+    const t = mockTmux(FLAG);
+    const s = createMonitorState();
+    s.status = 'safeguard'; s.safeguardWaitUntil = Date.now() - 1;
+    const r = await processOneTick(s, t, '%0', cfg(), () => true);
+    assert.equal(r, 'safeguard-retried');
+    assert.equal(t._sent[0], 'continue');
+    assert.equal(s.safeguardAttempts, 1);
+  });
+
+  it('is BOUNDED — gives up after maxRetries instead of looping', async () => {
+    const t = mockTmux(FLAG);
+    const s = createMonitorState();
+    const c = cfg({ maxRetries: 2, retryDelaySeconds: 1 });
+    // detect
+    await processOneTick(s, t, '%0', c, () => true);
+    // two retries
+    for (let i = 0; i < 2; i++) { s.safeguardWaitUntil = Date.now() - 1; await processOneTick(s, t, '%0', c, () => true); }
+    assert.equal(s.safeguardAttempts, 2);
+    assert.equal(t._sent.length, 2);
+    // third pass → give up, no further send
+    s.safeguardWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', c, () => true), 'safeguard-gave-up');
+    assert.equal(t._sent.length, 2);
+  });
+
+  it('clears back to monitoring when the flag is gone', async () => {
+    const t = mockTmux('All good — here is your answer.');
+    const s = createMonitorState();
+    s.status = 'safeguard'; s.safeguardWaitUntil = Date.now() - 1; s.safeguardAttempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'safeguard-cleared');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(s.safeguardAttempts, 0);
+  });
+
+  it('clears if Claude has resumed working', async () => {
+    const t = mockTmux(FLAG + '\n✻ Thinking… (esc to interrupt)');
+    const s = createMonitorState();
+    s.status = 'safeguard'; s.safeguardWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'safeguard-cleared');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('does not send into a non-claude foreground', async () => {
+    const t = mockTmux(FLAG, 'vim', false);
+    const s = createMonitorState();
+    s.status = 'safeguard'; s.safeguardWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'skipped-not-claude');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('usage-limit takes precedence over a co-present safeguard flag', async () => {
+    const t = mockTmux(FLAG + '\nYou\'ve hit your session limit · resets 3pm (UTC)');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'waiting');
+    assert.equal(s.status, 'waiting');
+  });
+
+  it('does not enter safeguard while Claude is working', async () => {
+    const t = mockTmux(FLAG + '\n· Cooking… (esc to interrupt)');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'monitoring');
+  });
+
+  it('disabled safeguard block is ignored', async () => {
+    const t = mockTmux(FLAG);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg({ enabled: false }), () => true), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+});

--- a/test/safeguard.test.js
+++ b/test/safeguard.test.js
@@ -34,10 +34,25 @@ const FLAG = [
 
 describe('detectSafeguard', () => {
   it('matches the safeguards-flagged render', () => assert.equal(detectSafeguard(FLAG, PATS), true));
-  it('matches the "can\'t respond to this request with" phrasing', () =>
-    assert.equal(detectSafeguard("Claude Code can't respond to this request with Opus 4.8.", PATS), true));
-  it('matches the AUP link', () => assert.equal(detectSafeguard('see https://www.anthropic.com/legal/aup', PATS), true));
-  it('is case-insensitive', () => assert.equal(detectSafeguard('SAFEGUARDS FLAGGED THIS MESSAGE', PATS), true));
+  it('matches the "can\'t respond to this request with" phrasing next to the API Error line', () =>
+    assert.equal(detectSafeguard([
+      "● API Error: Fable 5's safeguards flagged this message",
+      "  (https://www.anthropic.com/legal/aup). Claude Code can't respond to this request with Fable 5.",
+    ].join('\n'), PATS), true));
+  it('matches a wrapped render (phrase on a different physical line than "API Error")', () =>
+    assert.equal(detectSafeguard([
+      '● API Error: Fable',
+      "  5's safeguards flagged",
+      '  this message (https://www.anthropic.com/legal/aup).',
+    ].join('\n'), PATS), true));
+  it('is case-insensitive', () =>
+    assert.equal(detectSafeguard('API ERROR: SAFEGUARDS FLAGGED THIS MESSAGE', PATS), true));
+  it('does NOT fire on the phrases without the API Error render nearby (anti false-positive anchor)', () => {
+    // Regression: Claude ANSWERING a question about AUP flags must not trigger a retry.
+    assert.equal(detectSafeguard('see https://www.anthropic.com/legal/aup for the policy', PATS), false);
+    assert.equal(detectSafeguard("Claude Code can't respond to this request with Opus 4.8.", PATS), false);
+    assert.equal(detectSafeguard('they said safeguards flagged this message yesterday', PATS), false);
+  });
   it('returns false for normal output', () => assert.equal(detectSafeguard('Here is the refactor you asked for.', PATS), false));
   it('returns false for empty patterns/text', () => {
     assert.equal(detectSafeguard(FLAG, []), false);
@@ -129,11 +144,64 @@ describe('processOneTick — safeguard path', () => {
     assert.equal(s.safeguardAttempts, 0);
   });
 
-  it('clears if Claude has resumed working', async () => {
+  it('defers while Claude is working — WITHOUT resetting the attempt counter', async () => {
+    // Regression: a tick landing while the retried request is in flight used to reset
+    // safeguardAttempts to 0 via the clear path, so a sticky flag re-entered with a fresh
+    // budget every cycle and the maxRetries bound never tripped (observed: 10+ sends with
+    // maxRetries=3). Mirror the overload branch: defer without consuming or resetting.
     const t = mockTmux(FLAG + '\n✻ Thinking… (esc to interrupt)');
     const s = createMonitorState();
-    s.status = 'safeguard'; s.safeguardWaitUntil = Date.now() - 1;
-    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'safeguard-cleared');
+    s.status = 'safeguard'; s.safeguardWaitUntil = Date.now() - 1; s.safeguardAttempts = 2;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'safeguard-working');
+    assert.equal(s.safeguardAttempts, 2);   // NOT reset
+    assert.equal(s.status, 'safeguard');    // still owns the flag
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('stays BOUNDED even when working ticks interleave between retries (sticky flag)', async () => {
+    const c = cfg({ maxRetries: 2, retryDelaySeconds: 1 });
+    const flagged = mockTmux(FLAG);
+    const s = createMonitorState();
+    await processOneTick(s, flagged, '%0', c, () => true);            // detect
+    let sent = 0;
+    for (let i = 0; i < 10; i++) {
+      // alternate: retry tick at idle-with-flag, then a mid-flight (working) tick
+      s.safeguardWaitUntil = Date.now() - 1;
+      const idle = mockTmux(FLAG);
+      const r1 = await processOneTick(s, idle, '%0', c, () => true);
+      sent += idle._sent.length;
+      s.safeguardWaitUntil = Date.now() - 1;
+      const working = mockTmux(FLAG + '\n✻ Thinking… (esc to interrupt)');
+      await processOneTick(s, working, '%0', c, () => true);
+      sent += working._sent.length;
+      if (r1 === 'safeguard-gave-up' || r1 === 'safeguard-holding') break;
+    }
+    assert.equal(sent, 2);                  // exactly maxRetries sends, ever
+    assert.equal(s.safeguardAttempts, 2);
+  });
+
+  it('gives up loudly ONCE, then holds quietly', async () => {
+    const c = cfg({ maxRetries: 1 });
+    const t = mockTmux(FLAG);
+    const s = createMonitorState();
+    s.status = 'safeguard'; s.safeguardWaitUntil = Date.now() - 1; s.safeguardAttempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', c, () => true), 'safeguard-gave-up');
+    s.safeguardWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', c, () => true), 'safeguard-holding');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('does not inject into a healthy session whose reply mentions the AUP link at an idle prompt', async () => {
+    // Regression: unanchored patterns fired on Claude ANSWERING a question about AUP flags.
+    const pane = [
+      '● The safeguard error you saw means the model flagged the message. See',
+      '  https://www.anthropic.com/legal/aup for the policy. It can be a false positive.',
+      '',
+      '❯ ',
+    ].join('\n');
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'monitoring');
     assert.equal(t._sent.length, 0);
   });
 


### PR DESCRIPTION
Adds a third recovery path alongside usage-limit waits and 5xx overload backoff: the model's **safeguards flagging a message**, which Claude Code renders as

```
● API Error: <model>'s safeguards flagged this message (…/legal/aup). They may flag
  safe, normal content as well. … Claude Code can't respond to this request with <model>.
  Double press esc to edit your last message, or try a different model with /model.
```

The error itself notes these "may flag safe, normal content" — they're often false positives and semi-random, so an **immediate re-send frequently clears them**. But a *sticky* flag (genuinely blocked content/model) must not loop.

**Behavior.** On detecting the render at an idle prompt, the monitor sends a short retry message (`continue`), waits `retryDelaySeconds`, and repeats — capped at `maxRetries` (default **3**), then gives up loudly (logged) rather than looping. Foreground-gated and tail-anchored (last 12 pane lines) like the overload path, so the phrase in scrollback or in a conversation *about* safeguards won't trigger it. Usage limits take precedence; a flag co-present while Claude is working is ignored.

Lifecycle (verified): `safeguard-detected → safeguard-retried ×3 → safeguard-gave-up` (exactly 3 sends).

**Config** — a new `safeguard` block with validation/fallbacks:
```json
{ "safeguard": { "enabled": true,
    "patterns": ["safeguards flagged this message", "can't respond to this request with", "legal/aup"],
    "maxRetries": 3, "retryDelaySeconds": 8, "retryMessage": "continue" } }
```

+20 tests; README "Safeguard retry" section. Zero deps.