### PR TITLE
feat(cli): add `reconcile` — re-arm monitors for all live claude panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/usage-credits` hint) before reading the live tail, so a genuine banner behind a tall
   task widget is still detected (fixes a ~54-min stall) while a banner merely quoted in
   scrollback is not (#34).
+- **`reconcile` / `install-timer` / `exclude-self`** for self-healing monitor coverage: a
+  monitor killed (or a `claude` started outside the wrapper) is re-armed from live tmux +
+  process state, on demand or via a `systemd --user` timer (#32).
 - Safeguard/AUP false-positive auto-retry: when the model's safeguards flag a
   message ("safeguards flagged this message"), re-send a short retry up to
   `safeguard.maxRetries` times, then give up loudly once. Detection is anchored
@@ -47,6 +50,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chrome classifiers are anchored to real footer/widget renders (pipe-anchored version,
   indented task items, `⏵⏵` mode footer), so ordinary content — `Press ctrl+c…`, a
   `→` rename, a flush-left `✓ …` summary, `Released v0.5.1` — is no longer stripped (#34).
+- `install-timer` no longer crashes on npm installs — `systemd/` is shipped in the package
+  and the template reads fail with a clear message instead of ENOENT (#32).
+- `reconcile` distinguishes a real `pgrep` failure (ENOENT, busybox without `-a`, macOS
+  PID-only output) from "no monitors running", and aborts loudly rather than arming a
+  duplicate monitor per pane every run (#32).
+- Monitor coverage is keyed per-pane, so a stopped `claude` keeping its monitor can't lead
+  to a second monitor on the same pane (#32).
+- A single-instance lock (pid + start-token identity) stops an overlapping manual + timer
+  run from double-spawning, and can't wedge on PID reuse (#32).
+- Exclude-file PID entries are pruned when dead, so kernel PID reuse can't permanently mute
+  a future session (the self-expiring behavior the docs promised) (#32).
+- Print-mode panes (`claude -p` / `--print`) are no longer given a send-keys monitor (#32).
+- The generated systemd unit quotes the node/CLI paths (spaces no longer break it), drops
+  the no-op `Persistent=true`, and `install-timer` prints an nvm re-run caveat (#32).
 - `rate_limit` StopFailure events are no longer routed through the seconds-scale
   overload path — a session/usage limit is an hours-scale wait owned by the
   usage path, and the misroute made the two fight (futile `Continue` retries
@@ -56,6 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `customPatterns` are matched against the raw last-N lines (unchanged from pre-#34
   semantics), not the chrome-skipped view — the user owns their own tradeoff (#34).
+- Removed the dead `CLAUDE_COMMANDS` constant; documented that reconcile matches
+  `comm === 'claude'` (a bare-`node` session without `process.title` isn't detected) (#32).
 
 ## [0.5.1] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -440,9 +440,12 @@ is started outside the wrapper — that session ends up unmonitored, and only *n
 sessions get a monitor. Two commands restore and maintain full coverage:
 
 - **`reconcile`** re-arms a monitor for every live tmux pane running `claude` that isn't
-  already covered. It maps each `claude` to its pane from live process state, skips
-  panes already monitored (idempotent — safe to run anytime), and handles tmux pane-id
-  reuse. Run it after a crash, or use `--dry-run` to see what it would do.
+  already covered. It maps each `claude` to its pane from live process state, keeps one
+  monitor per pane (idempotent — safe to run anytime, and a single-instance lock stops an
+  overlapping manual+timer run from double-arming), and handles tmux pane-id reuse. Print-
+  mode sessions (`claude -p`) are skipped, and a `claude` that doesn't set its process
+  title to `claude` (a bare `node` shebang) isn't detected — use the wrapper for those.
+  Run it after a crash, or use `--dry-run` to see what it would do.
 - **`install-timer`** wires `reconcile` to a `systemd --user` timer that runs every 5
   minutes, so a monitor that dies is re-armed within one interval — coverage self-heals
   with no manual step. (Enable `loginctl enable-linger $USER` once if you want it to run

--- a/README.md
+++ b/README.md
@@ -452,10 +452,11 @@ sessions get a monitor. Two commands restore and maintain full coverage:
 pasting rate-limit text and don't want any auto-retry), run `claude-auto-retry
 exclude-self` from inside it. This records the session's `claude` PID in
 `~/.claude-auto-retry/reconcile-exclude`; both `reconcile` and the timer skip it. Keying
-on the PID makes the entry **self-expiring** — once that `claude` exits it matches
-nothing, so it can never accidentally mute a later session (tmux reuses pane ids, so a
-pane-based exclude could). You can also hand-add a `%pane` id or a PID to that file.
->>>>>>> 3113474 (docs(readme): document reconcile, install-timer, exclude-self + monitor coverage)
+on the PID makes the entry **self-expiring**: dead PIDs are pruned when the file is read,
+so once that `claude` exits its entry is dropped and can never accidentally mute a later
+session (tmux reuses pane ids, so a hand-added `%pane` exclude could — pane ids are not
+pruned, since staleness can't be detected). Prefer the PID form; you can also hand-add a
+`%pane` id or a PID to that file.
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ When you disconnect (SSH drops, close terminal, laptop sleeps), **tmux keeps run
 - **Timezone-aware** — parses reset times with full IANA timezone support (including half-hour offsets)
 - **DST-safe** — iterative offset correction handles daylight saving transitions
 - **Safe send-keys** — verifies Claude is still the foreground process before injecting text
+- **Self-healing coverage** — `reconcile` re-arms monitors for any live `claude` session that lost one; an optional `systemd --user` timer runs it automatically ([details](#keeping-monitors-alive))
 - **Overload backoff** — detects sustained API overload (`429/500/502/503/504/529`) and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff))
 - **Safeguard retry** — auto-continues past an AUP-safeguard false-positive (often transient), capped at a few tries so a sticky flag can't loop ([details](#safeguard-retry))
 - **tmux status bar indicator** — see at a glance whether a pane is being monitored, waiting on a reset, backing off from overload, or has given up ([details](#tmux-status-bar-indicator))
@@ -390,11 +391,22 @@ default `pollIntervalSeconds`) keeps the overload countdown responsive.
 ## CLI Commands
 
 ```bash
-claude-auto-retry install     # Install shell wrapper + tmux
-claude-auto-retry uninstall   # Remove shell wrapper
-claude-auto-retry status      # Show monitor activity + last log entries
-claude-auto-retry logs        # Tail today's log file in real-time
-claude-auto-retry version     # Print version
+claude-auto-retry install          # Install shell wrapper + tmux
+claude-auto-retry uninstall        # Remove shell wrapper
+claude-auto-retry status           # Show monitor activity + last log entries
+claude-auto-retry logs             # Tail today's log file in real-time
+claude-auto-retry version          # Print version
+
+# Event-driven overload detection (optional; see "Overload backoff")
+claude-auto-retry install-hook [dir]    # Install the StopFailure hook into a config dir
+claude-auto-retry uninstall-hook [dir]  # Remove it
+
+# Monitor coverage (see "Keeping monitors alive")
+claude-auto-retry reconcile        # Re-arm a monitor for every live claude pane not covered
+claude-auto-retry reconcile --dry-run   # Preview without arming
+claude-auto-retry install-timer    # systemd --user timer: run reconcile every 5 min
+claude-auto-retry uninstall-timer  # Remove the timer
+claude-auto-retry exclude-self     # Keep THIS session unmonitored (durable, self-expiring)
 ```
 
 ## For AI Agents
@@ -419,6 +431,31 @@ Notes for agents:
   back to defaults instead of crashing.
 - If the user runs multiple `CLAUDE_CONFIG_DIR`s, repeat `claude-auto-retry install-hook <path>` per dir.
 - Clean removal: `claude-auto-retry uninstall` and `claude-auto-retry uninstall-hook`.
+
+## Keeping monitors alive
+
+Each `claude` you launch through the wrapper gets its own background monitor. Monitors
+are detached processes with no supervising service, so if one is killed — or a `claude`
+is started outside the wrapper — that session ends up unmonitored, and only *new*
+sessions get a monitor. Two commands restore and maintain full coverage:
+
+- **`reconcile`** re-arms a monitor for every live tmux pane running `claude` that isn't
+  already covered. It maps each `claude` to its pane from live process state, skips
+  panes already monitored (idempotent — safe to run anytime), and handles tmux pane-id
+  reuse. Run it after a crash, or use `--dry-run` to see what it would do.
+- **`install-timer`** wires `reconcile` to a `systemd --user` timer that runs every 5
+  minutes, so a monitor that dies is re-armed within one interval — coverage self-heals
+  with no manual step. (Enable `loginctl enable-linger $USER` once if you want it to run
+  while logged out.)
+
+**Excluding a session.** To keep a specific session *unmonitored* (e.g. one where you're
+pasting rate-limit text and don't want any auto-retry), run `claude-auto-retry
+exclude-self` from inside it. This records the session's `claude` PID in
+`~/.claude-auto-retry/reconcile-exclude`; both `reconcile` and the timer skip it. Keying
+on the PID makes the entry **self-expiring** — once that `claude` exits it matches
+nothing, so it can never accidentally mute a later session (tmux reuses pane ids, so a
+pane-based exclude could). You can also hand-add a `%pane` id or a PID to that file.
+>>>>>>> 3113474 (docs(readme): document reconcile, install-timer, exclude-self + monitor coverage)
 
 ## Platform Support
 
@@ -505,7 +542,7 @@ npm link            # Install locally for testing
 
 ```
 claude-auto-retry/
-├── bin/cli.js              # CLI: install/uninstall/status/logs/version
+├── bin/cli.js              # CLI: install, hook, reconcile, timer, status, logs, ...
 ├── src/
 │   ├── patterns.js         # Rate limit + overload detection + ANSI stripping
 │   ├── time-parser.js      # Reset time parsing with timezone support
@@ -513,9 +550,12 @@ claude-auto-retry/
 │   ├── logger.js           # File-based logging with rotation
 │   ├── tmux.js             # tmux command wrappers (execFile-based)
 │   ├── monitor.js          # Core monitoring loop + retry logic (usage + overload paths)
+│   ├── events.js           # StopFailure hook event channel (scrape-free overload trigger)
+│   ├── reconcile.js        # Re-arm monitors for all live claude panes + exclusion
 │   ├── launcher.js         # Process orchestration + signal forwarding
 │   └── wrapper.sh          # Shell function template
-├── test/                   # 128 tests across 8 test files
+├── systemd/                # systemd --user units for the reconcile timer
+├── test/                   # tests across the src modules
 ├── package.json
 ├── LICENSE
 └── README.md

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -276,6 +276,12 @@ function userUnitDir() {
   return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'systemd', 'user');
 }
 
+// Substitute the node/CLI paths into a unit template. The template quotes the placeholders
+// (see the .service), so a path with spaces produces a valid quoted ExecStart.
+export function renderReconcileUnit(template, nodePath, cliPath) {
+  return template.replace(/__NODE_PATH__/g, nodePath).replace(/__CLI_PATH__/g, cliPath);
+}
+
 // Install the reconcile service+timer into the systemd --user unit dir, substituting the
 // node and CLI paths, then enable+start the timer. Makes monitor coverage self-healing:
 // every 5 min a missing monitor is re-armed. Requires systemd --user (Linux).
@@ -285,11 +291,18 @@ async function cmdInstallTimer() {
   const nodePath = process.execPath;
   const cliPath = __filename;
 
-  const svc = (await readFile(join(SYSTEMD_DIR, UNIT_SERVICE), 'utf-8'))
-    .replace(/__NODE_PATH__/g, nodePath)
-    .replace(/__CLI_PATH__/g, cliPath);
-  await writeFile(join(dest, UNIT_SERVICE), svc);
-  await writeFile(join(dest, UNIT_TIMER), await readFile(join(SYSTEMD_DIR, UNIT_TIMER), 'utf-8'));
+  let svcTemplate, timerTemplate;
+  try {
+    svcTemplate = await readFile(join(SYSTEMD_DIR, UNIT_SERVICE), 'utf-8');
+    timerTemplate = await readFile(join(SYSTEMD_DIR, UNIT_TIMER), 'utf-8');
+  } catch (err) {
+    console.error(`Could not read the systemd unit templates from ${SYSTEMD_DIR} (${err.code || err.message}).`);
+    console.error('If you installed from npm, upgrade to a version that ships the systemd/ directory,');
+    console.error('or run install-timer from a git checkout of the repo.');
+    process.exit(1);
+  }
+  await writeFile(join(dest, UNIT_SERVICE), renderReconcileUnit(svcTemplate, nodePath, cliPath));
+  await writeFile(join(dest, UNIT_TIMER), timerTemplate);
 
   try {
     execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'inherit' });
@@ -304,6 +317,8 @@ async function cmdInstallTimer() {
   console.log(`  next run: systemctl --user list-timers ${UNIT_TIMER}`);
   console.log(`  tip: for the timer to run while logged out, enable lingering once:`);
   console.log(`       loginctl enable-linger $USER`);
+  console.log(`\nNote: the unit pins this Node path (${nodePath}). If you switch Node`);
+  console.log(`versions (nvm), re-run: claude-auto-retry install-timer`);
 }
 
 async function cmdUninstallTimer() {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -266,6 +266,58 @@ async function cmdUninstallHook() {
   } catch { console.log('No settings file to modify.'); }
 }
 
