### PR TITLE
fix(patterns): chrome-aware tail so a limit banner behind a task widget still detects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Chrome-aware detection.** Limit/overload/menu detectors now skip trailing UI
+  furniture (input box, footer, key hints, todo/task widget, status spinner,
+  `/usage-credits` hint) before reading the live tail, so a genuine banner behind a tall
+  task widget is still detected (fixes a ~54-min stall) while a banner merely quoted in
+  scrollback is not (#34).
 - Safeguard/AUP false-positive auto-retry: when the model's safeguards flag a
   message ("safeguards flagged this message"), re-send a short retry up to
   `safeguard.maxRetries` times, then give up loudly once. Detection is anchored
@@ -23,11 +28,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actual poll interval, not a fixed constant).
 
 ### Fixed
+- The `/usage-credits` backstop no longer reopens the scrollback false positive: it only
+  fires when the companion sits in the live region (nothing but chrome below it), so a
+  resumed session's stale banner+companion can't drive spurious retries or a ~24h wait (#34).
+- `isWorking` is chrome-aware, matching `isRateLimited`: a live "esc to interrupt" footer
+  pushed up by a chrome stack is no longer missed, so retry text can't land in a
+  mid-flight session (#34).
+- The `/rate-limit-options` menu detectors are chrome-aware too, so a live menu behind a
+  widget is driven to "Stop and wait" instead of skipped (which risked confirming
+  "Upgrade your plan") (#34).
+- Overload detection is bounded to a max raw distance from the prompt, so the deeper
+  50-line capture can't reach an old quoted `API Error` buried behind a tall widget (#34).
+- Chrome classifiers are anchored to real footer/widget renders (pipe-anchored version,
+  indented task items, `⏵⏵` mode footer), so ordinary content — `Press ctrl+c…`, a
+  `→` rename, a flush-left `✓ …` summary, `Released v0.5.1` — is no longer stripped (#34).
 - `rate_limit` StopFailure events are no longer routed through the seconds-scale
   overload path — a session/usage limit is an hours-scale wait owned by the
   usage path, and the misroute made the two fight (futile `Continue` retries
   into a session-limited pane). The marker error type is validated at the
   consumer too, so an outdated installed hook can't reintroduce it (#31).
+
+### Changed
+- `customPatterns` are matched against the raw last-N lines (unchanged from pre-#34
+  semantics), not the chrome-skipped view — the user owns their own tradeoff (#34).
 
 ## [0.5.1] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ They may flag safe, normal content as well. … Claude Code can't respond to thi
 
 Custom patterns can be added via config for future message format changes.
 
+Detection is **chrome-aware**: it looks at the live bottom of the pane, but first skips
+past Claude Code's UI furniture — the input box, footer, key hints, the todo/task widget,
+the status spinner, and the `/usage-credits` hint. So a genuine limit banner still
+registers even when a tall task list or background-agent status pushes it well above the
+prompt, while a banner merely *quoted* in scrollback (with real output below it) does not
+trigger a retry.
+
 ## Configuration
 
 Optional. Create `~/.claude-auto-retry.json`:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ registers even when a tall task list or background-agent status pushes it well a
 prompt, while a banner merely *quoted* in scrollback (with real output below it) does not
 trigger a retry.
 
+Your own `customPatterns` are the exception: they are matched against the **raw** last-N
+lines (not the chrome-skipped view), so a pattern keyed on footer text — a usage
+percentage, a model name — keeps firing. You own the false-positive tradeoff for your
+regexes; the built-in detection keeps the chrome-aware discipline.
+
 ## Configuration
 
 Optional. Create `~/.claude-auto-retry.json`:

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -103,7 +103,10 @@ function enterOverload(state, overload, rand) {
 export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, rand = Math.random) {
   if (!isAlive()) return 'exit';
 
-  const raw = await tmuxAdapter.capturePane(pane, 20);
+  // Capture generously (was 20): a live banner can sit far above the bottom behind a tall
+  // task widget + input box + footer. The detectors chrome-strip and tail-window this, so
+  // extra lines are free headroom; 50 clears a large widget with margin.
+  const raw = await tmuxAdapter.capturePane(pane, 50);
   const stripped = stripAnsi(raw);
   const overload = config.overload;
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -185,8 +185,12 @@ const MENU_OPTION_REGEX = /^\s*❯?\s*\d+\.\s/;
 // same menu text quoted in scrollback (a conversation about limits) must not make us
 // drive arrow keys + Enter into whatever is actually on screen.
 export function isRateLimitOptionsPrompt(text, tailLines = 0) {
-  let lines = stripAnsi(text).split('\n');
-  if (tailLines > 0) lines = lines.slice(-tailLines);
+  const all = stripAnsi(text).split('\n');
+  // Chrome-aware, like the banner detectors (Finding 5): a live menu pushed up by a tall
+  // widget below it must still be seen, or the menu branch is skipped and a later sendKeys
+  // types into the open menu (Enter confirms the default "Upgrade your plan"). Menu lines
+  // are not chrome, so contentTail keeps them.
+  const lines = tailLines > 0 ? contentTail(all, tailLines) : all;
   const t = lines.join('\n');
   return /what do you want to do\?/i.test(t)
     && WAIT_OPTION_REGEX.test(t)
@@ -199,8 +203,8 @@ export function isRateLimitOptionsPrompt(text, tailLines = 0) {
 // caller MUST NOT press Enter in that case, to avoid confirming the wrong option.
 // tailLines mirrors isRateLimitOptionsPrompt so option counting ignores quoted menus.
 export function menuStepsToWaitOption(text, tailLines = 0) {
-  let lines = stripAnsi(text).split('\n');
-  if (tailLines > 0) lines = lines.slice(-tailLines);
+  const all = stripAnsi(text).split('\n');
+  const lines = tailLines > 0 ? contentTail(all, tailLines) : all;  // chrome-aware, matches isRateLimitOptionsPrompt (Finding 5)
   const optionLines = lines.filter(l => MENU_OPTION_REGEX.test(l));
   if (optionLines.length === 0) return null;
   const cursorPos = optionLines.findIndex(l => l.includes(MENU_CURSOR));

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -65,18 +65,27 @@ const CHROME_LINE = [
                                                      // banner back in. The glyph is the discriminator.
   /^\s*[❯>]\s*$/,                                    // empty input prompt (bare, unboxed)
   /^\s*⏵⏵/,                                          // mode footer ("⏵⏵ auto mode on…", "⏵⏵ accept edits…")
-  /\bauto mode\b/i,                                 // footer mode text / "Allowed by auto mode" notice
+  /Allowed by auto mode/i,                          // "Allowed by auto mode" permission notice (anchored to
+                                                     // the full phrase — bare /auto mode/ matched prose like
+                                                     // "auto mode is enabled in your settings"; the footer
+                                                     // itself is already covered by /^\s*⏵⏵/ above)
   /shift\+tab to (?:cycle|select)/i,                // tab-cycle footer hint (anchored to the phrase)
   /^\s*\?\s+for shortcuts\b/i,                       // "? for shortcuts" footer hint
   /\|\s*v\d+\.\d+\.\d+\b/,                           // footer version segment ("… | v2.1.201"), pipe-anchored
   /^\s+[□◻■◼▢▪◽◾✓✔☐☑]\s+\S/,                          // INDENTED todo/task items (leading ws required — a
                                                      // flush-left "✓ Fixed the bug" summary is content)
-  /^\s*\d+\s+tasks?\b/i,                             // task widget header ("8 tasks (…)")
+  /^\s*\d+\s+tasks?\s+\(/i,                           // task widget header ("8 tasks (…)") — the "(" count is
+                                                     // required so prose ("3 tasks remain in the backlog")
+                                                     // isn't stripped
   /^\s*…\s*\+\d+\b/,                                 // "… +N completed"
-  /new task\?|\/clear to save/i,                     // "new task? /clear to save …k tokens"
+  /\/clear to save/i,                               // "new task? /clear to save …k tokens" — anchored to the
+                                                     // save hint; bare /new task\?/ matched prose questions
+                                                     // ("Should I start the new task?")
   USAGE_CREDITS,                                     // live-limit companion hint (shared w/ the backstop)
   /^\s*[✻✢✽✳✴✶✷]\s/,                                 // status spinner ("✻ Brewed for …")
-  /Backgrounded agent|to manage · /i,                // background-agent notices
+  /Backgrounded agent \(|to manage · /i,             // background-agent notice — the "(" (or "to manage ·")
+                                                     // is required so prose ("Backgrounded agent finished
+                                                     // the lint run") isn't stripped
 ];
 // A live working footer ("✻ Cogitating… (esc to interrupt)") matches the spinner glyph
 // pattern above, so it must be excluded explicitly — it is live content, never furniture.

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -17,6 +17,20 @@ export function stripAnsi(text) {
     .replace(CSI_REGEX, '');
 }
 
+// Indicators that Claude is mid-flight and the pane is NOT in a terminal error state.
+// Two kinds: the streaming footer, and Claude Code's OWN internal-retry indicator.
+// While either is on screen the request's retries are not exhausted — acting now would
+// interrupt Claude's backoff. Defined up here because isChromeLine excludes these lines
+// (a live working footer must never be stripped as furniture) and isWorking scans for
+// them; both need the predicate.
+const WORKING_PATTERNS = [
+  /esc to interrupt/i,        // the working/streaming footer ("… (esc to interrupt)")
+  /\besc\b.*\binterrupt\b/i,  // tolerate reordering/spacing in the same footer
+  /Retrying in\b/i,           // internal-retry suffix — retries not yet exhausted
+  /\battempt\s+\d+\/\d+/i,    // "attempt 3/10" companion to the retry suffix
+];
+const isWorkingLine = (l) => WORKING_PATTERNS.some((p) => p.test(l));
+
 // --- Chrome-aware tail ---
 // Claude Code renders UI chrome BELOW the meaningful content: the input box, the footer
 // (model/usage/version), key hints, the todo/task widget, the status spinner
@@ -29,8 +43,6 @@ export function stripAnsi(text) {
 // scrollback false-positive fixed (real work below a quoted banner is NOT chrome, so it
 // isn't stripped and the stale banner stays out of the window).
 //
-// NOTE: the working footer ("… (esc to interrupt)") is deliberately NOT treated as
-// chrome — isWorking must still see it — so it uses the raw tail, not this one.
 // Each entry must be ANCHORED to how Claude Code actually renders the furniture — a
 // full-line shape, leading indentation, or a footer position — not just "the line
 // contains this glyph." The miss cost here is a false retry (stripping content lets a
@@ -54,7 +66,9 @@ const CHROME_LINE = [
   /^\s*[✻✢✽✳✴✶✷]\s/,                                 // status spinner ("✻ Brewed for …")
   /Backgrounded agent|to manage · /i,                // background-agent notices
 ];
-const isChromeLine = (l) => CHROME_LINE.some((r) => r.test(l));
+// A live working footer ("✻ Cogitating… (esc to interrupt)") matches the spinner glyph
+// pattern above, so it must be excluded explicitly — it is live content, never furniture.
+const isChromeLine = (l) => !isWorkingLine(l) && CHROME_LINE.some((r) => r.test(l));
 
 // Last `n` lines AFTER dropping trailing chrome, so a tall widget / input box below a
 // banner doesn't consume the window budget. Operates on an array of already-split lines.
@@ -212,30 +226,10 @@ export function menuStepsToWaitOption(text, tailLines = 0) {
 // still trimming the top ~8 lines of the 20-line capture (where stale scrollback lives).
 const OVERLOAD_TAIL_LINES = 12;
 
-// Indicators that Claude is mid-flight and the pane is NOT in a terminal error state.
-// Two kinds: the streaming footer, and Claude Code's OWN internal-retry indicator.
-// While either is on screen the request's retries are not exhausted — acting now would
-// interrupt Claude's backoff. The transient error render is "API Error (529 …) ·
-// Retrying in 5s · attempt 3/10"; the colon form can also carry the "· Retrying" suffix
-// until exhausted, so we gate on the suffix itself, not just the parens form.
-const WORKING_PATTERNS = [
-  /esc to interrupt/i,        // the working/streaming footer ("… (esc to interrupt)")
-  /\besc\b.*\binterrupt\b/i,  // tolerate reordering/spacing in the same footer
-  /Retrying in\b/i,           // internal-retry suffix — retries not yet exhausted
-  /\battempt\s+\d+\/\d+/i,    // "attempt 3/10" companion to the retry suffix
-];
-
 // Chrome-aware tail for the error/limit detectors: a terminal error can be pushed up by
 // the same widgets that pushed the limit banner, so strip trailing chrome first.
 function tail(text) {
   return contentTail(stripAnsi(text).split('\n'), OVERLOAD_TAIL_LINES);
-}
-
-// Raw tail (no chrome-strip) for isWorking: the working footer "… (esc to interrupt)"
-// and the "✻ … Retrying" indicator would otherwise be stripped as chrome, and isWorking
-// MUST still see them (they mean "do not act — Claude is mid-flight").
-function rawTail(text) {
-  return stripAnsi(text).split('\n').slice(-OVERLOAD_TAIL_LINES);
 }
 
 // Compile a config pattern (string → case-insensitive RegExp) once per call. Invalid
@@ -305,9 +299,13 @@ export function detectSafeguard(text, patterns = []) {
   return safeguardMatch(text, patterns) !== null;
 }
 
+// Chrome-aware, so isWorking measures the SAME bottom as isRateLimited/detectOverload. A
+// live working footer pushed up by a tall chrome stack below it (task widget + input box
+// + footer) would be invisible to a raw last-N tail while the chrome-aware detectors still
+// saw a lingering banner — the asymmetry that let retry text land in a mid-flight session
+// (Finding 3). isChromeLine excludes working lines, so contentTail never strips the footer.
 export function isWorking(text) {
-  const lines = rawTail(text);
-  return lines.some(line => WORKING_PATTERNS.some(p => p.test(line)));
+  return contentTail(stripAnsi(text).split('\n'), OVERLOAD_TAIL_LINES).some(isWorkingLine);
 }
 
 export function findRateLimitMessage(text, customPatterns = []) {

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -57,7 +57,7 @@ const isWorkingLine = (l) => WORKING_PATTERNS.some((p) => p.test(l));
 const CHROME_LINE = [
   /^\s*$/,                                          // blank
   /^[\s─│╭╮╰╯┌┐└┘├┤┬┴┼▏▕|]+$/,                       // box-drawing / rules
-  /^\s*│\s*[>❯].*│\s*$/,                             // boxed input row ("│ > … │"): anchored to
+  /^\s*│\s*[>❯][^│]*│\s*$/,                          // boxed input row ("│ > … │"): anchored to
                                                      // the PROMPT GLYPH, not "anything between two
                                                      // bars" — a bare │…│ rule matches unicode-
                                                      // border tool output (psql/duf tables) and
@@ -162,9 +162,13 @@ export function isRateLimited(text, customPatterns = [], tailLines = 0) {
   // tail-scoped; print mode uses the full scan below.)
   if (tailLines > 0) {
     const companionIdx = all.findLastIndex((l) => USAGE_CREDITS.test(l));
+    // Require a RESET line nearby — NOT just a LIMIT line. A live limit banner always prints
+    // its reset time next to the companion; a session merely *explaining* usage limits ("when
+    // you hit your usage limit you can run /usage-credits …") has the companion + a loose
+    // "usage limit" LIMIT match but no reset time, and would otherwise false-fire a retry.
     if (companionIdx !== -1
         && all.slice(companionIdx + 1).every(isChromeLine)
-        && (hasNearbyMatch(all, companionIdx, RESET_PATTERNS) || hasNearbyMatch(all, companionIdx, LIMIT_PATTERNS))) {
+        && hasNearbyMatch(all, companionIdx, RESET_PATTERNS)) {
       return true;
     }
   }

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -72,10 +72,16 @@ const isChromeLine = (l) => !isWorkingLine(l) && CHROME_LINE.some((r) => r.test(
 
 // Last `n` lines AFTER dropping trailing chrome, so a tall widget / input box below a
 // banner doesn't consume the window budget. Operates on an array of already-split lines.
-function contentTail(lines, n) {
+// maxRaw (optional) additionally caps how far above the FULL bottom the window may reach:
+// with it set, a line further than maxRaw raw lines from the bottom is excluded even if
+// chrome-stripping would otherwise expose it — bounding content-distance for the overload
+// path (Finding 6), where a terminal error sits just above the input box and anything
+// reachable only past a tall widget is stale scrollback, not a live error.
+function contentTail(lines, n, maxRaw = Infinity) {
   let end = lines.length;
   while (end > 0 && isChromeLine(lines[end - 1])) end--;
-  return lines.slice(Math.max(0, end - n), end);
+  const start = Math.max(0, end - n, lines.length - maxRaw);
+  return lines.slice(start, end);
 }
 
 // Claude Code renders rate limits across multiple lines in its TUI, e.g.:
@@ -234,11 +240,18 @@ export function menuStepsToWaitOption(text, tailLines = 0) {
 // its anchor line can land ~10 rows from the bottom. 12 covers that with margin while
 // still trimming the top ~8 lines of the 20-line capture (where stale scrollback lives).
 const OVERLOAD_TAIL_LINES = 12;
+// Hard raw-distance cap for the overload path. A terminal API error renders just above
+// the input box; an error only reachable by chrome-stripping past a tall widget is stale
+// scrollback, not live. Bounds the deeper (50-line) capture so overload — seconds-scale
+// and more false-positive-prone than the reset-anchored limit path — can't reach an old
+// quoted error. 20 matches master's original capture depth. (Finding 6.)
+const OVERLOAD_MAX_RAW_LINES = 20;
 
-// Chrome-aware tail for the error/limit detectors: a terminal error can be pushed up by
-// the same widgets that pushed the limit banner, so strip trailing chrome first.
+// Chrome-aware tail for the overload detectors: a terminal error can be pushed up by the
+// same widgets that pushed the limit banner, so strip trailing chrome first — but bound
+// the reach so a widget-buried stale error stays out.
 function tail(text) {
-  return contentTail(stripAnsi(text).split('\n'), OVERLOAD_TAIL_LINES);
+  return contentTail(stripAnsi(text).split('\n'), OVERLOAD_TAIL_LINES, OVERLOAD_MAX_RAW_LINES);
 }
 
 // Compile a config pattern (string → case-insensitive RegExp) once per call. Invalid

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -17,6 +17,46 @@ export function stripAnsi(text) {
     .replace(CSI_REGEX, '');
 }
 
+// --- Chrome-aware tail ---
+// Claude Code renders UI chrome BELOW the meaningful content: the input box, the footer
+// (model/usage/version), key hints, the todo/task widget, the status spinner
+// ("✻ Brewed for …"), background-agent notices, and the "/usage-credits" hint. A live
+// error/limit banner sits ABOVE this chrome, so when there's a lot of it — e.g. a tall
+// task list — the banner is pushed well up the pane. A fixed last-N-lines tail then
+// scrolls right past a genuine banner (observed: a session-limit banner ~16 lines up
+// behind a task widget went undetected for ~54 min). Stripping trailing chrome first
+// makes the tail measure distance-in-CONTENT, not raw lines — which also keeps the
+// scrollback false-positive fixed (real work below a quoted banner is NOT chrome, so it
+// isn't stripped and the stale banner stays out of the window).
+//
+// NOTE: the working footer ("… (esc to interrupt)") is deliberately NOT treated as
+// chrome — isWorking must still see it — so it uses the raw tail, not this one.
+const CHROME_LINE = [
+  /^\s*$/,                                          // blank
+  /^[\s─│╭╮╰╯┌┐└┘├┤┬┴┼▏▕|]+$/,                       // box-drawing / rules
+  /^\s*[❯>]\s*$/,                                    // empty input prompt
+  /\bauto mode\b/i,                                 // footer: "⏵⏵ auto mode on…"
+  /\bv\d+\.\d+\.\d+\b/,                             // footer: version segment
+  /(?:ctrl|shift)\s*\+|shift\+tab|↑|↓|←|→|\bctrl\+o\b|\/rc\b/i, // key hints / footer glyphs
+  /^\s*[□◻■◼▢▪◽◾✓✔☐☑]\s+\S/,                          // todo/task items (checkbox glyphs only —
+                                                     // NOT ·/• which also separate "· resets 3pm")
+  /^\s*\d+\s+tasks?\b/i,                             // task widget header ("8 tasks (…)")
+  /^\s*…\s*\+\d+\b/,                                 // "… +N completed"
+  /new task\?|\/clear to save/i,                     // "new task? /clear to save …k tokens"
+  /\/usage-credits\b/i,                              // live-limit companion hint
+  /^\s*[✻✢✽✳✴✶✷]\s/,                                 // status spinner ("✻ Brewed for …")
+  /Backgrounded agent|to manage · |Allowed by auto mode/i, // background-agent notices
+];
+const isChromeLine = (l) => CHROME_LINE.some((r) => r.test(l));
+
+// Last `n` lines AFTER dropping trailing chrome, so a tall widget / input box below a
+// banner doesn't consume the window budget. Operates on an array of already-split lines.
+function contentTail(lines, n) {
+  let end = lines.length;
+  while (end > 0 && isChromeLine(lines[end - 1])) end--;
+  return lines.slice(Math.max(0, end - n), end);
+}
+
 // Claude Code renders rate limits across multiple lines in its TUI, e.g.:
 //   "⚠ You've hit your limit"
 //   "· resets 3pm (UTC)"
@@ -54,15 +94,37 @@ function hasNearbyMatch(lines, idx, patterns) {
 // — a conversation discussing limits, a stale banner the session already moved past — are
 // NOT the current state and must not drive a retry. 0 = scan everything (print mode, where
 // the input is captured process output, not a scrolling TUI).
-export function isRateLimited(text, customPatterns = [], tailLines = 0) {
-  let lines = stripAnsi(text).split('\n');
-  if (tailLines > 0) lines = lines.slice(-tailLines);
+// The companion line Claude Code prints directly under a LIVE session/usage-limit banner.
+// It's a distinctive UI string (not something quoted casually), so finding it next to a
+// reset/limit line is a high-confidence live-limit signal even when a tall widget pushed
+// the banner past the content tail — a backstop against the chrome allowlist missing a
+// future UI element.
+const USAGE_CREDITS = /\/usage-credits\b/i;
 
-  // Custom patterns: check full text (user controls their own regex)
+export function isRateLimited(text, customPatterns = [], tailLines = 0) {
+  const all = stripAnsi(text).split('\n');
+  // Chrome-aware window: trailing UI furniture doesn't consume the tail budget.
+  const lines = tailLines > 0 ? contentTail(all, tailLines) : all;
+
+  // Custom patterns: check the window text (user controls their own regex)
   if (customPatterns.length > 0) {
     const full = lines.join('\n');
     const custom = customPatterns.map(p => typeof p === 'string' ? new RegExp(p, 'i') : p);
     if (custom.some(p => p.test(full))) return true;
+  }
+
+  // Backstop for the modern render: a live limit prints "/usage-credits to finish…" right
+  // by the banner. Scan a wider raw window for it adjacent to a limit/reset line, so a
+  // banner buried behind an unrecognized widget is still caught. (Only when tail-scoped;
+  // print mode uses the full scan below.)
+  if (tailLines > 0) {
+    const wide = all.slice(-Math.max(tailLines * 3, 40));
+    for (let i = 0; i < wide.length; i++) {
+      if (USAGE_CREDITS.test(wide[i])
+          && (hasNearbyMatch(wide, i, RESET_PATTERNS) || hasNearbyMatch(wide, i, LIMIT_PATTERNS))) {
+        return true;
+      }
+    }
   }
 
   // Find a "limit" line with a "resets" line nearby (works for both
@@ -153,7 +215,16 @@ const WORKING_PATTERNS = [
   /\battempt\s+\d+\/\d+/i,    // "attempt 3/10" companion to the retry suffix
 ];
 
+// Chrome-aware tail for the error/limit detectors: a terminal error can be pushed up by
+// the same widgets that pushed the limit banner, so strip trailing chrome first.
 function tail(text) {
+  return contentTail(stripAnsi(text).split('\n'), OVERLOAD_TAIL_LINES);
+}
+
+// Raw tail (no chrome-strip) for isWorking: the working footer "… (esc to interrupt)"
+// and the "✻ … Retrying" indicator would otherwise be stripped as chrome, and isWorking
+// MUST still see them (they mean "do not act — Claude is mid-flight").
+function rawTail(text) {
   return stripAnsi(text).split('\n').slice(-OVERLOAD_TAIL_LINES);
 }
 
@@ -225,7 +296,7 @@ export function detectSafeguard(text, patterns = []) {
 }
 
 export function isWorking(text) {
-  const lines = tail(text);
+  const lines = rawTail(text);
   return lines.some(line => WORKING_PATTERNS.some(p => p.test(line)));
 }
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -121,16 +121,19 @@ export function isRateLimited(text, customPatterns = [], tailLines = 0) {
   }
 
   // Backstop for the modern render: a live limit prints "/usage-credits to finish…" right
-  // by the banner. Scan a wider raw window for it adjacent to a limit/reset line, so a
-  // banner buried behind an unrecognized widget is still caught. (Only when tail-scoped;
-  // print mode uses the full scan below.)
+  // by the banner, so finding that companion next to a reset/limit line catches a banner
+  // buried behind a widget the chrome allowlist doesn't recognize. But it needs the SAME
+  // liveness discipline as the main path: only trust the companion when it sits in the
+  // live region — nothing but chrome below it. A resumed session's scrollback always
+  // contains the stale banner+companion with real work rendered below; without this gate
+  // the backstop fires on that (up to maxRetries injections + a ~24h wait). (Only when
+  // tail-scoped; print mode uses the full scan below.)
   if (tailLines > 0) {
-    const wide = all.slice(-Math.max(tailLines * 3, 40));
-    for (let i = 0; i < wide.length; i++) {
-      if (USAGE_CREDITS.test(wide[i])
-          && (hasNearbyMatch(wide, i, RESET_PATTERNS) || hasNearbyMatch(wide, i, LIMIT_PATTERNS))) {
-        return true;
-      }
+    const companionIdx = all.findLastIndex((l) => USAGE_CREDITS.test(l));
+    if (companionIdx !== -1
+        && all.slice(companionIdx + 1).every(isChromeLine)
+        && (hasNearbyMatch(all, companionIdx, RESET_PATTERNS) || hasNearbyMatch(all, companionIdx, LIMIT_PATTERNS))) {
+      return true;
     }
   }
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -17,6 +17,12 @@ export function stripAnsi(text) {
     .replace(CSI_REGEX, '');
 }
 
+// The companion line Claude Code prints directly under a LIVE session/usage-limit banner
+// ("… /usage-credits to finish what you're working on."). A distinctive UI string, so it
+// doubles as furniture in the chrome allowlist and as the high-confidence live-limit
+// backstop signal below — one source of truth for both.
+const USAGE_CREDITS = /\/usage-credits\b/i;
+
 // Indicators that Claude is mid-flight and the pane is NOT in a terminal error state.
 // Two kinds: the streaming footer, and Claude Code's OWN internal-retry indicator.
 // While either is on screen the request's retries are not exhausted — acting now would
@@ -62,7 +68,7 @@ const CHROME_LINE = [
   /^\s*\d+\s+tasks?\b/i,                             // task widget header ("8 tasks (…)")
   /^\s*…\s*\+\d+\b/,                                 // "… +N completed"
   /new task\?|\/clear to save/i,                     // "new task? /clear to save …k tokens"
-  /\/usage-credits\b/i,                              // live-limit companion hint
+  USAGE_CREDITS,                                     // live-limit companion hint (shared w/ the backstop)
   /^\s*[✻✢✽✳✴✶✷]\s/,                                 // status spinner ("✻ Brewed for …")
   /Backgrounded agent|to manage · /i,                // background-agent notices
 ];
@@ -120,14 +126,9 @@ function hasNearbyMatch(lines, idx, patterns) {
 // banner sits at the prompt (the last thing printed); the same words quoted in scrollback
 // — a conversation discussing limits, a stale banner the session already moved past — are
 // NOT the current state and must not drive a retry. 0 = scan everything (print mode, where
-// the input is captured process output, not a scrolling TUI).
-// The companion line Claude Code prints directly under a LIVE session/usage-limit banner.
-// It's a distinctive UI string (not something quoted casually), so finding it next to a
-// reset/limit line is a high-confidence live-limit signal even when a tall widget pushed
-// the banner past the content tail — a backstop against the chrome allowlist missing a
-// future UI element.
-const USAGE_CREDITS = /\/usage-credits\b/i;
-
+// the input is captured process output, not a scrolling TUI). The USAGE_CREDITS companion
+// (defined above) backstops a banner buried behind a widget the chrome allowlist doesn't
+// recognize — trusted only when it sits in the live region (nothing but chrome below it).
 export function isRateLimited(text, customPatterns = [], tailLines = 0) {
   const all = stripAnsi(text).split('\n');
   // Chrome-aware window: trailing UI furniture doesn't consume the tail budget.
@@ -232,13 +233,14 @@ export function menuStepsToWaitOption(text, tailLines = 0) {
 //      or the "overloaded_error" JSON type) — never a bare status number.
 //   2. Only the TAIL of the pane is inspected. A *terminal* error is the last thing
 //      Claude printed; the same digits sitting in scrollback the user scrolled past
-//      are not an error. Matching the full 20-line capture is what drove the false
-//      positives — a 503 far up the buffer kept re-triggering during unrelated work.
+//      are not an error. Scanning the whole capture is what drove the false positives —
+//      a 503 far up the buffer kept re-triggering during unrelated work.
 
 // A real terminal error sits just above the input box (~5-6 variable lines: box
 // borders + input row(s) + footer). A multi-line JSON error body adds a few more, so
-// its anchor line can land ~10 rows from the bottom. 12 covers that with margin while
-// still trimming the top ~8 lines of the 20-line capture (where stale scrollback lives).
+// its anchor line can land ~10 rows from the bottom. 12 content lines cover that with
+// margin; the monitor captures 50 raw lines, so trailing chrome is stripped and this
+// keeps only the live error region (bounded further by OVERLOAD_MAX_RAW_LINES below).
 const OVERLOAD_TAIL_LINES = 12;
 // Hard raw-distance cap for the overload path. A terminal API error renders just above
 // the input box; an error only reachable by chrome-stripping past a tall widget is stale

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -31,21 +31,28 @@ export function stripAnsi(text) {
 //
 // NOTE: the working footer ("… (esc to interrupt)") is deliberately NOT treated as
 // chrome — isWorking must still see it — so it uses the raw tail, not this one.
+// Each entry must be ANCHORED to how Claude Code actually renders the furniture — a
+// full-line shape, leading indentation, or a footer position — not just "the line
+// contains this glyph." The miss cost here is a false retry (stripping content lets a
+// stale banner re-enter the window), so a loose glyph match (a bare "ctrl+", a stray
+// arrow, any semver) is unacceptable. See Finding 2 in the PR review.
 const CHROME_LINE = [
   /^\s*$/,                                          // blank
   /^[\s─│╭╮╰╯┌┐└┘├┤┬┴┼▏▕|]+$/,                       // box-drawing / rules
   /^\s*[❯>]\s*$/,                                    // empty input prompt
-  /\bauto mode\b/i,                                 // footer: "⏵⏵ auto mode on…"
-  /\bv\d+\.\d+\.\d+\b/,                             // footer: version segment
-  /(?:ctrl|shift)\s*\+|shift\+tab|↑|↓|←|→|\bctrl\+o\b|\/rc\b/i, // key hints / footer glyphs
-  /^\s*[□◻■◼▢▪◽◾✓✔☐☑]\s+\S/,                          // todo/task items (checkbox glyphs only —
-                                                     // NOT ·/• which also separate "· resets 3pm")
+  /^\s*⏵⏵/,                                          // mode footer ("⏵⏵ auto mode on…", "⏵⏵ accept edits…")
+  /\bauto mode\b/i,                                 // footer mode text / "Allowed by auto mode" notice
+  /shift\+tab to (?:cycle|select)/i,                // tab-cycle footer hint (anchored to the phrase)
+  /^\s*\?\s+for shortcuts\b/i,                       // "? for shortcuts" footer hint
+  /\|\s*v\d+\.\d+\.\d+\b/,                           // footer version segment ("… | v2.1.201"), pipe-anchored
+  /^\s+[□◻■◼▢▪◽◾✓✔☐☑]\s+\S/,                          // INDENTED todo/task items (leading ws required — a
+                                                     // flush-left "✓ Fixed the bug" summary is content)
   /^\s*\d+\s+tasks?\b/i,                             // task widget header ("8 tasks (…)")
   /^\s*…\s*\+\d+\b/,                                 // "… +N completed"
   /new task\?|\/clear to save/i,                     // "new task? /clear to save …k tokens"
   /\/usage-credits\b/i,                              // live-limit companion hint
   /^\s*[✻✢✽✳✴✶✷]\s/,                                 // status spinner ("✻ Brewed for …")
-  /Backgrounded agent|to manage · |Allowed by auto mode/i, // background-agent notices
+  /Backgrounded agent|to manage · /i,                // background-agent notices
 ];
 const isChromeLine = (l) => CHROME_LINE.some((r) => r.test(l));
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -127,9 +127,14 @@ export function isRateLimited(text, customPatterns = [], tailLines = 0) {
   // Chrome-aware window: trailing UI furniture doesn't consume the tail budget.
   const lines = tailLines > 0 ? contentTail(all, tailLines) : all;
 
-  // Custom patterns: check the window text (user controls their own regex)
+  // Custom patterns test the RAW tail, not the chrome-stripped window (Finding 4). The
+  // user owns their own false-positive tradeoff, so a pattern keyed on footer text (a
+  // usage percentage, a model name) must still fire even though the footer is furniture
+  // the built-in path strips — and it stays bounded to the same tailLines so it can't
+  // reach deeper into scrollback than before. Matches master's semantics.
   if (customPatterns.length > 0) {
-    const full = lines.join('\n');
+    const raw = tailLines > 0 ? all.slice(-tailLines) : all;
+    const full = raw.join('\n');
     const custom = customPatterns.map(p => typeof p === 'string' ? new RegExp(p, 'i') : p);
     if (custom.some(p => p.test(full))) return true;
   }

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -57,7 +57,13 @@ const isWorkingLine = (l) => WORKING_PATTERNS.some((p) => p.test(l));
 const CHROME_LINE = [
   /^\s*$/,                                          // blank
   /^[\s─│╭╮╰╯┌┐└┘├┤┬┴┼▏▕|]+$/,                       // box-drawing / rules
-  /^\s*[❯>]\s*$/,                                    // empty input prompt
+  /^\s*│\s*[>❯].*│\s*$/,                             // boxed input row ("│ > … │"): anchored to
+                                                     // the PROMPT GLYPH, not "anything between two
+                                                     // bars" — a bare │…│ rule matches unicode-
+                                                     // border tool output (psql/duf tables) and
+                                                     // would strip it as chrome, pulling a stale
+                                                     // banner back in. The glyph is the discriminator.
+  /^\s*[❯>]\s*$/,                                    // empty input prompt (bare, unboxed)
   /^\s*⏵⏵/,                                          // mode footer ("⏵⏵ auto mode on…", "⏵⏵ accept edits…")
   /\bauto mode\b/i,                                 // footer mode text / "Allowed by auto mode" notice
   /shift\+tab to (?:cycle|select)/i,                // tab-cycle footer hint (anchored to the phrase)

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -149,6 +149,39 @@ describe('processOneTick', () => {
     const s = createMonitorState();
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
   });
+
+  // --- Regression: a LIVE limit banner pushed far up the pane by UI chrome (a tall task
+  //     widget + input box + footer) must still be detected. Observed live: a session-limit
+  //     banner ~16 lines up behind a task list went unretried for ~54 min because the fixed
+  //     12-line tail never reached it. Chrome-aware tail strips trailing furniture first. ---
+  it('detects a live limit banner buried behind a task widget + input box + footer', async () => {
+    const pane = [
+      '● Agent "Map LI drop-point" finished · 1m 5s',
+      "  └ You've hit your session limit · resets 2am (Europe/Zurich)",
+      "     /usage-credits to finish what you're working on.",
+      '',
+      '✻ Brewed for 54m 35s',
+      '',
+      '  8 tasks (4 done, 1 in progress, 3 open)',
+      '  ◼ FU-4(b): build + run per-order re-drive over remnant',
+      '  □ FU-4(a): cache OD inventory map per country',
+      '  □ FU-1: analyze tax-free/reverse-charge COGS netting',
+      '  □ FU-2: LI routing gap fix',
+      '  ✓ Restore sqlrun webhook for DB queries',
+      '   … +3 completed',
+      '                              new task? /clear to save 468.1k tokens',
+      '',
+      '───────────────────────────────',
+      '❯ ',
+      '───────────────────────────────',
+      '  Opus 4.8 1M | automation-monorepo@dev | 5h 100% @02:00 | v2.1.201',
+      '  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents',
+    ].join('\n');
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.equal(s.status, 'waiting');
+  });
   it('retries when Claude process is in foreground (fixes macOS zsh issue)', async () => {
     const t = mockTmux('5-hour limit reached - resets 3pm (UTC)', 'zsh', true);
     const s = createMonitorState();

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -132,6 +132,29 @@ describe('processOneTick', () => {
     assert.equal(s.attempts, 0);
   });
 
+  // --- Regression (Finding 3): isWorking and isRateLimited must measure the same bottom.
+  //     A live "esc to interrupt" footer pushed up by a chrome stack was invisible to the
+  //     raw-tail isWorking while chrome-aware isRateLimited still saw a lingering banner →
+  //     retry text into a mid-flight session. Both are chrome-aware now. ---
+  it('does NOT re-send when Claude is working above a chrome stack (banner still lingering)', async () => {
+    const pane = [
+      "You've hit your session limit · resets 3pm (UTC)",
+      '✻ Cogitating… (12s · esc to interrupt)',
+      '  10 tasks (2 done, 1 in progress, 7 open)',
+      '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g',
+      '   … +2 completed', '  new task? /clear to save 300k tokens', '',
+      '───────────────', '❯ ', '───────────────',
+      '  Opus 4.8 | repo@dev | v2.1.201',
+      '  ⏵⏵ auto mode on (shift+tab to cycle)',
+    ].join('\n');   // working footer sits >12 raw lines above the bottom
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    s.waitUntil = Date.now() - 1000; s.status = 'waiting'; s.attempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'user-continued');
+    assert.equal(t._sent.length, 0);
+    assert.equal(s.status, 'monitoring');
+  });
+
   // --- Regression: self-referential false positive. A limit banner only quoted in
   //     scrollback (a conversation discussing limits, a stale banner scrolled past) is
   //     NOT the live state. Tail-anchoring stops it from driving a retry. ---

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -150,6 +150,24 @@ describe('processOneTick', () => {
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
   });
 
+  // --- Regression (Finding 1): the /usage-credits backstop must not resurrect the
+  //     scrollback false positive. A resumed session shows the stale banner+companion
+  //     with real work rendered below it — that is NOT the live limit state and must not
+  //     drive a retry (previously: up to maxRetries injections + a ~24h wait to tomorrow). ---
+  it('does NOT enter a wait via the /usage-credits backstop when real work is below it', async () => {
+    const pane = [
+      "You've hit your session limit · resets 2am (Europe/Zurich)",
+      "     /usage-credits to finish what you're working on.",
+      ...Array(15).fill('● wrote some code after resuming'),
+      '❯ ',
+    ].join('\n');
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'monitoring');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+
   // --- Regression: a LIVE limit banner pushed far up the pane by UI chrome (a tall task
   //     widget + input box + footer) must still be detected. Observed live: a session-limit
   //     banner ~16 lines up behind a task list went unretried for ~54 min because the fixed

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -88,6 +88,31 @@ describe('isWorking', () => {
   // Claude's internal-retry indicator means retries are NOT exhausted → not terminal.
   it('treats the "Retrying in" suffix as still-working', () => assert.equal(isWorking('API Error: 529 Overloaded · Retrying in 5s · attempt 3/10'), true));
   it('treats an "attempt n/m" indicator as still-working', () => assert.equal(isWorking('thinking… attempt 2/10'), true));
+
+  // --- Finding 3: isWorking must measure the SAME bottom as isRateLimited (both
+  //     chrome-aware). A live working footer pushed up by a tall chrome stack below it was
+  //     invisible to the old raw tail, while chrome-aware isRateLimited still saw a
+  //     lingering banner → the waiting branch injected retry text into a mid-flight
+  //     session. contentTail strips the chrome stack and reaches the working footer. ---
+  it('sees a working footer even when a tall chrome stack is rendered below it', () => {
+    const pane = [
+      '✻ Cogitating… (12s · esc to interrupt)',
+      '  10 tasks (2 done, 1 in progress, 7 open)',
+      '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g',
+      '   … +2 completed',
+      '  new task? /clear to save 300k tokens',
+      '',
+      '───────────────',
+      '❯ ',
+      '───────────────',
+      '  Opus 4.8 | repo@dev | v2.1.201',
+      '  ⏵⏵ auto mode on (shift+tab to cycle)',
+    ].join('\n');   // 17 lines: footer at index 0 is >12 raw lines from the bottom
+    assert.equal(isWorking(pane), true);
+  });
+  it('does not treat the idle "✻ Brewed for …" spinner as working', () => {
+    assert.equal(isWorking('✻ Brewed for 54m 35s\n❯ '), false);
+  });
 });
 
 describe('DEFAULT_OVERLOAD config', () => {

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -66,6 +66,26 @@ describe('detectOverload', () => {
     const pane = ['some earlier output', 'more output', 'API Error: 529 Overloaded'].join('\n');
     assert.equal(detectOverload(pane, PATS), true);
   });
+
+  // --- Finding 6: the 50-line capture + chrome-strip let an old quoted error be reached
+  //     from far up when everything below it is chrome (a tall task widget). Unlike the
+  //     content-below case above (contentTail stops at the content), chrome is all
+  //     stripped, so an error 20+ raw lines up would re-enter the window. A terminal error
+  //     sits just above the input box; bound overload to a max raw distance from the
+  //     bottom so a widget-buried stale error stays out. ---
+  it('does NOT match an API error buried >20 raw lines up behind a tall chrome widget', () => {
+    const pane = [
+      'API Error: 529 Overloaded',
+      '  20 tasks (0 done, 20 open)',
+      ...Array(22).fill('  □ pending task'),
+      '───────────────', '❯ ',
+    ].join('\n');
+    assert.equal(detectOverload(pane, PATS), false);
+  });
+  it('still matches a terminal API error just above the input box', () => {
+    const pane = ['API Error: 529 Overloaded', '───────────────', '❯ ', '───────────────', '  ⏵⏵ auto mode on'].join('\n');
+    assert.equal(detectOverload(pane, PATS), true);
+  });
 });
 
 describe('overloadMatch (observability)', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -121,6 +121,13 @@ describe('isRateLimited', () => {
       '', '  8 tasks', '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g', '❯ '].join('\n');
     assert.equal(isRateLimited(pane, [], 12), true);
   });
+  // Fable review F3: a session EXPLAINING /usage-credits (companion + a loose "usage limit"
+  // LIMIT match, but no reset time) must not fire the backstop.
+  it('does NOT backstop-fire on a conversation explaining /usage-credits (no reset nearby)', () => {
+    const pane = ['When you hit your usage limit you can run',
+      '/usage-credits to purchase extra usage.', '', '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
   // --- Finding 1: the /usage-credits backstop must have the same liveness discipline as
   //     the main path. A resumed session's scrollback always contains the stale
   //     banner+companion (the live render prints the companion), with real work rendered
@@ -184,6 +191,14 @@ describe('isRateLimited', () => {
       ...Array(10).fill('     │ 0      │ user0     │'), '     └────────┴───────────┘'];
     const pane = ["You've hit your session limit · resets 3pm (UTC)",
       '● Bash(psql -c "select * from users limit 8")', ...table, '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
+  // Fable review F4a: the boxed-input rule must not match a table row whose FIRST cell is a
+  // ">"/prompt glyph (`│ >  │ … │`) — the `[^│]*` (was `.*`) forbids an internal bar.
+  it('does NOT strip a psql row whose first cell is ">" (internal bar guard)', () => {
+    const table = ['  ⎿  ┌────────┬───────────┐', '     │ op     │ meaning   │', '     ├────────┼───────────┤',
+      ...Array(10).fill('     │ >      │ greater-than op │'), '     └────────┴───────────┘'];
+    const pane = ["You've hit your session limit · resets 3pm (UTC)", '● Bash(psql)', ...table, '❯ '].join('\n');
     assert.equal(isRateLimited(pane, [], 12), false);
   });
 

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -118,7 +118,7 @@ describe('isRateLimited', () => {
   it('finds it via the /usage-credits companion even without the reset on the banner line', () => {
     const pane = ['Ran 1 shell command', '  └ Session limit hit',
       '     /usage-credits to finish what you\'re working on. resets 2am',
-      '', '  8 tasks', '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g', '❯ '].join('\n');
+      '', '  8 tasks (4 done, 1 in progress, 3 open)', '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g', '❯ '].join('\n');
     assert.equal(isRateLimited(pane, [], 12), true);
   });
   // Fable review F3: a session EXPLAINING /usage-credits (companion + a loose "usage limit"
@@ -240,6 +240,48 @@ describe('isRateLimited', () => {
     ].join('\n');
     assert.equal(isRateLimited(pane, [], 12), true);
   });
+
+  // --- Fable review F4b: four CHROME_LINE patterns still matched ordinary PROSE as a
+  //     last-content-line, so a stale banner exactly at the content boundary could be
+  //     stripped back into the window (same false-positive class as Finding 2). Anchor each
+  //     to its actual render: the auto-mode notice, the "N tasks (" widget header, the
+  //     "Backgrounded agent (" notice, and the "/clear to save" save hint. ---
+  const F4B_PROSE_PROBES = [
+    'auto mode is enabled in your settings',   // matched bare /\bauto mode\b/
+    '3 tasks remain in the backlog',           // matched /^\s*\d+\s+tasks?\b/ (no widget "(")
+    'Backgrounded agent finished the lint run', // matched bare /Backgrounded agent/
+    'Should I start the new task?',            // matched standalone /new task\?/
+  ];
+  for (const probe of F4B_PROSE_PROBES) {
+    it(`does not strip prose "${probe}" as chrome, so a stale banner above it stays out (tail=12)`, () => {
+      const pane = [
+        "You've hit your session limit · resets 3pm (UTC)",
+        ...Array(13).fill(probe),
+        '───────────────────────────────',
+        '❯ ',
+      ].join('\n');
+      assert.equal(isRateLimited(pane, [], 12), false);
+    });
+  }
+  // The genuine renders these anchors target must STILL classify as chrome (banner behind
+  // them detected): the auto-mode footer/notice, the "N tasks (" header, the backgrounded-
+  // agent notice, and the "new task? /clear to save" hint.
+  const F4B_CHROME_RENDERS = [
+    '  Allowed by auto mode',
+    '  8 tasks (4 done, 1 in progress, 3 open)',
+    '  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)',
+    '  new task? /clear to save 300k tokens',
+  ];
+  for (const render of F4B_CHROME_RENDERS) {
+    it(`still strips genuine render "${render.trim()}" as chrome (banner behind it detected)`, () => {
+      const pane = [
+        "You've hit your session limit · resets 2am (Europe/Zurich)",
+        ...Array(13).fill(render),
+        '❯ ',
+      ].join('\n');
+      assert.equal(isRateLimited(pane, [], 12), true);
+    });
+  }
 });
 
 describe('stripAnsi (private-mode sequences)', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -243,6 +243,36 @@ describe('isRateLimitOptionsPrompt (#19)', () => {
   });
 });
 
+describe('isRateLimitOptionsPrompt / menuStepsToWaitOption chrome-aware (Finding 5)', () => {
+  // A live menu pushed up by a tall widget below it must still be detected — otherwise the
+  // menu branch is skipped, a usage-wait is entered, and the later sendKeys types into the
+  // open menu where Enter confirms the highlighted default ("Upgrade your plan"). All four
+  // detectors must share the chrome-aware window.
+  const MENU_BEHIND_WIDGET = [
+    'What do you want to do?',
+    '❯ 1. Upgrade your plan',
+    '  2. Stop and wait for limit to reset',
+    'Enter to confirm · Esc to cancel',
+    '',
+    '  8 tasks (2 done, 6 open)',
+    '  □ a', '  □ b', '  □ c', '  □ d',
+    '───────────────',
+    '❯ ',
+    '───────────────',
+    '  ⏵⏵ auto mode on',
+  ].join('\n');
+  it('detects a live menu pushed up by a widget below it (tail-scoped)', () => {
+    assert.equal(isRateLimitOptionsPrompt(MENU_BEHIND_WIDGET, 6), true);
+  });
+  it('counts steps to the wait option on a menu behind a widget (tail-scoped)', () => {
+    assert.equal(menuStepsToWaitOption(MENU_BEHIND_WIDGET, 6), 1);
+  });
+  it('still ignores a menu only quoted above live work (tail-scoped)', () => {
+    const pane = [...MENU_UPGRADE_FIRST.split('\n'), ...Array(10).fill('● unrelated work'), '❯ '].join('\n');
+    assert.equal(isRateLimitOptionsPrompt(pane, 6), false);
+  });
+});
+
 describe('menuStepsToWaitOption (#19)', () => {
   it('returns +1 when "Stop and wait" is one below the cursor (Upgrade first)', () => {
     assert.equal(menuStepsToWaitOption(MENU_UPGRADE_FIRST), 1);

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -116,6 +116,45 @@ describe('isRateLimited', () => {
   it('full scan (tailLines=0, print mode) is unaffected by chrome logic', () => {
     assert.equal(isRateLimited("You've hit your session limit · resets 3pm (UTC)", [], 0), true);
   });
+
+  // --- Finding 2: chrome classifiers must not match ordinary content. Each probe below is
+  //     a real output line the reviewer showed being wrongly stripped as chrome, which
+  //     lets contentTail "see through" it and pull a STALE banner above back into the
+  //     window. Scenario: stale banner, then 13 copies of the probe (the "real work
+  //     below"), then the input box. If the probe is correctly CONTENT, contentTail stops
+  //     at it and the stale banner stays out (→ false). If wrongly chrome, all get
+  //     stripped and the banner re-enters the window (→ true, the false positive). ---
+  const CONTENT_PROBES = [
+    'Press ctrl+c to stop the dev server',   // contains "ctrl+"
+    '⎿ Renamed a.js → b.js',                  // contains arrow →
+    '✓ Fixed the bug',                        // checkmark bullet, no leading indent
+    'Released v0.5.1',                        // bare semver, no footer pipe
+    'Run /rc to reconnect',                   // contains /rc
+  ];
+  for (const probe of CONTENT_PROBES) {
+    it(`does not strip "${probe}" as chrome, so a stale banner above it stays out (tail=12)`, () => {
+      const pane = [
+        "You've hit your session limit · resets 3pm (UTC)",
+        ...Array(13).fill(probe),
+        '───────────────────────────────',
+        '❯ ',
+      ].join('\n');
+      assert.equal(isRateLimited(pane, [], 12), false);
+    });
+  }
+  // The genuine footer/widget lines these patterns replaced must still classify as chrome,
+  // so a banner behind them is still reachable.
+  it('still strips the real version footer and mode footer (banner behind them detected)', () => {
+    const pane = [
+      "You've hit your session limit · resets 2am (Europe/Zurich)",
+      '───────────────────────────────',
+      '❯ ',
+      '───────────────────────────────',
+      '  Opus 4.8 1M | automation-monorepo@dev | 5h 100% @02:00 | v2.1.201',
+      '  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents',
+    ].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), true);
+  });
 });
 
 describe('stripAnsi (private-mode sequences)', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -86,6 +86,36 @@ describe('isRateLimited', () => {
   it('still detects "You\'ve hit your 5-hour limit" (no qualifier regression)', () => {
     assert.equal(isRateLimited("You've hit your 5-hour limit · resets 3pm (UTC)"), true);
   });
+
+  // --- Chrome-aware tail (tailLines > 0): a live banner pushed up by UI furniture is
+  //     still found; a stale/quoted banner with real work below it is not. ---
+  const withChrome = (banner) => [
+    banner,
+    "     /usage-credits to finish what you're working on.",
+    '', '✻ Brewed for 12m 3s', '',
+    '  8 tasks (4 done, 1 in progress, 3 open)',
+    '  ◼ a', '  □ b', '  □ c', '  ✓ d', '   … +3 completed',
+    '  new task? /clear to save 300k tokens',
+    '', '──────', '❯ ', '──────',
+    '  Opus 4.8 | repo@dev | v2.1.201', '  ⏵⏵ auto mode on',
+  ].join('\n');
+  it('finds a banner buried behind a task widget + input box (tail=12)', () => {
+    assert.equal(isRateLimited(withChrome("You've hit your session limit · resets 2am (Europe/Zurich)"), [], 12), true);
+  });
+  it('finds it via the /usage-credits companion even without the reset on the banner line', () => {
+    const pane = ['Ran 1 shell command', '  └ Session limit hit',
+      '     /usage-credits to finish what you\'re working on. resets 2am',
+      '', '  8 tasks', '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g', '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), true);
+  });
+  it('does NOT fire on a quoted banner with real work below it (tail=12)', () => {
+    const pane = ["You've hit your session limit · resets 3pm (UTC)",
+      ...Array(15).fill('● wrote some code'), '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
+  it('full scan (tailLines=0, print mode) is unaffected by chrome logic', () => {
+    assert.equal(isRateLimited("You've hit your session limit · resets 3pm (UTC)", [], 0), true);
+  });
 });
 
 describe('stripAnsi (private-mode sequences)', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -68,6 +68,19 @@ describe('isRateLimited', () => {
   it('matches custom patterns', () => {
     assert.equal(isRateLimited('custom error xyz', [/custom error/i]), true);
   });
+  // --- Finding 4: customPatterns test the RAW tail window (master's semantics), not the
+  //     chrome-stripped one — the user owns their own false-positive tradeoff. A pattern
+  //     keyed on footer text (e.g. a usage percentage) must still fire even though the
+  //     footer is furniture the chrome path strips. ---
+  it('matches a footer-keyed custom pattern in the raw tail (not chrome-stripped)', () => {
+    const pane = [
+      ...Array(6).fill('● ordinary work'),
+      '  Opus 4.8 | repo@dev | 5h 3% left @02:00 | v2.1.201',
+      '  ⏵⏵ auto mode on',
+      '❯ ',
+    ].join('\n');
+    assert.equal(isRateLimited(pane, [/\b3% left\b/i], 12), true);
+  });
   it('detects "You\'ve hit your limit" (real Claude Code message)', () => {
     assert.equal(isRateLimited("You've hit your limit · resets 3pm (Asia/Tbilisi)"), true);
   });

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -154,6 +154,39 @@ describe('isRateLimited', () => {
     assert.equal(isRateLimited("You've hit your session limit · resets 3pm (UTC)", [], 0), true);
   });
 
+  // --- Review follow-up: the flagship "banner behind a widget" fix must also fire for the
+  //     BOXED input render Claude Code actually uses. contentTail stops at the first
+  //     non-chrome line from the bottom; the box middle row "│ >          │" isn't matched
+  //     by the all-box-chars rule (the `>` breaks it) nor the empty-prompt rule (starts
+  //     with `│`), so the strip halted at the input box and never reached the widget/banner
+  //     above. Classifying the "│ … │" row as chrome fixes it. ---
+  const widget = ['  8 tasks (4 done, 1 in progress, 3 open)',
+    '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g', '   … +3 completed',
+    '  new task? /clear to save 300k tokens'];
+  const banner = "You've hit your session limit · resets 3pm (UTC)";
+  it('finds a banner behind a widget above a BARE prompt (tail=12)', () => {
+    const bare = ['───────', '❯ ', '───────', '  ⏵⏵ auto mode on'];
+    assert.equal(isRateLimited([banner, ...widget, ...bare].join('\n'), [], 12), true);
+  });
+  it('finds a banner behind a widget above a BOXED input "│ > │" (tail=12)', () => {
+    const boxed = ['╭────────────────────────╮', '│ >                      │', '╰────────────────────────╯', '  ? for shortcuts'];
+    assert.equal(isRateLimited([banner, ...widget, ...boxed].join('\n'), [], 12), true);
+  });
+  it('boxed input with typed text is still chrome (box row stripped)', () => {
+    const boxed = ['╭────────────────────────╮', '│ > continue the task    │', '╰────────────────────────╯'];
+    assert.equal(isRateLimited([banner, ...widget, ...boxed].join('\n'), [], 12), true);
+  });
+  // The rule must NOT strip unicode-border tool output (psql/mysql/duf tables). Those rows
+  // (`│ 0 │ user0 │`, no prompt glyph) are content — stripping them would collapse the
+  // content distance and pull a stale, scrolled-past banner back into the window.
+  it('does NOT strip a psql unicode-border table, so a stale banner above it stays out', () => {
+    const table = ['  ⎿  ┌────────┬───────────┐', '     │ id     │ name      │', '     ├────────┼───────────┤',
+      ...Array(10).fill('     │ 0      │ user0     │'), '     └────────┴───────────┘'];
+    const pane = ["You've hit your session limit · resets 3pm (UTC)",
+      '● Bash(psql -c "select * from users limit 8")', ...table, '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
+
   // --- Finding 2: chrome classifiers must not match ordinary content. Each probe below is
   //     a real output line the reviewer showed being wrongly stripped as chrome, which
   //     lets contentTail "see through" it and pull a STALE banner above back into the

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -108,6 +108,30 @@ describe('isRateLimited', () => {
       '', '  8 tasks', '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g', '❯ '].join('\n');
     assert.equal(isRateLimited(pane, [], 12), true);
   });
+  // --- Finding 1: the /usage-credits backstop must have the same liveness discipline as
+  //     the main path. A resumed session's scrollback always contains the stale
+  //     banner+companion (the live render prints the companion), with real work rendered
+  //     BELOW it. The backstop must not fire on that — otherwise up to maxRetries bogus
+  //     injections and (since "resets 2am" has passed) a ~24h wait rolled to tomorrow. ---
+  it('does NOT fire on a stale banner+companion with real work rendered below (resumed session)', () => {
+    const pane = [
+      "You've hit your session limit · resets 2am (Europe/Zurich)",
+      "     /usage-credits to finish what you're working on.",
+      ...Array(15).fill('● wrote some code'),
+      '❯ ',
+    ].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
+  it('does NOT fire when a stale companion sits above later non-chrome output', () => {
+    const pane = [
+      "  └ Session limit hit · /usage-credits to finish. resets 2am",
+      '● Ran a shell command',
+      '  └ done',
+      ...Array(12).fill('● more real work after the resume'),
+      '❯ ',
+    ].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
   it('does NOT fire on a quoted banner with real work below it (tail=12)', () => {
     const pane = ["You've hit your session limit · resets 3pm (UTC)",
       ...Array(15).fill('● wrote some code'), '❯ '].join('\n');


### PR DESCRIPTION
> ♻️ Recreated from #34 to rebase onto the current `master`. The base branch history was cleaned up, which invalidated the fork-based PR's diff. **All commits are @romerjon's — authorship preserved**; only the base was updated (and merged cleanly, tests green). No action needed from @romerjon; superseded PR #34 will be closed with a pointer here.

---

**Symptom (observed live).** A genuine session-limit banner — `You've hit your session limit · resets 2am (Europe/Zurich)` + `/usage-credits to finish…` — sat ~16 lines above the prompt because a tall **todo/task widget**, the `✻ Brewed for 54m` status spinner, the input box, and the footer rendered below it. The tail-scoped `isRateLimited` (last 12 lines, added to fix a scrollback false-positive) never reached the banner, so **no retry fired and the session stalled ~54 min.**

**Why not just widen the window.** That reopens the false positive it was added for: a limit banner buried 15+ lines up *in scrollback* would re-match. Window size alone can't tell the two apart.

**Fix — measure distance in *content*, not raw lines.** The discriminator is what sits *below* the banner: after a live limit only Claude Code UI chrome renders below it (input box, footer, key hints, todo/task widget, status spinner, `/usage-credits` hint, background-agent notices); a stale/quoted banner has real output below it. So the detector strips **trailing chrome** before applying the tail window. A quoted banner with real work below stays out of the window (false-positive still fixed); a live banner behind a tall widget is now reached.

Plus a `/usage-credits` companion backstop scanned over a wider window — a distinctive live-limit string that catches the modern render even if a future widget escapes the chrome allowlist.

Details:
- `isWorking` deliberately keeps a **raw** tail (the `esc to interrupt` / `Retrying` indicators would otherwise be stripped as chrome).
- Same chrome-aware tail applied to the overload detector (same failure class).
- `·`/`•` excluded from the task-item chrome pattern (they also separate `· resets 3pm` in the multi-line render).
- Capture bumped 20→50 for headroom.

+10 tests including the exact reported pane; the scrollback false-positive and the common near-prompt case both still pass. Zero deps.