+// --- systemd --user timer (self-healing monitor coverage) ---
+
+const SYSTEMD_DIR = join(SRC_DIR, '..', 'systemd');
+const UNIT_SERVICE = 'claude-auto-retry-reconcile.service';
+const UNIT_TIMER = 'claude-auto-retry-reconcile.timer';
+
+function userUnitDir() {
+  return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'systemd', 'user');
+}
+
+// Install the reconcile service+timer into the systemd --user unit dir, substituting the
+// node and CLI paths, then enable+start the timer. Makes monitor coverage self-healing:
+// every 5 min a missing monitor is re-armed. Requires systemd --user (Linux).
+async function cmdInstallTimer() {
+  const dest = userUnitDir();
+  await mkdir(dest, { recursive: true });
+  const nodePath = process.execPath;
+  const cliPath = __filename;
+
+  const svc = (await readFile(join(SYSTEMD_DIR, UNIT_SERVICE), 'utf-8'))
+    .replace(/__NODE_PATH__/g, nodePath)
+    .replace(/__CLI_PATH__/g, cliPath);
+  await writeFile(join(dest, UNIT_SERVICE), svc);
+  await writeFile(join(dest, UNIT_TIMER), await readFile(join(SYSTEMD_DIR, UNIT_TIMER), 'utf-8'));
+
+  try {
+    execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'inherit' });
+    execFileSync('systemctl', ['--user', 'enable', '--now', UNIT_TIMER], { stdio: 'inherit' });
+  } catch {
+    console.error(`\nUnits written to ${dest} but enabling failed. Enable manually:`);
+    console.error(`  systemctl --user daemon-reload && systemctl --user enable --now ${UNIT_TIMER}`);
+    process.exit(1);
+  }
+  console.log(`\nTimer installed and started. Monitor coverage now self-heals every 5 min.`);
+  console.log(`  status:  systemctl --user status ${UNIT_TIMER}`);
+  console.log(`  next run: systemctl --user list-timers ${UNIT_TIMER}`);
+  console.log(`  tip: for the timer to run while logged out, enable lingering once:`);
+  console.log(`       loginctl enable-linger $USER`);
+}
+
+async function cmdUninstallTimer() {
+  try {
+    execFileSync('systemctl', ['--user', 'disable', '--now', UNIT_TIMER], { stdio: 'inherit' });
+  } catch { /* not enabled — fine */ }
+  const dest = userUnitDir();
+  for (const u of [UNIT_TIMER, UNIT_SERVICE]) {
+    try { await (await import('node:fs/promises')).unlink(join(dest, u)); } catch { /* absent */ }
+  }
+  try { execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'inherit' }); } catch { /* ignore */ }
+  console.log('Timer removed. (Already-running monitors are unaffected.)');
+}
+
 // Re-arm a monitor for every live tmux pane running claude that isn't already covered.
 // Restores coverage after a crash/kill or for sessions started outside the wrapper.
 async function cmdReconcile() {
@@ -310,6 +362,8 @@ switch (command) {
   case 'uninstall-hook': await cmdUninstallHook(); break;
   case HOOK_MARKER: await cmdStopFailureHook(); break;
   case 'reconcile': await cmdReconcile(); break;
+  case 'install-timer': await cmdInstallTimer(); break;
+  case 'uninstall-timer': await cmdUninstallTimer(); break;
   case 'status': await cmdStatus(); break;
   case 'logs': await cmdLogs(); break;
   case 'version': case '--version': case '-v': await cmdVersion(); break;
@@ -325,6 +379,9 @@ switch (command) {
     console.log('  claude-auto-retry reconcile          Re-arm a monitor for every live tmux');
     console.log('                                       claude session not already covered');
     console.log('                                       (--dry-run to preview). Run after a crash.');
+    console.log('  claude-auto-retry install-timer      Install a systemd --user timer that runs');
+    console.log('                                       reconcile every 5 min (self-healing coverage)');
+    console.log('  claude-auto-retry uninstall-timer    Remove the reconcile timer');
     console.log('  claude-auto-retry status             Show monitor status');
     console.log('  claude-auto-retry logs               Tail today\'s log');
     console.log('  claude-auto-retry version            Print version');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -349,6 +349,10 @@ async function cmdReconcile() {
     console.error('(needs a running tmux server; run from a machine with your claude sessions)');
     process.exit(1);
   }
+  if (result.locked) {
+    console.log('Another reconcile is already running (lock held). Nothing to do.');
+    return;
+  }
   const { armed, skipped } = result;
   if (armed.length === 0 && skipped.length === 0) {
     console.log('No tmux panes running claude found. Nothing to reconcile.');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ import { execFileSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { writeStopFailureEvent, isRetryableError } from '../src/events.js';
 import { sweepStaleStatus } from '../src/status-file.js';
-import { reconcile, excludeSelf } from '../src/reconcile.js';
+import { reconcile, excludeSelf, parseRunningMonitors } from '../src/reconcile.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -343,12 +343,11 @@ async function cmdExcludeSelf() {
     : `Excluded this session: claude PID ${r.pid} (pane ${r.pane}). reconcile/timer will skip it.`);
   console.log('The entry self-expires when this claude exits (no cleanup needed).');
   // Kill any monitor already covering this pane so exclusion takes effect immediately.
+  // Reuse parseRunningMonitors (same parser reconcile uses) instead of a bespoke one.
   try {
-    const out = execFileSync('pgrep', ['-af', `src/monitor\\.js ${r.pane} ${r.pid}`], { encoding: 'utf-8' });
-    for (const line of out.split('\n')) {
-      const mpid = line.trim().split(/\s+/)[0];
-      if (mpid && /^\d+$/.test(mpid)) { try { process.kill(Number(mpid)); console.log(`Stopped existing monitor ${mpid}.`); } catch {} }
-    }
+    const out = execFileSync('pgrep', ['-af', 'node .*src/monitor\\.js'], { encoding: 'utf-8' });
+    const mpid = parseRunningMonitors(out).get(`${r.pane} ${r.pid}`);
+    if (mpid) { try { process.kill(mpid); console.log(`Stopped existing monitor ${mpid}.`); } catch {} }
   } catch { /* no monitor running for this pane — nothing to stop */ }
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,6 +8,7 @@ import { execFileSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { writeStopFailureEvent, isRetryableError } from '../src/events.js';
 import { sweepStaleStatus } from '../src/status-file.js';
+import { reconcile } from '../src/reconcile.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -265,6 +266,31 @@ async function cmdUninstallHook() {
   } catch { console.log('No settings file to modify.'); }
 }
 
+// Re-arm a monitor for every live tmux pane running claude that isn't already covered.
+// Restores coverage after a crash/kill or for sessions started outside the wrapper.
+async function cmdReconcile() {
+  const dryRun = process.argv.includes('--dry-run');
+  let result;
+  try {
+    result = await reconcile({ dryRun });
+  } catch (err) {
+    console.error(`reconcile failed: ${err.message}`);
+    console.error('(needs a running tmux server; run from a machine with your claude sessions)');
+    process.exit(1);
+  }
+  const { armed, skipped } = result;
+  if (armed.length === 0 && skipped.length === 0) {
+    console.log('No tmux panes running claude found. Nothing to reconcile.');
+    return;
+  }
+  if (armed.length) {
+    console.log(dryRun ? `Would arm ${armed.length} monitor(s):` : `Armed ${armed.length} monitor(s):`);
+    for (const a of armed) console.log(`  ${a.pane} → claude ${a.pid}${a.monitorPid ? ` (monitor ${a.monitorPid})` : ''}`);
+  }
+  for (const s of skipped) console.log(`  ${s.pane} → claude ${s.pid}: skipped (${s.reason})`);
+  if (armed.length === 0) console.log('All live claude sessions already monitored.');
+}
+
 async function cmdVersion() {
   try {
     const pkg = JSON.parse(await readFile(join(__dirname, '..', 'package.json'), 'utf-8'));
@@ -283,6 +309,7 @@ switch (command) {
   case 'install-hook': await cmdInstallHook(); break;
   case 'uninstall-hook': await cmdUninstallHook(); break;
   case HOOK_MARKER: await cmdStopFailureHook(); break;
+  case 'reconcile': await cmdReconcile(); break;
   case 'status': await cmdStatus(); break;
   case 'logs': await cmdLogs(); break;
   case 'version': case '--version': case '-v': await cmdVersion(); break;
@@ -295,6 +322,9 @@ switch (command) {
     console.log('                                       overload detection) into <dir>/settings.json');
     console.log('                                       (default: $CLAUDE_CONFIG_DIR or ~/.claude)');
     console.log('  claude-auto-retry uninstall-hook [dir]  Remove the StopFailure hook');
+    console.log('  claude-auto-retry reconcile          Re-arm a monitor for every live tmux');
+    console.log('                                       claude session not already covered');
+    console.log('                                       (--dry-run to preview). Run after a crash.');
     console.log('  claude-auto-retry status             Show monitor status');
     console.log('  claude-auto-retry logs               Tail today\'s log');
     console.log('  claude-auto-retry version            Print version');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ import { execFileSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { writeStopFailureEvent, isRetryableError } from '../src/events.js';
 import { sweepStaleStatus } from '../src/status-file.js';
-import { reconcile } from '../src/reconcile.js';
+import { reconcile, excludeSelf } from '../src/reconcile.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -318,6 +318,25 @@ async function cmdUninstallTimer() {
   console.log('Timer removed. (Already-running monitors are unaffected.)');
 }
 
+// Durably exclude the current session from auto-monitoring (by its claude PID, which
+// is self-expiring and immune to tmux pane-id reuse). Run from inside the session.
+async function cmdExcludeSelf() {
+  const r = await excludeSelf();
+  if (!r.ok) { console.error(`exclude-self: ${r.reason}`); process.exit(1); }
+  console.log(r.already
+    ? `Already excluded (claude PID ${r.pid}, pane ${r.pane}).`
+    : `Excluded this session: claude PID ${r.pid} (pane ${r.pane}). reconcile/timer will skip it.`);
+  console.log('The entry self-expires when this claude exits (no cleanup needed).');
+  // Kill any monitor already covering this pane so exclusion takes effect immediately.
+  try {
+    const out = execFileSync('pgrep', ['-af', `src/monitor\\.js ${r.pane} ${r.pid}`], { encoding: 'utf-8' });
+    for (const line of out.split('\n')) {
+      const mpid = line.trim().split(/\s+/)[0];
+      if (mpid && /^\d+$/.test(mpid)) { try { process.kill(Number(mpid)); console.log(`Stopped existing monitor ${mpid}.`); } catch {} }
+    }
+  } catch { /* no monitor running for this pane — nothing to stop */ }
+}
+
 // Re-arm a monitor for every live tmux pane running claude that isn't already covered.
 // Restores coverage after a crash/kill or for sessions started outside the wrapper.
 async function cmdReconcile() {
@@ -362,6 +381,7 @@ switch (command) {
   case 'uninstall-hook': await cmdUninstallHook(); break;
   case HOOK_MARKER: await cmdStopFailureHook(); break;
   case 'reconcile': await cmdReconcile(); break;
+  case 'exclude-self': await cmdExcludeSelf(); break;
   case 'install-timer': await cmdInstallTimer(); break;
   case 'uninstall-timer': await cmdUninstallTimer(); break;
   case 'status': await cmdStatus(); break;
@@ -379,6 +399,8 @@ switch (command) {
     console.log('  claude-auto-retry reconcile          Re-arm a monitor for every live tmux');
     console.log('                                       claude session not already covered');
     console.log('                                       (--dry-run to preview). Run after a crash.');
+    console.log('  claude-auto-retry exclude-self       Keep THIS session unmonitored (durable,');
+    console.log('                                       by claude PID; self-expires on exit)');
     console.log('  claude-auto-retry install-timer      Install a systemd --user timer that runs');
     console.log('                                       reconcile every 5 min (self-healing coverage)');
     console.log('  claude-auto-retry uninstall-timer    Remove the reconcile timer');

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "type": "git",
     "url": "https://github.com/cheapestinference/claude-auto-retry"
   },
-  "files": ["bin/", "src/", "LICENSE", "README.md", "CHANGELOG.md", "llms.txt"]
+  "files": ["bin/", "src/", "systemd/", "LICENSE", "README.md", "CHANGELOG.md", "llms.txt"]
 }

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -86,6 +86,26 @@ export function parseRunningMonitors(out) {
   return covered;
 }
 
+// Interpret a pgrep invocation for the running-monitor probe. The ONLY benign failure is
+// exit code 1 with no output ("no processes matched") → zero monitors running. Every other
+// failure — ENOENT (pgrep absent), a non-1 exit (busybox usage error / no `-a` support), or
+// a success that yields no parseable monitor args (macOS/BSD `pgrep -af` prints PIDs only)
+// — means we CANNOT verify current coverage. Reporting "zero" there would arm a duplicate
+// monitor per pane on every timer fire (Finding 2), so we throw and let reconcile abort
+// loudly instead. `err` is the rejected-execFile error (with .code) or null on success.
+export function runningFromPgrep(err, stdout) {
+  const out = stdout || '';
+  if (err) {
+    if (err.code === 1 && !out.trim()) return new Map();  // no matches — nothing running
+    throw new Error(`pgrep probe failed (code ${err.code}): ${err.message}. Refusing to reconcile — reporting "zero monitors" here would arm duplicate monitors.`);
+  }
+  const covered = parseRunningMonitors(out);
+  if (out.trim() && covered.size === 0) {
+    throw new Error('pgrep matched processes but printed no monitor args (needs `pgrep -a`; busybox/macOS print PIDs only). Refusing to reconcile — cannot verify coverage without risking duplicate monitors.');
+  }
+  return covered;
+}
+
 // Walk pid → ppid chain until we hit a process that is a tmux pane_pid; return that pane.
 function paneForPid(pid, byPid, panePidToPane) {
   let cur = pid, hops = 0;
@@ -159,12 +179,13 @@ async function gather() {
     execFile('tmux', ['list-panes', '-a', '-F', '#{pane_id} #{pane_pid}']),
     execFile('ps', ['-eo', 'pid=,ppid=,stat=,comm=,args=']),
   ]);
-  let monOut = '';
-  try { monOut = (await execFile('pgrep', ['-af', 'node .*src/monitor\\.js'])).stdout; } catch { /* none running → pgrep exits 1 */ }
+  let pgrepErr = null, monOut = '';
+  try { monOut = (await execFile('pgrep', ['-af', 'node .*src/monitor\\.js'])).stdout; }
+  catch (err) { pgrepErr = err; monOut = err.stdout || ''; }
   return {
     panes: parsePanes(panesOut),
     processes: parseProcesses(psOut),
-    running: parseRunningMonitors(monOut),
+    running: runningFromPgrep(pgrepErr, monOut),  // throws on unverifiable coverage (Finding 2)
   };
 }
 

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -11,7 +11,7 @@
 
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFile, open, unlink, mkdir, appendFile } from 'node:fs/promises';
+import { readFile, writeFile, unlink, link, rename, mkdir, appendFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -52,6 +52,10 @@ export const LOCK_FILE = join(homedir(), '.claude-auto-retry', 'reconcile.lock')
 // as "alive" forever, wedging acquireLock at {ok:false} and silently disabling self-heal).
 // Linux: /proc/<pid>/stat field 22 (starttime; the "(comm)" field may contain spaces/parens,
 // so slice past the last ')'). Fallback (macOS/BSD, no /proc): `ps -o lstart=`. null if gone.
+// NOTE: `ps -o lstart=` is locale-dependent (LC_TIME), so on non-Linux a checker running
+// under a different locale than the writer (e.g. cron vs shell) could misjudge a live holder
+// as stale. Linux always takes the /proc path on both sides, and this tool targets
+// Linux/systemd, so it's unaffected in practice.
 export async function processStartToken(pid) {
   try {
     const stat = await readFile(`/proc/${pid}/stat`, 'utf-8');
@@ -78,34 +82,64 @@ async function holderIsLive(holderId) {
 }
 
 // Only remove the lock if it still holds OUR identity — never cross-delete a lock a
-// concurrent run has since taken over (so a run that was stolen from can't delete the
-// new holder's lock on release).
+// concurrent run has since taken over. Compare trimmed (a null-token id is a bare "<pid>",
+// so this also matches its own file content without a trailing-tab mismatch).
 async function releaseLock(lockPath, myId) {
   try {
     if ((await readFile(lockPath, 'utf-8')).trim() === myId) await unlink(lockPath);
   } catch { /* already gone or unreadable */ }
 }
 
+// Single-instance lock with an unforgeable holder identity ("<pid>\t<startToken>", or a bare
+// "<pid>" when no token is available). Two atomicity properties close the double-hold windows
+// a plain open('wx')+write left open:
+//   • CREATE atomically with content — write the id to a private temp file, then link() it
+//     into place. link() fails EEXIST if a lock exists, and a racer never sees an empty or
+//     half-written lock (the gap between open and write).
+//   • STEAL a stale lock via rename() to a graveyard name — rename of a given path succeeds
+//     for exactly ONE racer; the loser ENOENTs and retries. No unconditional unlink that
+//     could delete a lock another run just legitimately created.
 export async function acquireLock(lockPath = LOCK_FILE) {
-  await mkdir(dirname(lockPath), { recursive: true });
-  const myId = `${process.pid}\t${(await processStartToken(process.pid)) ?? ''}`;
+  const dir = dirname(lockPath);
+  await mkdir(dir, { recursive: true });
+  const token = await processStartToken(process.pid);
+  const myId = token ? `${process.pid}\t${token}` : String(process.pid);
+  const uniq = `${process.pid}.${Date.now()}`;
   const noop = { ok: false, release: async () => {} };
-  for (let attempt = 0; attempt < 2; attempt++) {
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const tmp = join(dir, `.lock.${uniq}.${attempt}.tmp`);
     try {
-      const fh = await open(lockPath, 'wx');   // wx = O_CREAT|O_EXCL: atomic create-or-fail
-      await fh.writeFile(myId);
-      await fh.close();
-      // Re-read: if a concurrent stale-steal clobbered our write between create and now, we
-      // don't actually hold it — back off rather than double-hold.
-      if ((await readFile(lockPath, 'utf-8')).trim() !== myId) return noop;
+      await writeFile(tmp, myId);
+      await link(tmp, lockPath);              // atomic create-or-EEXIST, content already present
+      await unlink(tmp).catch(() => {});
       return { ok: true, release: () => releaseLock(lockPath, myId) };
     } catch (err) {
+      await unlink(tmp).catch(() => {});
       if (err.code !== 'EEXIST') throw err;
-      let holderId = '';
-      try { holderId = (await readFile(lockPath, 'utf-8')).trim(); } catch { /* unreadable */ }
-      if (holderId && await holderIsLive(holderId)) return noop;   // genuine live holder
-      try { await unlink(lockPath); } catch { /* someone else won the steal */ }  // stale → steal + retry
     }
+
+    // A lock exists. Genuine live holder → back off; otherwise steal it atomically.
+    let holderId = '';
+    try { holderId = (await readFile(lockPath, 'utf-8')).trim(); }
+    catch { continue; }                       // vanished between link-fail and read → retry create
+    if (holderId && await holderIsLive(holderId)) return noop;
+
+    const grave = join(dir, `.lock.${uniq}.${attempt}.grave`);
+    try { await rename(lockPath, grave); }
+    catch (err) {
+      if (err.code === 'ENOENT') continue;    // lost the steal race → retry create
+      throw err;
+    }
+    // Won the rename. Confirm we took the SAME stale lock we evaluated; if a racer replaced
+    // it with a LIVE one in the gap, restore it rather than steal a live holder.
+    let stolen = '';
+    try { stolen = (await readFile(grave, 'utf-8')).trim(); } catch { /* empty/gone */ }
+    if (stolen && stolen !== holderId && await holderIsLive(stolen)) {
+      await rename(grave, lockPath).catch(() => {});
+      return noop;
+    }
+    await unlink(grave).catch(() => {});      // stale confirmed → drop it, loop to create
   }
   return noop;
 }

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -11,7 +11,7 @@
 
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFile, writeFile, unlink, link, rename, mkdir, appendFile } from 'node:fs/promises';
+import { readFile, writeFile, unlink, link, mkdir, appendFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -90,56 +90,75 @@ async function releaseLock(lockPath, myId) {
   } catch { /* already gone or unreadable */ }
 }
 
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Atomic create-with-content: write `id` to a private temp file, then hardlink it into
+// place. link() is atomic and fails EEXIST if the path already exists — so a racer never
+// sees an empty or half-written file (the gap a plain open('wx')+write left). Returns true
+// iff we now own `path`.
+async function linkCreate(path, tmp, id) {
+  try {
+    await writeFile(tmp, id);
+    await link(tmp, path);
+    return true;
+  } catch (err) {
+    if (err.code === 'EEXIST') return false;
+    throw err;
+  } finally {
+    await unlink(tmp).catch(() => {});
+  }
+}
+
 // Single-instance lock with an unforgeable holder identity ("<pid>\t<startToken>", or a bare
-// "<pid>" when no token is available). Two atomicity properties close the double-hold windows
-// a plain open('wx')+write left open:
-//   • CREATE atomically with content — write the id to a private temp file, then link() it
-//     into place. link() fails EEXIST if a lock exists, and a racer never sees an empty or
-//     half-written lock (the gap between open and write).
-//   • STEAL a stale lock via rename() to a graveyard name — rename of a given path succeeds
-//     for exactly ONE racer; the loser ENOENTs and retries. No unconditional unlink that
-//     could delete a lock another run just legitimately created.
+// "<pid>" when no token is available). Creating the lock is a plain atomic linkCreate. The
+// hard part is breaking a STALE lock (a run SIGKILLed before release) without two runs both
+// breaking + recreating it — the double-hold class. We serialize the break through a second
+// "breaker" lock, so exactly one run ever removes and recreates a stale main lock; everyone
+// else either backs off (live holder) or waits for the breaker. No rename/steal of a lock
+// whose liveness we haven't re-verified while holding the breaker, so a live holder's lock is
+// never moved out from under it.
 export async function acquireLock(lockPath = LOCK_FILE) {
   const dir = dirname(lockPath);
   await mkdir(dir, { recursive: true });
   const token = await processStartToken(process.pid);
   const myId = token ? `${process.pid}\t${token}` : String(process.pid);
+  const breakerPath = `${lockPath}.breaker`;
   const uniq = `${process.pid}.${Date.now()}`;
   const noop = { ok: false, release: async () => {} };
 
-  for (let attempt = 0; attempt < 4; attempt++) {
-    const tmp = join(dir, `.lock.${uniq}.${attempt}.tmp`);
-    try {
-      await writeFile(tmp, myId);
-      await link(tmp, lockPath);              // atomic create-or-EEXIST, content already present
-      await unlink(tmp).catch(() => {});
+  for (let attempt = 0; attempt < 8; attempt++) {
+    // Fast path: create the lock outright.
+    if (await linkCreate(lockPath, join(dir, `.acq.${uniq}.${attempt}`), myId)) {
       return { ok: true, release: () => releaseLock(lockPath, myId) };
-    } catch (err) {
-      await unlink(tmp).catch(() => {});
-      if (err.code !== 'EEXIST') throw err;
     }
-
-    // A lock exists. Genuine live holder → back off; otherwise steal it atomically.
+    // Exists. Genuine live holder → back off.
     let holderId = '';
-    try { holderId = (await readFile(lockPath, 'utf-8')).trim(); }
-    catch { continue; }                       // vanished between link-fail and read → retry create
+    try { holderId = (await readFile(lockPath, 'utf-8')).trim(); } catch { continue; }
     if (holderId && await holderIsLive(holderId)) return noop;
 
-    const grave = join(dir, `.lock.${uniq}.${attempt}.grave`);
-    try { await rename(lockPath, grave); }
-    catch (err) {
-      if (err.code === 'ENOENT') continue;    // lost the steal race → retry create
-      throw err;
+    // Stale. Take the breaker to serialize removal+recreation.
+    if (!(await linkCreate(breakerPath, join(dir, `.brk.${uniq}.${attempt}`), myId))) {
+      // Someone else is breaking. Only clear the breaker if IT is stale (crashed mid-break).
+      let bId = '';
+      try { bId = (await readFile(breakerPath, 'utf-8')).trim(); } catch {}
+      if (!bId || !(await holderIsLive(bId))) await unlink(breakerPath).catch(() => {});
+      await sleep(10);
+      continue;
     }
-    // Won the rename. Confirm we took the SAME stale lock we evaluated; if a racer replaced
-    // it with a LIVE one in the gap, restore it rather than steal a live holder.
-    let stolen = '';
-    try { stolen = (await readFile(grave, 'utf-8')).trim(); } catch { /* empty/gone */ }
-    if (stolen && stolen !== holderId && await holderIsLive(stolen)) {
-      await rename(grave, lockPath).catch(() => {});
-      return noop;
+    try {
+      // We hold the breaker. Re-verify the lock is still stale (a prior breaker may have
+      // already replaced it with a live one), then remove it and create ours.
+      let cur = '';
+      try { cur = (await readFile(lockPath, 'utf-8')).trim(); } catch {}
+      if (cur && await holderIsLive(cur)) return noop;      // became live → back off
+      await unlink(lockPath).catch(() => {});               // remove the stale lock (sole breaker)
+      if (await linkCreate(lockPath, join(dir, `.acqb.${uniq}.${attempt}`), myId)) {
+        return { ok: true, release: () => releaseLock(lockPath, myId) };
+      }
+      // A fresh acquirer won the empty path in the unlink→create gap; loop and re-evaluate.
+    } finally {
+      await releaseLock(breakerPath, myId);                 // release the breaker (identity-checked)
     }
-    await unlink(grave).catch(() => {});      // stale confirmed → drop it, loop to create
   }
   return noop;
 }

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -138,16 +138,25 @@ export async function acquireLock(lockPath = LOCK_FILE) {
 
     // Stale. Take the breaker to serialize removal+recreation.
     if (!(await linkCreate(breakerPath, join(dir, `.brk.${uniq}.${attempt}`), myId))) {
-      // Someone else is breaking. Only clear the breaker if IT is stale (crashed mid-break).
+      // Someone else is breaking. Only clear the breaker if IT is stale (crashed mid-break) —
+      // and clear it via an IDENTITY-CHECKED unlink (releaseLock re-reads and only removes it
+      // if it STILL holds the dead id we saw). An unconditional unlink could delete a fresh,
+      // LIVE breaker a racer created between our read and our unlink — breaking serialization
+      // and letting two runs both break the lock (double-hold).
       let bId = '';
       try { bId = (await readFile(breakerPath, 'utf-8')).trim(); } catch {}
-      if (!bId || !(await holderIsLive(bId))) await unlink(breakerPath).catch(() => {});
+      if (!bId || !(await holderIsLive(bId))) await releaseLock(breakerPath, bId);
       await sleep(10);
       continue;
     }
     try {
-      // We hold the breaker. Re-verify the lock is still stale (a prior breaker may have
-      // already replaced it with a live one), then remove it and create ours.
+      // We hold the breaker — but re-confirm that (a racing stale-breaker cleanup could have
+      // cleared ours in the gap) before touching the main lock.
+      let mine = '';
+      try { mine = (await readFile(breakerPath, 'utf-8')).trim(); } catch {}
+      if (mine !== myId) continue;                          // lost the breaker → retry from the top
+      // Re-verify the lock is still stale (a prior breaker may have already replaced it with
+      // a live one), then remove it and create ours.
       let cur = '';
       try { cur = (await readFile(lockPath, 'utf-8')).trim(); } catch {}
       if (cur && await holderIsLive(cur)) return noop;      // became live → back off
@@ -189,9 +198,22 @@ async function readExcludeFile(path = EXCLUDE_FILE) {
 const CLAUDE_COMM = 'claude';
 // Print mode: `claude -p` / `claude --print` produces piped/scripted output, never an
 // interactive TUI. The wrapper never arms a monitor there; reconcile must skip it too, or
-// retry text would be injected into that output (Finding 8). Anchored so a prompt word
-// like "-pretty" doesn't false-match.
-const PRINT_MODE = /(?:^|\s)(?:-p|--print)(?:[\s=]|$)/;
+// retry text would be injected into that output (Finding 8). Only treat -p/--print as print
+// mode when it appears as a FLAG — before the first non-flag positional argument — so a
+// PROMPT that merely contains "-p" (`claude "explain the -p flag"`) isn't misread as print
+// mode and left silently unmonitored. (ps strips quotes, so this is a heuristic: a
+// value-taking flag before -p, e.g. `claude --model x -p`, is the rare miss — which errs
+// toward arming a monitor, the safe direction, not toward an invisible session.)
+function isPrintMode(args) {
+  if (!args) return false;
+  const toks = args.trim().split(/\s+/);
+  for (let i = 1; i < toks.length; i++) {          // skip toks[0] = the command ("claude")
+    const t = toks[i];
+    if (t === '-p' || t === '--print' || t.startsWith('--print=')) return true;
+    if (!t.startsWith('-')) return false;          // first positional (the prompt) → stop scanning
+  }
+  return false;
+}
 
 // --- Pure parsing ---
 
@@ -275,7 +297,7 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
 
   // Every interactive claude (comm === 'claude'), excluding print-mode sessions; map to
   // its pane.
-  const claudes = processes.filter(p => p.comm === CLAUDE_COMM && !(p.args && PRINT_MODE.test(p.args)));
+  const claudes = processes.filter(p => p.comm === CLAUDE_COMM && !(isPrintMode(p.args)));
   const byPane = new Map();  // pane -> [claudeProc]
   for (const c of claudes) {
     const pane = paneForPid(c.pid, byPid, panePidToPane);
@@ -373,7 +395,7 @@ export async function claudePidForPane(pane) {
   const byPid = new Map(processes.map(p => [p.pid, p]));
   const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
   const here = processes.filter(p => p.comm === CLAUDE_COMM
-    && !(p.args && PRINT_MODE.test(p.args))
+    && !(isPrintMode(p.args))
     && paneForPid(p.pid, byPid, panePidToPane) === pane);
   if (here.length === 0) return null;
   return (here.find(p => p.stat.includes('+')) ?? here.sort((a, b) => b.pid - a.pid)[0]).pid;

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -11,7 +11,7 @@
 
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFile } from 'node:fs/promises';
+import { readFile, open, unlink, mkdir, appendFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -37,6 +37,33 @@ export const EXCLUDE_FILE = join(homedir(), '.claude-auto-retry', 'reconcile-exc
 function isProcessAlive(pid) {
   try { process.kill(pid, 0); return true; }
   catch (err) { return err.code === 'EPERM'; }  // exists but not ours → still alive
+}
+
+// Single-instance lock (Finding 4). A manual reconcile overlapping a timer fire would
+// otherwise both sample coverage once and both spawn the same arm set, with nothing
+// reaping the extras. Uses an atomic O_CREAT|O_EXCL open; on contention it reads the
+// holder pid and STEALS the lock only if that process is dead (crash-safe), so a stale
+// lock never wedges the timer permanently. Returns { ok, release } — release() is a no-op
+// when ok is false, so callers can always call it.
+export const LOCK_FILE = join(homedir(), '.claude-auto-retry', 'reconcile.lock');
+
+export async function acquireLock(lockPath = LOCK_FILE) {
+  await mkdir(dirname(lockPath), { recursive: true });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fh = await open(lockPath, 'wx');   // wx = O_CREAT|O_EXCL: fails if it exists
+      await fh.writeFile(String(process.pid));
+      await fh.close();
+      return { ok: true, release: async () => { try { await unlink(lockPath); } catch { /* already gone */ } } };
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      let holder = null;
+      try { holder = Number((await readFile(lockPath, 'utf-8')).trim()); } catch { /* unreadable */ }
+      if (holder && isProcessAlive(holder)) return { ok: false, release: async () => {} };
+      try { await unlink(lockPath); } catch { /* someone else won the race */ }  // stale → steal and retry
+    }
+  }
+  return { ok: false, release: async () => {} };
 }
 
 // Prune numeric PID entries whose process is gone: a dead PID can never legitimately match
@@ -217,17 +244,28 @@ function armMonitor(pane, pid) {
 // Returns { armed: [...], skipped: [...] }. `selfPane` (default $TMUX_PANE) is never armed,
 // so reconciling from inside a session doesn't monitor its own pane.
 export async function reconcile({ selfPane = process.env.TMUX_PANE || null, dryRun = false } = {}) {
-  const { panes, processes, running } = await gather();
-  const exclude = await readExcludeFile();
-  const plan = planReconcile({ panes, processes, running, selfPane, exclude });
-  const armed = [];
+  // dry-run only reads state, so it needs no lock. A real run takes the single-instance
+  // lock so an overlapping manual+timer invocation can't both spawn the same monitors.
+  let lock = null;
   if (!dryRun) {
-    for (const { pane, pid } of plan.arm) {
-      const monitorPid = armMonitor(pane, pid);
-      armed.push({ pane, pid, monitorPid });
-    }
+    lock = await acquireLock();
+    if (!lock.ok) return { armed: [], skipped: [], dryRun, locked: true };
   }
-  return { armed: dryRun ? plan.arm : armed, skipped: plan.skipped, dryRun };
+  try {
+    const { panes, processes, running } = await gather();
+    const exclude = await readExcludeFile();
+    const plan = planReconcile({ panes, processes, running, selfPane, exclude });
+    const armed = [];
+    if (!dryRun) {
+      for (const { pane, pid } of plan.arm) {
+        const monitorPid = armMonitor(pane, pid);
+        armed.push({ pane, pid, monitorPid });
+      }
+    }
+    return { armed: dryRun ? plan.arm : armed, skipped: plan.skipped, dryRun };
+  } finally {
+    if (lock) await lock.release();
+  }
 }
 
 // Resolve the claude PID for a given pane from live process state (same mapping
@@ -252,8 +290,6 @@ export async function excludeSelf(pane = process.env.TMUX_PANE || null, path = E
   if (!pid) return { ok: false, reason: `no claude process found for pane ${pane}` };
   const existing = await readExcludeFile(path);
   if (existing.includes(String(pid))) return { ok: true, pane, pid, already: true };
-  const { mkdir } = await import('node:fs/promises');
-  const { appendFile } = await import('node:fs/promises');
   await mkdir(dirname(path), { recursive: true });
   await appendFile(path, `${pid}\t# pane ${pane}, excluded by exclude-self\n`);
   return { ok: true, pane, pid };

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -1,0 +1,144 @@
+// `claude-auto-retry reconcile` — re-arm a monitor for every live tmux pane running
+// claude, skipping panes already covered. Closes the persistence gap: monitors are
+// detached processes with no service supervising them, so a crash/kill (or a session
+// launched outside the wrapper) leaves a live claude unmonitored. Reconcile restores
+// full coverage from the authoritative tmux + process state — run after a crash, or on
+// a timer.
+//
+// The pure core (parsing + planning) is separated from the impure runner (spawning
+// tmux/ps and forking monitors) so the mapping logic — including the tricky pane-id
+// reuse case — is unit-tested.
+
+import { execFile as execFileCb, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const execFile = promisify(execFileCb);
+const MONITOR_PATH = join(dirname(fileURLToPath(import.meta.url)), 'monitor.js');
+
+const CLAUDE_COMMANDS = ['claude', 'node'];  // pane_current_command / comm can be either
+
+// --- Pure parsing ---
+
+// tmux: "<pane_id> <pane_pid>" per line → [{ pane, panePid }]
+export function parsePanes(out) {
+  return out.split('\n').map(l => l.trim()).filter(Boolean).map(l => {
+    const [pane, panePid] = l.split(/\s+/);
+    return { pane, panePid: Number(panePid) };
+  }).filter(p => p.pane && Number.isFinite(p.panePid));
+}
+
+// ps "-eo pid=,ppid=,stat=,comm=" → [{ pid, ppid, stat, comm }]
+export function parseProcesses(out) {
+  return out.split('\n').map(l => l.trim()).filter(Boolean).map(l => {
+    const m = l.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+    if (!m) return null;
+    return { pid: Number(m[1]), ppid: Number(m[2]), stat: m[3], comm: m[4].trim() };
+  }).filter(Boolean);
+}
+
+// pgrep -af output for running monitors → Set of "pane pid" keys already covered, plus
+// the raw records so a caller can report/kill. Line: "<mpid> ... monitor.js <pane> <pid>"
+export function parseRunningMonitors(out) {
+  const covered = new Map();  // "pane pid" -> monitorPid
+  for (const line of out.split('\n')) {
+    const m = line.match(/monitor\.js\s+(%\d+)\s+(\d+)\b/);
+    if (m) covered.set(`${m[1]} ${m[2]}`, Number(line.trim().split(/\s+/)[0]));
+  }
+  return covered;
+}
+
+// Walk pid → ppid chain until we hit a process that is a tmux pane_pid; return that pane.
+function paneForPid(pid, byPid, panePidToPane) {
+  let cur = pid, hops = 0;
+  while (cur && cur > 1 && hops < 40) {
+    if (panePidToPane.has(cur)) return panePidToPane.get(cur);
+    const proc = byPid.get(cur);
+    if (!proc) return null;
+    cur = proc.ppid; hops++;
+  }
+  return null;
+}
+
+// --- Pure planning ---
+// Given tmux panes, ps processes, and already-running monitors, decide which
+// (pane, claudePid) pairs need a monitor armed. Handles pane-id reuse: when >1 claude
+// resolves to the same pane, prefer the foreground one (stat contains '+').
+//
+// Returns { arm: [{pane, pid, cwdHint?}], skipped: [{pane, pid, reason}] }.
+export function planReconcile({ panes, processes, running, selfPane = null }) {
+  const byPid = new Map(processes.map(p => [p.pid, p]));
+  const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
+
+  // Every claude/node process that is claude (comm === 'claude'); map to its pane.
+  const claudes = processes.filter(p => p.comm === 'claude');
+  const byPane = new Map();  // pane -> [claudeProc]
+  for (const c of claudes) {
+    const pane = paneForPid(c.pid, byPid, panePidToPane);
+    if (!pane) continue;
+    if (!byPane.has(pane)) byPane.set(pane, []);
+    byPane.get(pane).push(c);
+  }
+
+  const arm = [], skipped = [];
+  for (const [pane, procs] of byPane) {
+    if (selfPane && pane === selfPane) {
+      skipped.push({ pane, pid: procs[0].pid, reason: 'self (excluded)' });
+      continue;
+    }
+    // Pane-id reuse: pick the foreground claude ('+' in stat), else the highest pid
+    // (most-recently-started) as a stable tiebreak.
+    let target = procs.find(p => p.stat.includes('+'));
+    if (!target) target = procs.slice().sort((a, b) => b.pid - a.pid)[0];
+
+    if (running.has(`${pane} ${target.pid}`)) {
+      skipped.push({ pane, pid: target.pid, reason: 'already monitored' });
+    } else {
+      arm.push({ pane, pid: target.pid });
+    }
+  }
+  return { arm, skipped };
+}
+
+// --- Impure runner ---
+
+async function gather() {
+  const [{ stdout: panesOut }, { stdout: psOut }] = await Promise.all([
+    execFile('tmux', ['list-panes', '-a', '-F', '#{pane_id} #{pane_pid}']),
+    execFile('ps', ['-eo', 'pid=,ppid=,stat=,comm=']),
+  ]);
+  let monOut = '';
+  try { monOut = (await execFile('pgrep', ['-af', 'node .*src/monitor\\.js'])).stdout; } catch { /* none running → pgrep exits 1 */ }
+  return {
+    panes: parsePanes(panesOut),
+    processes: parseProcesses(psOut),
+    running: parseRunningMonitors(monOut),
+  };
+}
+
+function armMonitor(pane, pid) {
+  // spawn (not fork): fork() opens an IPC channel that keeps this CLI's event loop
+  // alive even after unref(), so the command would hang. spawn detached + unref lets
+  // the monitor outlive us while `reconcile` exits cleanly.
+  const child = spawn(process.execPath, [MONITOR_PATH, pane, String(pid)], {
+    detached: true, stdio: 'ignore',
+  });
+  child.unref();
+  return child.pid;
+}
+
+// Returns { armed: [...], skipped: [...] }. `selfPane` (default $TMUX_PANE) is never armed,
+// so reconciling from inside a session doesn't monitor its own pane.
+export async function reconcile({ selfPane = process.env.TMUX_PANE || null, dryRun = false } = {}) {
+  const { panes, processes, running } = await gather();
+  const plan = planReconcile({ panes, processes, running, selfPane });
+  const armed = [];
+  if (!dryRun) {
+    for (const { pane, pid } of plan.arm) {
+      const monitorPid = armMonitor(pane, pid);
+      armed.push({ pane, pid, monitorPid });
+    }
+  }
+  return { armed: dryRun ? plan.arm : armed, skipped: plan.skipped, dryRun };
+}

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -98,6 +98,11 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
   const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
   const excluded = new Set(exclude);
   if (selfPane) excluded.add(selfPane);
+  // Coverage is keyed PER PANE, not per (pane,pid) (Finding 3): a stopped claude keeps its
+  // monitor alive, so if we keyed on pid we'd arm a SECOND monitor for the new foreground
+  // claude in that pane and both would send keys. One monitor per pane suffices — a
+  // monitor whose target pid has exited already shuts itself down (isAlive check).
+  const coveredPanes = new Set([...running.keys()].map(k => k.split(' ')[0]));
 
   // Every claude/node process that is claude (comm === 'claude'); map to its pane.
   const claudes = processes.filter(p => p.comm === 'claude');
@@ -126,7 +131,7 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
       continue;
     }
 
-    if (running.has(`${pane} ${target.pid}`)) {
+    if (coveredPanes.has(pane)) {
       skipped.push({ pane, pid: target.pid, reason: 'already monitored' });
     } else {
       arm.push({ pane, pid: target.pid });

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -19,16 +19,27 @@ import { homedir } from 'node:os';
 const execFile = promisify(execFileCb);
 const MONITOR_PATH = join(dirname(fileURLToPath(import.meta.url)), 'monitor.js');
 
-// Panes to never auto-monitor (one pane id per line, e.g. "%2"). Honored by BOTH
-// interactive reconcile and the systemd timer — the timer has no $TMUX_PANE, so a
-// durable file is the only way to keep a specific pane unmonitored. Note: tmux reuses
-// pane ids, so an entry can go stale; it's a deliberate per-pane opt-out, not permanent.
+// Sessions to never auto-monitor. Honored by BOTH interactive reconcile and the systemd
+// timer (the timer has no $TMUX_PANE, so a durable file is the only self-exclusion path).
+// One entry per line; two forms:
+//   <pid>   e.g. "1842917" — the claude PID. PREFERRED: unique while alive and
+//                            SELF-EXPIRING — once that claude exits the entry matches no
+//                            live process, so it can never mute a different future
+//                            session. Immune to tmux pane-id reuse. Written by
+//                            `exclude-self`.
+//   %<pane> e.g. "%2"       — a tmux pane id. Convenient to hand-edit, but tmux REUSES
+//                            pane ids, so a stale entry can silently mute a later,
+//                            unrelated session in that pane. Prefer the PID form.
+// '#' comments and blank lines are ignored.
 export const EXCLUDE_FILE = join(homedir(), '.claude-auto-retry', 'reconcile-exclude');
 
 async function readExcludeFile(path = EXCLUDE_FILE) {
   try {
     return (await readFile(path, 'utf-8'))
-      .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l && !l.startsWith('#'))
+      .map(l => l.split(/[\s#]/)[0]);  // take the first token; allow "1234  # note"
   } catch { return []; }
 }
 
@@ -100,14 +111,20 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
 
   const arm = [], skipped = [];
   for (const [pane, procs] of byPane) {
-    if (excluded.has(pane)) {
-      skipped.push({ pane, pid: procs[0].pid, reason: pane === selfPane ? 'self (excluded)' : 'excluded' });
-      continue;
-    }
     // Pane-id reuse: pick the foreground claude ('+' in stat), else the highest pid
     // (most-recently-started) as a stable tiebreak.
     let target = procs.find(p => p.stat.includes('+'));
     if (!target) target = procs.slice().sort((a, b) => b.pid - a.pid)[0];
+
+    // Exclusion matches either the claude PID (preferred — self-expiring, reuse-proof)
+    // or the pane id. PID is checked against the resolved target so it survives pane
+    // reuse; pane match is the convenience form.
+    if (excluded.has(String(target.pid)) || excluded.has(pane)) {
+      const reason = pane === selfPane ? 'self (excluded)'
+        : excluded.has(String(target.pid)) ? 'excluded (pid)' : 'excluded (pane)';
+      skipped.push({ pane, pid: target.pid, reason });
+      continue;
+    }
 
     if (running.has(`${pane} ${target.pid}`)) {
       skipped.push({ pane, pid: target.pid, reason: 'already monitored' });
@@ -159,4 +176,32 @@ export async function reconcile({ selfPane = process.env.TMUX_PANE || null, dryR
     }
   }
   return { armed: dryRun ? plan.arm : armed, skipped: plan.skipped, dryRun };
+}
+
+// Resolve the claude PID for a given pane from live process state (same mapping
+// reconcile uses). Returns the foreground claude's pid, or null.
+export async function claudePidForPane(pane) {
+  if (!pane) return null;
+  const { panes, processes } = await gather();
+  const byPid = new Map(processes.map(p => [p.pid, p]));
+  const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
+  const here = processes.filter(p => p.comm === 'claude'
+    && paneForPid(p.pid, byPid, panePidToPane) === pane);
+  if (here.length === 0) return null;
+  return (here.find(p => p.stat.includes('+')) ?? here.sort((a, b) => b.pid - a.pid)[0]).pid;
+}
+
+// Durably exclude the CURRENT session from auto-monitoring by appending its claude PID
+// (self-expiring, reuse-proof) to the exclude file. Run from inside the session.
+export async function excludeSelf(pane = process.env.TMUX_PANE || null, path = EXCLUDE_FILE) {
+  if (!pane) return { ok: false, reason: 'not inside tmux ($TMUX_PANE unset)' };
+  const pid = await claudePidForPane(pane);
+  if (!pid) return { ok: false, reason: `no claude process found for pane ${pane}` };
+  const existing = await readExcludeFile(path);
+  if (existing.includes(String(pid))) return { ok: true, pane, pid, already: true };
+  const { mkdir } = await import('node:fs/promises');
+  const { appendFile } = await import('node:fs/promises');
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${pid}\t# pane ${pane}, excluded by exclude-self\n`);
+  return { ok: true, pane, pid };
 }

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -43,7 +43,17 @@ async function readExcludeFile(path = EXCLUDE_FILE) {
   } catch { return []; }
 }
 
-const CLAUDE_COMMANDS = ['claude', 'node'];  // pane_current_command / comm can be either
+// Reconcile matches a session by `comm === 'claude'`, which works because Claude Code
+// sets its process.title to "claude". A session launched via a `#!/usr/bin/env node`
+// shebang that does NOT set process.title shows comm "node" and is invisible to reconcile
+// — install the shell wrapper for those. (Matching bare "node" here would arm a monitor on
+// every unrelated node process, so it is deliberately not attempted.)
+const CLAUDE_COMM = 'claude';
+// Print mode: `claude -p` / `claude --print` produces piped/scripted output, never an
+// interactive TUI. The wrapper never arms a monitor there; reconcile must skip it too, or
+// retry text would be injected into that output (Finding 8). Anchored so a prompt word
+// like "-pretty" doesn't false-match.
+const PRINT_MODE = /(?:^|\s)(?:-p|--print)(?:[\s=]|$)/;
 
 // --- Pure parsing ---
 
@@ -55,12 +65,13 @@ export function parsePanes(out) {
   }).filter(p => p.pane && Number.isFinite(p.panePid));
 }
 
-// ps "-eo pid=,ppid=,stat=,comm=" → [{ pid, ppid, stat, comm }]
+// ps "-eo pid=,ppid=,stat=,comm=,args=" → [{ pid, ppid, stat, comm, args }]. args is the
+// trailing field (may contain spaces); absent → '' (tolerates comm-only ps output).
 export function parseProcesses(out) {
   return out.split('\n').map(l => l.trim()).filter(Boolean).map(l => {
-    const m = l.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+    const m = l.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+(.*))?$/);
     if (!m) return null;
-    return { pid: Number(m[1]), ppid: Number(m[2]), stat: m[3], comm: m[4].trim() };
+    return { pid: Number(m[1]), ppid: Number(m[2]), stat: m[3], comm: m[4], args: (m[5] || '').trim() };
   }).filter(Boolean);
 }
 
@@ -104,8 +115,9 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
   // monitor whose target pid has exited already shuts itself down (isAlive check).
   const coveredPanes = new Set([...running.keys()].map(k => k.split(' ')[0]));
 
-  // Every claude/node process that is claude (comm === 'claude'); map to its pane.
-  const claudes = processes.filter(p => p.comm === 'claude');
+  // Every interactive claude (comm === 'claude'), excluding print-mode sessions; map to
+  // its pane.
+  const claudes = processes.filter(p => p.comm === CLAUDE_COMM && !(p.args && PRINT_MODE.test(p.args)));
   const byPane = new Map();  // pane -> [claudeProc]
   for (const c of claudes) {
     const pane = paneForPid(c.pid, byPid, panePidToPane);
@@ -145,7 +157,7 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
 async function gather() {
   const [{ stdout: panesOut }, { stdout: psOut }] = await Promise.all([
     execFile('tmux', ['list-panes', '-a', '-F', '#{pane_id} #{pane_pid}']),
-    execFile('ps', ['-eo', 'pid=,ppid=,stat=,comm=']),
+    execFile('ps', ['-eo', 'pid=,ppid=,stat=,comm=,args=']),
   ]);
   let monOut = '';
   try { monOut = (await execFile('pgrep', ['-af', 'node .*src/monitor\\.js'])).stdout; } catch { /* none running → pgrep exits 1 */ }
@@ -190,7 +202,8 @@ export async function claudePidForPane(pane) {
   const { panes, processes } = await gather();
   const byPid = new Map(processes.map(p => [p.pid, p]));
   const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
-  const here = processes.filter(p => p.comm === 'claude'
+  const here = processes.filter(p => p.comm === CLAUDE_COMM
+    && !(p.args && PRINT_MODE.test(p.args))
     && paneForPid(p.pid, byPid, panePidToPane) === pane);
   if (here.length === 0) return null;
   return (here.find(p => p.stat.includes('+')) ?? here.sort((a, b) => b.pid - a.pid)[0]).pid;

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -47,23 +47,67 @@ function isProcessAlive(pid) {
 // when ok is false, so callers can always call it.
 export const LOCK_FILE = join(homedir(), '.claude-auto-retry', 'reconcile.lock');
 
+// Process START TOKEN — an identity that survives PID reuse (a bare PID cannot: the kernel
+// reuses PIDs, so a stale lock's PID may later belong to an unrelated live process and read
+// as "alive" forever, wedging acquireLock at {ok:false} and silently disabling self-heal).
+// Linux: /proc/<pid>/stat field 22 (starttime; the "(comm)" field may contain spaces/parens,
+// so slice past the last ')'). Fallback (macOS/BSD, no /proc): `ps -o lstart=`. null if gone.
+export async function processStartToken(pid) {
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, 'utf-8');
+    const after = stat.slice(stat.lastIndexOf(')') + 1).trim().split(/\s+/);
+    if (after[19]) return after[19];   // field 22 overall = index 19 after "state"
+  } catch { /* not Linux, or process gone */ }
+  try {
+    const { stdout } = await execFile('ps', ['-o', 'lstart=', '-p', String(pid)]);
+    return stdout.trim() || null;
+  } catch { return null; }
+}
+
+// Is the recorded lock holder still the SAME live process (not just a reused PID)? Identity
+// is "<pid>\t<startToken>". A dead PID → stale. A live PID whose start token no longer
+// matches → the PID was reused → stale. A legacy bare-PID lock (no token) → respect it if
+// the PID is alive (can't disambiguate; don't risk stealing a real holder's lock).
+async function holderIsLive(holderId) {
+  const tab = holderId.indexOf('\t');
+  const pid = Number(tab === -1 ? holderId : holderId.slice(0, tab));
+  if (!pid || !isProcessAlive(pid)) return false;
+  const recordedStart = tab === -1 ? '' : holderId.slice(tab + 1);
+  if (!recordedStart) return true;
+  return (await processStartToken(pid)) === recordedStart;
+}
+
+// Only remove the lock if it still holds OUR identity — never cross-delete a lock a
+// concurrent run has since taken over (so a run that was stolen from can't delete the
+// new holder's lock on release).
+async function releaseLock(lockPath, myId) {
+  try {
+    if ((await readFile(lockPath, 'utf-8')).trim() === myId) await unlink(lockPath);
+  } catch { /* already gone or unreadable */ }
+}
+
 export async function acquireLock(lockPath = LOCK_FILE) {
   await mkdir(dirname(lockPath), { recursive: true });
+  const myId = `${process.pid}\t${(await processStartToken(process.pid)) ?? ''}`;
+  const noop = { ok: false, release: async () => {} };
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const fh = await open(lockPath, 'wx');   // wx = O_CREAT|O_EXCL: fails if it exists
-      await fh.writeFile(String(process.pid));
+      const fh = await open(lockPath, 'wx');   // wx = O_CREAT|O_EXCL: atomic create-or-fail
+      await fh.writeFile(myId);
       await fh.close();
-      return { ok: true, release: async () => { try { await unlink(lockPath); } catch { /* already gone */ } } };
+      // Re-read: if a concurrent stale-steal clobbered our write between create and now, we
+      // don't actually hold it — back off rather than double-hold.
+      if ((await readFile(lockPath, 'utf-8')).trim() !== myId) return noop;
+      return { ok: true, release: () => releaseLock(lockPath, myId) };
     } catch (err) {
       if (err.code !== 'EEXIST') throw err;
-      let holder = null;
-      try { holder = Number((await readFile(lockPath, 'utf-8')).trim()); } catch { /* unreadable */ }
-      if (holder && isProcessAlive(holder)) return { ok: false, release: async () => {} };
-      try { await unlink(lockPath); } catch { /* someone else won the race */ }  // stale → steal and retry
+      let holderId = '';
+      try { holderId = (await readFile(lockPath, 'utf-8')).trim(); } catch { /* unreadable */ }
+      if (holderId && await holderIsLive(holderId)) return noop;   // genuine live holder
+      try { await unlink(lockPath); } catch { /* someone else won the steal */ }  // stale → steal + retry
     }
   }
-  return { ok: false, release: async () => {} };
+  return noop;
 }
 
 // Prune numeric PID entries whose process is gone: a dead PID can never legitimately match

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -23,24 +23,38 @@ const MONITOR_PATH = join(dirname(fileURLToPath(import.meta.url)), 'monitor.js')
 // timer (the timer has no $TMUX_PANE, so a durable file is the only self-exclusion path).
 // One entry per line; two forms:
 //   <pid>   e.g. "1842917" — the claude PID. PREFERRED: unique while alive and
-//                            SELF-EXPIRING — once that claude exits the entry matches no
-//                            live process, so it can never mute a different future
-//                            session. Immune to tmux pane-id reuse. Written by
-//                            `exclude-self`.
+//                            SELF-EXPIRING — dead PIDs are pruned on read (see
+//                            pruneExcludeEntries), so once that claude exits the entry is
+//                            dropped and can never mute a different future session. Immune
+//                            to tmux pane-id reuse. Written by `exclude-self`.
 //   %<pane> e.g. "%2"       — a tmux pane id. Convenient to hand-edit, but tmux REUSES
 //                            pane ids, so a stale entry can silently mute a later,
-//                            unrelated session in that pane. Prefer the PID form.
+//                            unrelated session in that pane (and pane ids are NOT pruned —
+//                            we can't know if one is stale). Prefer the PID form.
 // '#' comments and blank lines are ignored.
 export const EXCLUDE_FILE = join(homedir(), '.claude-auto-retry', 'reconcile-exclude');
 
+function isProcessAlive(pid) {
+  try { process.kill(pid, 0); return true; }
+  catch (err) { return err.code === 'EPERM'; }  // exists but not ours → still alive
+}
+
+// Prune numeric PID entries whose process is gone: a dead PID can never legitimately match
+// again, and keeping it risks muting a future claude that the kernel hands the reused PID
+// (Finding 5). Pane ids (%N) and any non-numeric token are hand-managed and kept as-is.
+export function pruneExcludeEntries(entries, isAlive = isProcessAlive) {
+  return entries.filter(e => !/^\d+$/.test(e) || isAlive(Number(e)));
+}
+
 async function readExcludeFile(path = EXCLUDE_FILE) {
-  try {
-    return (await readFile(path, 'utf-8'))
-      .split('\n')
-      .map(l => l.trim())
-      .filter(l => l && !l.startsWith('#'))
-      .map(l => l.split(/[\s#]/)[0]);  // take the first token; allow "1234  # note"
-  } catch { return []; }
+  let raw;
+  try { raw = await readFile(path, 'utf-8'); } catch { return []; }
+  const entries = raw
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l && !l.startsWith('#'))
+    .map(l => l.split(/[\s#]/)[0]);  // take the first token; allow "1234  # note"
+  return pruneExcludeEntries(entries);
 }
 
 // Reconcile matches a session by `comm === 'claude'`, which works because Claude Code

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -11,11 +11,26 @@
 
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
 
 const execFile = promisify(execFileCb);
 const MONITOR_PATH = join(dirname(fileURLToPath(import.meta.url)), 'monitor.js');
+
+// Panes to never auto-monitor (one pane id per line, e.g. "%2"). Honored by BOTH
+// interactive reconcile and the systemd timer — the timer has no $TMUX_PANE, so a
+// durable file is the only way to keep a specific pane unmonitored. Note: tmux reuses
+// pane ids, so an entry can go stale; it's a deliberate per-pane opt-out, not permanent.
+export const EXCLUDE_FILE = join(homedir(), '.claude-auto-retry', 'reconcile-exclude');
+
+async function readExcludeFile(path = EXCLUDE_FILE) {
+  try {
+    return (await readFile(path, 'utf-8'))
+      .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+  } catch { return []; }
+}
 
 const CLAUDE_COMMANDS = ['claude', 'node'];  // pane_current_command / comm can be either
 
@@ -67,9 +82,11 @@ function paneForPid(pid, byPid, panePidToPane) {
 // resolves to the same pane, prefer the foreground one (stat contains '+').
 //
 // Returns { arm: [{pane, pid, cwdHint?}], skipped: [{pane, pid, reason}] }.
-export function planReconcile({ panes, processes, running, selfPane = null }) {
+export function planReconcile({ panes, processes, running, selfPane = null, exclude = [] }) {
   const byPid = new Map(processes.map(p => [p.pid, p]));
   const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
+  const excluded = new Set(exclude);
+  if (selfPane) excluded.add(selfPane);
 
   // Every claude/node process that is claude (comm === 'claude'); map to its pane.
   const claudes = processes.filter(p => p.comm === 'claude');
@@ -83,8 +100,8 @@ export function planReconcile({ panes, processes, running, selfPane = null }) {
 
   const arm = [], skipped = [];
   for (const [pane, procs] of byPane) {
-    if (selfPane && pane === selfPane) {
-      skipped.push({ pane, pid: procs[0].pid, reason: 'self (excluded)' });
+    if (excluded.has(pane)) {
+      skipped.push({ pane, pid: procs[0].pid, reason: pane === selfPane ? 'self (excluded)' : 'excluded' });
       continue;
     }
     // Pane-id reuse: pick the foreground claude ('+' in stat), else the highest pid
@@ -132,7 +149,8 @@ function armMonitor(pane, pid) {
 // so reconciling from inside a session doesn't monitor its own pane.
 export async function reconcile({ selfPane = process.env.TMUX_PANE || null, dryRun = false } = {}) {
   const { panes, processes, running } = await gather();
-  const plan = planReconcile({ panes, processes, running, selfPane });
+  const exclude = await readExcludeFile();
+  const plan = planReconcile({ panes, processes, running, selfPane, exclude });
   const armed = [];
   if (!dryRun) {
     for (const { pane, pid } of plan.arm) {

--- a/systemd/claude-auto-retry-reconcile.service
+++ b/systemd/claude-auto-retry-reconcile.service
@@ -12,5 +12,6 @@ Type=oneshot
 # reconcile process, leaving the freshly-armed monitors running.
 KillMode=process
 # __NODE_PATH__ and __CLI_PATH__ are substituted by `claude-auto-retry install-timer`.
-ExecStart=__NODE_PATH__ __CLI_PATH__ reconcile
+# Quoted so a path containing spaces (e.g. an nvm dir under "/home/My User/") survives.
+ExecStart="__NODE_PATH__" "__CLI_PATH__" reconcile
 # tmux is reached via its default socket (/tmp/tmux-<uid>/default); no $TMUX needed.

--- a/systemd/claude-auto-retry-reconcile.service
+++ b/systemd/claude-auto-retry-reconcile.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=claude-auto-retry: re-arm monitors for all live claude tmux panes
+Documentation=https://github.com/cheapestinference/claude-auto-retry
+# Only meaningful once a graphical/user session (and thus the tmux server) exists.
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+# CRITICAL: reconcile spawns DETACHED monitor processes and exits. The default
+# KillMode=control-group would SIGKILL those monitors as soon as this oneshot
+# finishes (they share the unit's cgroup). KillMode=process kills only the main
+# reconcile process, leaving the freshly-armed monitors running.
+KillMode=process
+# __NODE_PATH__ and __CLI_PATH__ are substituted by `claude-auto-retry install-timer`.
+ExecStart=__NODE_PATH__ __CLI_PATH__ reconcile
+# tmux is reached via its default socket (/tmp/tmux-<uid>/default); no $TMUX needed.

--- a/systemd/claude-auto-retry-reconcile.timer
+++ b/systemd/claude-auto-retry-reconcile.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Periodically reconcile claude-auto-retry monitors (self-healing coverage)
+Documentation=https://github.com/cheapestinference/claude-auto-retry
+
+[Timer]
+# First run shortly after the user session comes up (lets tmux settle)...
+OnStartupSec=2min
+# ...then every 5 min. A monitor that dies is re-armed within one interval; a
+# crash mid-window loses at most ~5 min of coverage on that pane.
+OnUnitActiveSec=5min
+# Catch up on a missed run (e.g. box asleep) instead of waiting a full interval.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/claude-auto-retry-reconcile.timer
+++ b/systemd/claude-auto-retry-reconcile.timer
@@ -8,8 +8,9 @@ OnStartupSec=2min
 # ...then every 5 min. A monitor that dies is re-armed within one interval; a
 # crash mid-window loses at most ~5 min of coverage on that pane.
 OnUnitActiveSec=5min
-# Catch up on a missed run (e.g. box asleep) instead of waiting a full interval.
-Persistent=true
+# NOTE: no Persistent= here — it only affects OnCalendar= (wall-clock) timers. These are
+# monotonic (OnStartupSec/OnUnitActiveSec), which pause across suspend and resume on wake,
+# so there is nothing for Persistent to "catch up".
 
 [Install]
 WantedBy=timers.target

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -3,7 +3,39 @@ import assert from 'node:assert/strict';
 import { writeFile, readFile, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { injectWrapper, removeWrapper, MARKER_START, MARKER_END } from '../bin/cli.js';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { injectWrapper, removeWrapper, MARKER_START, MARKER_END, renderReconcileUnit } from '../bin/cli.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// --- Finding 7: the generated systemd unit was fragile — unquoted ExecStart paths broke
+//     on spaces, and Persistent=true is a no-op on a monotonic (OnUnitActiveSec) timer. ---
+describe('renderReconcileUnit (Finding 7)', () => {
+  it('substitutes into the quoted ExecStart so a path with spaces survives', () => {
+    const out = renderReconcileUnit(
+      'ExecStart="__NODE_PATH__" "__CLI_PATH__" reconcile\n',
+      '/home/a b/.nvm/node', '/home/a b/cli.js',
+    );
+    assert.match(out, /ExecStart="\/home\/a b\/\.nvm\/node" "\/home\/a b\/cli\.js" reconcile/);
+    assert.ok(!out.includes('__NODE_PATH__') && !out.includes('__CLI_PATH__'));
+  });
+  it('the shipped .service template quotes the ExecStart placeholders', async () => {
+    const svc = await readFile(join(REPO_ROOT, 'systemd', 'claude-auto-retry-reconcile.service'), 'utf-8');
+    assert.match(svc, /ExecStart="__NODE_PATH__" "__CLI_PATH__" reconcile/);
+  });
+  it('the shipped .timer template has no no-op Persistent=true', async () => {
+    const timer = await readFile(join(REPO_ROOT, 'systemd', 'claude-auto-retry-reconcile.timer'), 'utf-8');
+    assert.ok(!/Persistent\s*=\s*true/.test(timer));
+  });
+});
+
+describe('package.json files whitelist (Finding 1)', () => {
+  it('includes systemd/ so install-timer works from an npm install', async () => {
+    const pkg = JSON.parse(await readFile(join(REPO_ROOT, 'package.json'), 'utf-8'));
+    assert.ok(pkg.files.includes('systemd/'), 'package.json "files" must include "systemd/"');
+  });
+});
 
 describe('injectWrapper', () => {
   const testFile = join(tmpdir(), `car-rc-test-${Date.now()}`);

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  parsePanes, parseProcesses, parseRunningMonitors, planReconcile,
+  parsePanes, parseProcesses, parseRunningMonitors, planReconcile, runningFromPgrep,
 } from '../src/reconcile.js';
 
 describe('reconcile parsing', () => {
@@ -26,6 +26,34 @@ describe('reconcile parsing', () => {
     assert.equal(c.size, 2);
   });
   it('empty pgrep output → no covered', () => assert.equal(parseRunningMonitors('').size, 0));
+});
+
+// --- Finding 2: the impure gather() used an unconditional catch, so ANY pgrep failure
+//     (ENOENT, busybox pgrep with no -a, macOS pgrep printing PIDs only) collapsed to
+//     "zero monitors running" → the 5-min timer armed a duplicate monitor per pane every
+//     run, unbounded. runningFromPgrep distinguishes the benign case (exit 1, no matches)
+//     from real failures, and refuses to proceed when it can't verify coverage. ---
+describe('runningFromPgrep (Finding 2)', () => {
+  it('exit code 1 with no output → empty coverage (nothing running, the benign case)', () => {
+    const err = Object.assign(new Error('Command failed'), { code: 1, stdout: '' });
+    assert.equal(runningFromPgrep(err, '').size, 0);
+  });
+  it('parses monitor lines on success', () => {
+    const out = '1866839 node /x/src/monitor.js %1 2453159\n';
+    assert.equal(runningFromPgrep(null, out).get('%1 2453159'), 1866839);
+  });
+  it('throws on ENOENT (pgrep missing) rather than reporting zero', () => {
+    const err = Object.assign(new Error('spawn pgrep ENOENT'), { code: 'ENOENT' });
+    assert.throws(() => runningFromPgrep(err, ''), /pgrep/i);
+  });
+  it('throws on a non-1 exit code (e.g. busybox usage error)', () => {
+    const err = Object.assign(new Error('unrecognized option -a'), { code: 2, stdout: '' });
+    assert.throws(() => runningFromPgrep(err, ''), /reconcile/i);
+  });
+  it('throws when pgrep succeeds but prints no parseable monitor args (macOS PID-only)', () => {
+    // pgrep matched processes (non-empty output) but -a gave no args → cannot verify.
+    assert.throws(() => runningFromPgrep(null, '1866839\n1866840\n'), /pgrep/i);
+  });
 });
 
 // A small fixture: pane %1 (pane_pid 100) has a claude (200) as a child; pane %2 (300)

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -2,11 +2,30 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { writeFile, unlink, readFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { writeFile, unlink, readFile, mkdtemp, rm } from 'node:fs/promises';
 import {
   parsePanes, parseProcesses, parseRunningMonitors, planReconcile, runningFromPgrep,
   pruneExcludeEntries, acquireLock, processStartToken,
 } from '../src/reconcile.js';
+
+const RECONCILE_URL = new URL('../src/reconcile.js', import.meta.url).href;
+// A worker that acquires the lock, records its exact hold interval (hrtime), then releases —
+// run as a separate PROCESS so it exercises real cross-process syscall interleaving (an
+// in-process caller shares one PID/identity and just sees its own live lock).
+const LOCK_WORKER = `
+import { acquireLock } from ${JSON.stringify(RECONCILE_URL)};
+import { appendFile } from 'node:fs/promises';
+const [LOCK, LOG, iter] = process.argv.slice(2);
+const r = await acquireLock(LOCK);
+if (!r.ok) process.exit(0);
+const a = process.hrtime.bigint();
+await new Promise((res) => setTimeout(res, 15));
+const b = process.hrtime.bigint();
+await appendFile(LOG, iter + ' ' + a + ' ' + b + '\\n');
+await r.release();
+process.exit(0);
+`;
 
 describe('reconcile parsing', () => {
   it('parses tmux pane list', () => {
@@ -112,22 +131,38 @@ describe('acquireLock (Finding 4)', () => {
     assert.match(still, /someone-else/);
     await unlink(lockPath);
   });
-  // --- Review follow-up: the unlink-based steal double-held (reviewer reproduced 1/120).
-  //     link()-create + rename()-steal grant to exactly one racer. In-process contention
-  //     exercises the interleaving. ---
-  it('grants the lock to exactly one of many concurrent acquirers (no contention)', async () => {
-    const results = await Promise.all(Array.from({ length: 8 }, () => acquireLock(lockPath)));
-    assert.equal(results.filter(r => r.ok).length, 1);
-    // whoever won leaves exactly one lock file; content is never empty
-    const held = (await readFile(lockPath, 'utf-8'));
-    assert.ok(held.trim().length > 0);
-    await Promise.all(results.map(r => r.release()));
-  });
-  it('grants to exactly one when a stale lock is contended', async () => {
-    await writeFile(lockPath, '2147483646');   // stale, dead pid
-    const results = await Promise.all(Array.from({ length: 8 }, () => acquireLock(lockPath)));
-    assert.equal(results.filter(r => r.ok).length, 1);
-    await Promise.all(results.map(r => r.release()));
+  // --- Review follow-up: the unlink/rename-based steal double-held under real cross-process
+  //     contention (reviewer reproduced it; an in-process test can't — all callers share one
+  //     PID and just see their own live lock). The serialized-breaker design grants strict
+  //     mutual exclusion. Spawn real processes, seed a STALE lock each round to force the
+  //     break path, and assert no two hold intervals overlap in time. ---
+  it('grants mutual exclusion across real concurrent processes (breaks a stale lock safely)', async () => {
+    const wdir = await mkdtemp(join(tmpdir(), 'car-lockx-'));
+    const worker = join(wdir, 'w.mjs'), LOCK = join(wdir, 'x.lock'), LOG = join(wdir, 'x.log');
+    await writeFile(worker, LOCK_WORKER);
+    await writeFile(LOG, '');
+    const run = (it) => new Promise((res) =>
+      spawn(process.execPath, [worker, LOCK, LOG, String(it)], { stdio: 'ignore' }).on('exit', res));
+    const ITER = 12, N = 6;
+    for (let i = 0; i < ITER; i++) {
+      await writeFile(LOCK, '2147483646');                 // stale, dead-pid lock → force the break path
+      await Promise.all(Array.from({ length: N }, () => run(i)));
+      await unlink(LOCK).catch(() => {});
+    }
+    const byIter = {};
+    for (const line of (await readFile(LOG, 'utf-8')).trim().split('\n').filter(Boolean)) {
+      const [it, a, b] = line.split(' ');
+      (byIter[it] ??= []).push([BigInt(a), BigInt(b)]);
+    }
+    let overlaps = 0;
+    for (const it in byIter) {
+      const h = byIter[it];
+      for (let x = 0; x < h.length; x++)
+        for (let y = x + 1; y < h.length; y++)
+          if (h[x][0] < h[y][1] && h[y][0] < h[x][1]) overlaps++;   // intervals intersect → concurrent hold
+    }
+    await rm(wdir, { recursive: true, force: true });
+    assert.equal(overlaps, 0, `expected no time-overlapping holds across processes, got ${overlaps}`);
   });
 });
 

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -1,8 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFile, unlink, readFile } from 'node:fs/promises';
 import {
   parsePanes, parseProcesses, parseRunningMonitors, planReconcile, runningFromPgrep,
-  pruneExcludeEntries,
+  pruneExcludeEntries, acquireLock,
 } from '../src/reconcile.js';
 
 describe('reconcile parsing', () => {
@@ -54,6 +57,29 @@ describe('runningFromPgrep (Finding 2)', () => {
   it('throws when pgrep succeeds but prints no parseable monitor args (macOS PID-only)', () => {
     // pgrep matched processes (non-empty output) but -a gave no args → cannot verify.
     assert.throws(() => runningFromPgrep(null, '1866839\n1866840\n'), /pgrep/i);
+  });
+});
+
+// --- Finding 4: a manual reconcile overlapping a timer fire both sample coverage once
+//     and both spawn the same arm set (nothing reaps the extras). A single-instance lock
+//     makes the second run a no-op. ---
+describe('acquireLock (Finding 4)', () => {
+  const lockPath = join(tmpdir(), `car-lock-${process.pid}-${Date.now()}`);
+  it('is exclusive: a second acquire fails while held, and succeeds after release', async () => {
+    const a = await acquireLock(lockPath);
+    assert.equal(a.ok, true);
+    const b = await acquireLock(lockPath);
+    assert.equal(b.ok, false);              // another run holds it
+    await a.release();
+    const c = await acquireLock(lockPath);
+    assert.equal(c.ok, true);               // free again
+    await c.release();
+  });
+  it('steals a stale lock whose holder pid is dead', async () => {
+    await writeFile(lockPath, '2147483646');  // a pid that is not alive
+    const a = await acquireLock(lockPath);
+    assert.equal(a.ok, true);               // stole the stale lock
+    await a.release();
   });
 });
 

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -112,6 +112,23 @@ describe('acquireLock (Finding 4)', () => {
     assert.match(still, /someone-else/);
     await unlink(lockPath);
   });
+  // --- Review follow-up: the unlink-based steal double-held (reviewer reproduced 1/120).
+  //     link()-create + rename()-steal grant to exactly one racer. In-process contention
+  //     exercises the interleaving. ---
+  it('grants the lock to exactly one of many concurrent acquirers (no contention)', async () => {
+    const results = await Promise.all(Array.from({ length: 8 }, () => acquireLock(lockPath)));
+    assert.equal(results.filter(r => r.ok).length, 1);
+    // whoever won leaves exactly one lock file; content is never empty
+    const held = (await readFile(lockPath, 'utf-8'));
+    assert.ok(held.trim().length > 0);
+    await Promise.all(results.map(r => r.release()));
+  });
+  it('grants to exactly one when a stale lock is contended', async () => {
+    await writeFile(lockPath, '2147483646');   // stale, dead pid
+    const results = await Promise.all(Array.from({ length: 8 }, () => acquireLock(lockPath)));
+    assert.equal(results.filter(r => r.ok).length, 1);
+    await Promise.all(results.map(r => r.release()));
+  });
 });
 
 // A small fixture: pane %1 (pane_pid 100) has a claude (200) as a child; pane %2 (300)

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -338,6 +338,25 @@ describe('planReconcile', () => {
     ];
     assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%1', pid: 200 }]);
   });
+  // Fable review F5: a standalone "-p" INSIDE the prompt (after the first positional) must
+  // NOT be read as print mode — the old regex matched it and left the session invisible
+  // (neither armed nor skipped). Only a "-p" flag before the prompt counts.
+  it('arms an interactive claude whose PROMPT contains a standalone -p token', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Sl+', comm: 'claude', args: 'claude explain what the -p flag does' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%1', pid: 200 }]);
+  });
+  it('still treats a leading -p flag (with other flags before it) as print mode', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Rl+', comm: 'claude', args: 'claude --verbose -p "do a thing"' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
+  });
 
   it('resolves a claude nested several levels below the pane shell', () => {
     const panes = [{ pane: '%1', panePid: 100 }];

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -58,11 +58,33 @@ describe('planReconcile', () => {
     assert.equal(skipped.find(s => s.pane === '%2').reason, 'self (excluded)');
   });
 
-  it('honors an explicit exclude list (durable, e.g. from the systemd timer)', () => {
+  it('honors a pane-id exclude entry', () => {
     const { panes, processes } = fixture();
     const { arm, skipped } = planReconcile({ panes, processes, running: new Map(), exclude: ['%1'] });
     assert.deepEqual(arm, [{ pane: '%2', pid: 400 }]);
-    assert.equal(skipped.find(s => s.pane === '%1').reason, 'excluded');
+    assert.equal(skipped.find(s => s.pane === '%1').reason, 'excluded (pane)');
+  });
+
+  it('honors a claude-PID exclude entry (reuse-proof form)', () => {
+    const { panes, processes } = fixture();
+    // Exclude by the claude PID (400 = the %2 session), not the pane.
+    const { arm, skipped } = planReconcile({ panes, processes, running: new Map(), exclude: ['400'] });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 200 }]);
+    assert.equal(skipped.find(s => s.pane === '%2').reason, 'excluded (pid)');
+  });
+
+  it('a PID exclude matches the FOREGROUND claude after pane-id reuse', () => {
+    // Pane %1 reused: background claude 200 (old, excluded) + foreground 201 (current).
+    // Excluding pane %1 would wrongly mute the new session; excluding PID 200 does not.
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Ssl', comm: 'claude' },
+      { pid: 201, ppid: 100, stat: 'Sl+', comm: 'claude' },
+    ];
+    // target resolves to foreground 201; excluding old PID 200 must NOT skip it.
+    const { arm } = planReconcile({ panes, processes, running: new Map(), exclude: ['200'] });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 201 }]);
   });
 
   it('pane-id reuse: prefers the FOREGROUND claude when two share a pane', () => {

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parsePanes, parseProcesses, parseRunningMonitors, planReconcile,
+} from '../src/reconcile.js';
+
+describe('reconcile parsing', () => {
+  it('parses tmux pane list', () => {
+    const p = parsePanes('%1 460807\n%10 1642861\n\n');
+    assert.deepEqual(p, [{ pane: '%1', panePid: 460807 }, { pane: '%10', panePid: 1642861 }]);
+  });
+  it('parses ps output with multi-word comm', () => {
+    const p = parseProcesses('1842917 460471 Sl+ claude\n460471 1 Ss bash\n');
+    assert.deepEqual(p[0], { pid: 1842917, ppid: 460471, stat: 'Sl+', comm: 'claude' });
+  });
+  it('extracts covered pane/pid keys from pgrep output', () => {
+    const c = parseRunningMonitors('1866839 node /x/src/monitor.js %1 2453159\n1866840 node /x/src/monitor.js %10 1842917\n');
+    assert.equal(c.get('%1 2453159'), 1866839);
+    assert.equal(c.get('%10 1842917'), 1866840);
+    assert.equal(c.size, 2);
+  });
+  it('empty pgrep output → no covered', () => assert.equal(parseRunningMonitors('').size, 0));
+});
+
+// A small fixture: pane %1 (pane_pid 100) has a claude (200) as a child; pane %2 (300)
+// has a claude (400). Process tree links claude→shell(pane_pid).
+function fixture() {
+  const panes = [{ pane: '%1', panePid: 100 }, { pane: '%2', panePid: 300 }];
+  const processes = [
+    { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+    { pid: 200, ppid: 100, stat: 'Sl+', comm: 'claude' },
+    { pid: 300, ppid: 1, stat: 'Ss', comm: 'bash' },
+    { pid: 400, ppid: 300, stat: 'Sl+', comm: 'claude' },
+  ];
+  return { panes, processes };
+}
+
+describe('planReconcile', () => {
+  it('arms a monitor for each live claude pane', () => {
+    const { panes, processes } = fixture();
+    const { arm } = planReconcile({ panes, processes, running: new Map() });
+    assert.deepEqual(arm.sort((a, b) => a.pane < b.pane ? -1 : 1),
+      [{ pane: '%1', pid: 200 }, { pane: '%2', pid: 400 }]);
+  });
+
+  it('skips a pane that already has a monitor', () => {
+    const { panes, processes } = fixture();
+    const running = parseRunningMonitors('9 node src/monitor.js %1 200\n');
+    const { arm, skipped } = planReconcile({ panes, processes, running });
+    assert.deepEqual(arm, [{ pane: '%2', pid: 400 }]);
+    assert.equal(skipped.find(s => s.pane === '%1').reason, 'already monitored');
+  });
+
+  it('never arms the self pane', () => {
+    const { panes, processes } = fixture();
+    const { arm, skipped } = planReconcile({ panes, processes, running: new Map(), selfPane: '%2' });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 200 }]);
+    assert.equal(skipped.find(s => s.pane === '%2').reason, 'self (excluded)');
+  });
+
+  it('pane-id reuse: prefers the FOREGROUND claude when two share a pane', () => {
+    // Two claudes resolve to pane %1 (pane-id was reused); only 201 is foreground ('+').
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Ssl', comm: 'claude' },   // background
+      { pid: 201, ppid: 100, stat: 'Sl+', comm: 'claude' },   // foreground
+    ];
+    const { arm } = planReconcile({ panes, processes, running: new Map() });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 201 }]);
+  });
+
+  it('pane-id reuse with no foreground marker: falls back to the highest pid', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Ssl', comm: 'claude' },
+      { pid: 250, ppid: 100, stat: 'Ssl', comm: 'claude' },
+    ];
+    const { arm } = planReconcile({ panes, processes, running: new Map() });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 250 }]);
+  });
+
+  it('ignores non-claude panes and panes with no claude', () => {
+    const panes = [{ pane: '%1', panePid: 100 }, { pane: '%9', panePid: 900 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Sl+', comm: 'claude' },
+      { pid: 900, ppid: 1, stat: 'Ss+', comm: 'vim' },       // %9 runs vim, no claude
+    ];
+    const { arm } = planReconcile({ panes, processes, running: new Map() });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 200 }]);
+  });
+
+  it('resolves a claude nested several levels below the pane shell', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 150, ppid: 100, stat: 'Sl', comm: 'node' },     // wrapper/launcher
+      { pid: 200, ppid: 150, stat: 'Sl+', comm: 'claude' },  // actual claude
+    ];
+    const { arm } = planReconcile({ panes, processes, running: new Map() });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 200 }]);
+  });
+});

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { writeFile, unlink, readFile } from 'node:fs/promises';
 import {
   parsePanes, parseProcesses, parseRunningMonitors, planReconcile, runningFromPgrep,
-  pruneExcludeEntries, acquireLock,
+  pruneExcludeEntries, acquireLock, processStartToken,
 } from '../src/reconcile.js';
 
 describe('reconcile parsing', () => {
@@ -80,6 +80,37 @@ describe('acquireLock (Finding 4)', () => {
     const a = await acquireLock(lockPath);
     assert.equal(a.ok, true);               // stole the stale lock
     await a.release();
+  });
+
+  // --- Review follow-up: a bare-PID lock can't survive PID reuse. A stale lock holding a
+  //     PID the kernel later reuses for an UNRELATED live process would read as "alive"
+  //     forever → acquireLock wedged at {ok:false} → self-healing silently off. The lock
+  //     identity now includes the process START TOKEN, so a reused PID (different start)
+  //     is correctly seen as stale and stolen. ---
+  it('does not wedge on PID reuse: steals a lock whose PID is alive but start-token differs', async () => {
+    // our own live PID, but a start token that can't match this process → must be stealable
+    await writeFile(lockPath, `${process.pid}\tSTALE-START-TOKEN-0000`);
+    const a = await acquireLock(lockPath);
+    assert.equal(a.ok, true);               // recognized stale via start-token mismatch, stolen
+    await a.release();
+  });
+  it('respects a genuine live holder whose start token matches (does not steal)', async () => {
+    // our live PID WITH its real start token = a genuine live holder; must not be stolen.
+    await writeFile(lockPath, `${process.pid}\t${await processStartToken(process.pid)}`);
+    const a = await acquireLock(lockPath);
+    assert.equal(a.ok, false);              // live holder, matching identity → back off
+    await unlink(lockPath);
+  });
+  // --- Review follow-up: release() must not cross-delete. If we were stolen from (the lock
+  //     now holds someone else's identity), releasing must leave their lock intact. ---
+  it('release only removes the lock when we still own it (no cross-delete)', async () => {
+    const a = await acquireLock(lockPath);
+    assert.equal(a.ok, true);
+    await writeFile(lockPath, '999999\tsomeone-else');  // a concurrent run replaced it
+    await a.release();                                   // must NOT delete their lock
+    const still = await readFile(lockPath, 'utf-8');
+    assert.match(still, /someone-else/);
+    await unlink(lockPath);
   });
 });
 

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   parsePanes, parseProcesses, parseRunningMonitors, planReconcile, runningFromPgrep,
+  pruneExcludeEntries,
 } from '../src/reconcile.js';
 
 describe('reconcile parsing', () => {
@@ -68,6 +69,26 @@ function fixture() {
   ];
   return { panes, processes };
 }
+
+// --- Finding 5: exclude entries claimed to be self-expiring but a dead PID was never
+//     pruned and matched by bare string compare, so kernel PID reuse could mute a future
+//     claude forever. pruneExcludeEntries drops numeric entries whose process is gone,
+//     while keeping pane ids (%N, hand-managed) and live PIDs. ---
+describe('pruneExcludeEntries (Finding 5)', () => {
+  const alive = (pid) => new Set([200, 400]).has(pid);
+  it('drops a dead PID entry', () => {
+    assert.deepEqual(pruneExcludeEntries(['200', '999'], alive), ['200']);
+  });
+  it('keeps pane-id entries untouched (user-managed)', () => {
+    assert.deepEqual(pruneExcludeEntries(['%2', '999'], alive), ['%2']);
+  });
+  it('keeps live PIDs and drops only the dead ones', () => {
+    assert.deepEqual(pruneExcludeEntries(['200', '400', '999', '%3'], alive), ['200', '400', '%3']);
+  });
+  it('is a no-op on an empty list', () => {
+    assert.deepEqual(pruneExcludeEntries([], alive), []);
+  });
+});
 
 describe('planReconcile', () => {
   it('arms a monitor for each live claude pane', () => {

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -9,9 +9,15 @@ describe('reconcile parsing', () => {
     const p = parsePanes('%1 460807\n%10 1642861\n\n');
     assert.deepEqual(p, [{ pane: '%1', panePid: 460807 }, { pane: '%10', panePid: 1642861 }]);
   });
-  it('parses ps output with multi-word comm', () => {
-    const p = parseProcesses('1842917 460471 Sl+ claude\n460471 1 Ss bash\n');
-    assert.deepEqual(p[0], { pid: 1842917, ppid: 460471, stat: 'Sl+', comm: 'claude' });
+  it('parses ps output with comm and args (args is the trailing field)', () => {
+    const p = parseProcesses('1842917 460471 Sl+ claude claude -p "do a thing"\n460471 1 Ss bash -bash\n');
+    assert.deepEqual(p[0], { pid: 1842917, ppid: 460471, stat: 'Sl+', comm: 'claude', args: 'claude -p "do a thing"' });
+    assert.equal(p[1].comm, 'bash');
+  });
+  it('tolerates a missing args column (comm-only ps output)', () => {
+    const p = parseProcesses('1842917 460471 Sl+ claude\n');
+    assert.equal(p[0].comm, 'claude');
+    assert.equal(p[0].args, '');
   });
   it('extracts covered pane/pid keys from pgrep output', () => {
     const c = parseRunningMonitors('1866839 node /x/src/monitor.js %1 2453159\n1866840 node /x/src/monitor.js %10 1842917\n');
@@ -136,6 +142,43 @@ describe('planReconcile', () => {
     ];
     const { arm } = planReconcile({ panes, processes, running: new Map() });
     assert.deepEqual(arm, [{ pane: '%1', pid: 200 }]);
+  });
+
+  // --- Finding 8: a `claude -p` (print mode) pane must NOT get a send-keys monitor — the
+  //     wrapper never arms one there, and retry text injected into piped/scripted output
+  //     would corrupt it. Filter processes whose argv carries -p/--print. ---
+  it('does not arm a monitor for a claude running in print mode (-p)', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Rl+', comm: 'claude', args: 'claude -p "summarize the diff"' },
+    ];
+    const { arm } = planReconcile({ panes, processes, running: new Map() });
+    assert.deepEqual(arm, []);
+  });
+  it('does not arm for the --print long form either', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Rl+', comm: 'claude', args: 'claude --print "hi"' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
+  });
+  it('still arms an interactive claude (args present, no -p)', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Sl+', comm: 'claude', args: 'claude --resume' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%1', pid: 200 }]);
+  });
+  it('does not mistake a prompt word for the -p flag', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'Sl+', comm: 'claude', args: 'claude add a -pretty flag' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%1', pid: 200 }]);
   });
 
   it('resolves a claude nested several levels below the pane shell', () => {

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -58,6 +58,13 @@ describe('planReconcile', () => {
     assert.equal(skipped.find(s => s.pane === '%2').reason, 'self (excluded)');
   });
 
+  it('honors an explicit exclude list (durable, e.g. from the systemd timer)', () => {
+    const { panes, processes } = fixture();
+    const { arm, skipped } = planReconcile({ panes, processes, running: new Map(), exclude: ['%1'] });
+    assert.deepEqual(arm, [{ pane: '%2', pid: 400 }]);
+    assert.equal(skipped.find(s => s.pane === '%1').reason, 'excluded');
+  });
+
   it('pane-id reuse: prefers the FOREGROUND claude when two share a pane', () => {
     // Two claudes resolve to pane %1 (pane-id was reused); only 201 is foreground ('+').
     const panes = [{ pane: '%1', panePid: 100 }];

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -87,6 +87,23 @@ describe('planReconcile', () => {
     assert.deepEqual(arm, [{ pane: '%1', pid: 201 }]);
   });
 
+  // --- Finding 3: coverage is keyed PER PANE, not per (pane,pid). A SIGSTOP'd claude
+  //     keeps its monitor alive (kill(pid,0) succeeds on stopped procs); without per-pane
+  //     keying, reconcile arms a SECOND monitor for the new foreground claude in the same
+  //     pane and both send retry keys on a banner. One monitor per pane, whatever the pid. ---
+  it('does not arm a second monitor for a pane that already has one (stopped + new foreground)', () => {
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 200, ppid: 100, stat: 'T', comm: 'claude' },    // SIGSTOP'd — its monitor is still alive
+      { pid: 201, ppid: 100, stat: 'Sl+', comm: 'claude' },  // new foreground claude
+    ];
+    const running = parseRunningMonitors('9 node src/monitor.js %1 200\n');  // monitor covers the pane (for pid 200)
+    const { arm, skipped } = planReconcile({ panes, processes, running });
+    assert.deepEqual(arm, []);   // pane already covered — do NOT arm a second
+    assert.equal(skipped.find(s => s.pane === '%1').reason, 'already monitored');
+  });
+
   it('pane-id reuse: prefers the FOREGROUND claude when two share a pane', () => {
     // Two claudes resolve to pane %1 (pane-id was reused); only 201 is foreground ('+').
     const panes = [{ pane: '%1', panePid: 100 }];


### PR DESCRIPTION
> ♻️ Recreated from #32 to rebase onto the current `master`. The base branch history was cleaned up, which invalidated the fork-based PR's diff. **All commits are @romerjon's — authorship preserved**; only the base was updated (and merged cleanly, tests green). No action needed from @romerjon; superseded PR #32 will be closed with a pointer here.

---

**Problem.** Monitors are detached processes with no supervising service. If one is killed/crashes — or a claude session is started outside the wrapper — that live session is silently left unmonitored. Only *new* wrapper-launched sessions get a monitor, so coverage degrades over time with no way to restore it short of manual `pgrep`/`kill`/relaunch (error-prone: pane IDs get reused).

**`reconcile`.** Re-arms a monitor for every live tmux pane running claude that isn't already covered, from authoritative tmux + process state:
- maps each live claude to its tmux pane by walking the process tree to the pane's `pane_pid`;
- skips panes that already have a monitor (idempotent — safe to run anytime / on a timer);
- never arms its own pane (`$TMUX_PANE`);
- handles **pane-id reuse** (two claudes resolving to one recycled pane → prefer the foreground one, else highest pid);
- `--dry-run` previews the plan.

The pure parse/plan core is separated from the tmux/ps/spawn runner and unit-tested (11 tests). Uses `spawn` (not `fork`) for the detached monitors so no IPC channel keeps the CLI alive — it exits immediately after arming.

Usage:
```
claude-auto-retry reconcile            # re-arm all uncovered live sessions
claude-auto-retry reconcile --dry-run  # preview
```

Pairs well with a periodic `--user` timer to make monitor coverage self-healing.