### PR TITLE
fix(time-parser): grace window so a just-passed reset retries promptly, not in ~24h

### DIFF
--- a/src/time-parser.js
+++ b/src/time-parser.js
@@ -30,6 +30,21 @@ export function parseResetTime(text) {
   return null;
 }
 
+// Reset-boundary grace window. A live limit banner whose parsed reset time is already in
+// the PAST almost always means the reset just happened: the monitor can settle on the
+// banner minutes-to-an-hour after the reset (a session that kept working past it — see the
+// chrome-aware anti-spam guard), and Claude's session limits reset on short cadences, so a
+// past reset time is recent, not "tomorrow". Rolling a just-passed reset a full day forward
+// parks the session ~24h even though the limit has effectively cleared (observed live:
+// "resets 10am" detected at 10:03 → 86273s wait). rollPastReset retries promptly instead
+// (diff→0, so the wait is just the margin); only a reset MORE than the grace window in the
+// past plausibly means the next occurrence is tomorrow.
+const RESET_GRACE_MS = 60 * 60 * 1000; // 1 hour
+function rollPastReset(diffMs) {
+  if (diffMs >= 0) return diffMs;
+  return diffMs > -RESET_GRACE_MS ? 0 : diffMs + 86400_000;
+}
+
 export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, now = new Date()) {
   if (!parsed) return (fallbackHours * 3600 + marginSeconds) * 1000;
 
@@ -100,13 +115,12 @@ export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, n
     if (d1 > 0 && d2 > 0) target = Math.min(d1, d2);
     else if (d1 > 0) target = d1;
     else if (d2 > 0) target = d2;
-    else target = d1 + 86400_000; // tomorrow
+    else target = rollPastReset(Math.max(d1, d2)); // both past → take the more recent, grace-windowed
 
     return Math.max(0, target) + marginSeconds * 1000;
   }
 
-  let diff = getTargetTimestamp(parsed.hour, parsed.minute) - now.getTime();
-  if (diff < 0) diff += 86400_000; // tomorrow
+  const diff = rollPastReset(getTargetTimestamp(parsed.hour, parsed.minute) - now.getTime());
 
   return diff + marginSeconds * 1000;
 }

--- a/src/time-parser.js
+++ b/src/time-parser.js
@@ -115,7 +115,13 @@ export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, n
     if (d1 > 0 && d2 > 0) target = Math.min(d1, d2);
     else if (d1 > 0) target = d1;
     else if (d2 > 0) target = d2;
-    else target = rollPastReset(Math.max(d1, d2)); // both past → take the more recent, grace-windowed
+    else {
+      // Both interpretations are past. Grace-check the MOST RECENT one (is it just-passed?);
+      // but if we roll to tomorrow, roll to the EARLIEST occurrence (t1 < t2 always, so
+      // Math.min), not the later pm one — otherwise we wait ~12h longer than necessary.
+      const recent = Math.max(d1, d2);
+      target = recent > -RESET_GRACE_MS ? 0 : Math.min(d1, d2) + 86400_000;
+    }
 
     return Math.max(0, target) + marginSeconds * 1000;
   }

--- a/src/time-parser.js
+++ b/src/time-parser.js
@@ -13,6 +13,10 @@ export function parseResetTime(text) {
     if (ampm === 'pm' && hour !== 12) hour += 12;
     if (ampm === 'am' && hour === 12) hour = 0;
 
+    // Reject an out-of-range clock (e.g. a bare "resets 30"): a bad hour/minute would make
+    // calculateWaitMs build an invalid Date and throw, crashing the monitor. null → fallback.
+    if (hour > 23 || hour < 0 || minute > 59) return null;
+
     const ambiguous = !ampm && hour >= 1 && hour <= 12;
     return { hour, minute, timezone, ambiguous };
   }
@@ -107,7 +111,7 @@ export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, n
 
   if (parsed.ambiguous) {
     const t1 = getTargetTimestamp(parsed.hour, parsed.minute);
-    const t2 = getTargetTimestamp(parsed.hour + 12, parsed.minute);
+    const t2 = getTargetTimestamp((parsed.hour + 12) % 24, parsed.minute);  // %24: 12→0 (midnight), never hour 24 (→ Invalid Date)
     const d1 = t1 - now.getTime();
     const d2 = t2 - now.getTime();
 

--- a/test/time-parser.test.js
+++ b/test/time-parser.test.js
@@ -115,7 +115,8 @@ describe('calculateWaitMs', () => {
   });
 
   // Regression (#6): reset already passed today → target tomorrow (~22.6h),
-  // not 48h. Symmetric case for the off-by-a-day bug.
+  // not 48h. Symmetric case for the off-by-a-day bug. (1h20m past → beyond the grace
+  // window below, so it still rolls to tomorrow.)
   it('targets tomorrow when reset time already passed today', () => {
     const now = new Date('2026-05-03T15:00:00Z'); // 1:00 AM next day in Melbourne
     const wait = calculateWaitMs(
@@ -123,5 +124,34 @@ describe('calculateWaitMs', () => {
     );
     const hours = wait / 3600_000;
     assert.ok(hours > 22 && hours < 23, `expected ~22.6h, got ${hours.toFixed(2)}h`);
+  });
+
+  // Reset-boundary grace window: detecting a limit banner whose reset time only JUST
+  // passed (the monitor can settle on the banner minutes-to-~an-hour after the reset,
+  // e.g. a session that kept working past it) must retry promptly — the limit has
+  // effectively reset — not park ~24h by rolling to tomorrow. Reproduces the live
+  // "resets 10am" stall: detected 10:03 Zurich, previously waited 86273s (~24h).
+  it('retries promptly when the reset time only just passed (grace window)', () => {
+    const now = new Date('2026-07-07T08:03:06Z'); // 10:03 Zurich, 3 min after a 10am reset
+    const wait = calculateWaitMs(
+      { hour: 10, minute: 0, timezone: 'Europe/Zurich' }, 60, 5, now
+    );
+    const mins = wait / 60_000;
+    assert.ok(mins < 5, `expected a prompt retry (~margin), got ${mins.toFixed(1)}min`);
+  });
+  it('applies the grace window within the hour after the reset', () => {
+    const now = new Date('2026-07-07T08:55:00Z'); // 10:55 Zurich, 55 min after a 10am reset
+    const wait = calculateWaitMs(
+      { hour: 10, minute: 0, timezone: 'Europe/Zurich' }, 60, 5, now
+    );
+    assert.ok(wait / 60_000 < 5, 'within 1h grace → prompt retry');
+  });
+  it('still rolls to tomorrow once the reset is well over an hour past', () => {
+    const now = new Date('2026-07-07T10:00:00Z'); // 12:00 Zurich, 2h after a 10am reset
+    const wait = calculateWaitMs(
+      { hour: 10, minute: 0, timezone: 'Europe/Zurich' }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 21 && hours < 23, `expected ~22h (tomorrow), got ${hours.toFixed(2)}h`);
   });
 });

--- a/test/time-parser.test.js
+++ b/test/time-parser.test.js
@@ -31,6 +31,15 @@ describe('parseResetTime', () => {
   it('returns null for unparseable text', () => {
     assert.equal(parseResetTime('some random text'), null);
   });
+  // Fable review F6: an out-of-range clock ("resets 30") must not parse a bad hour that
+  // later makes calculateWaitMs build an Invalid Date and throw (crashing the monitor).
+  it('returns null for an out-of-range hour ("resets 30")', () => {
+    assert.equal(parseResetTime('resets 30'), null);
+  });
+  it('parses a 24h-style "resets 12:30" without an am/pm as ambiguous noon/midnight', () => {
+    const r = parseResetTime('resets 12:30');
+    assert.equal(r.hour, 12); assert.equal(r.minute, 30); assert.equal(r.ambiguous, true);
+  });
   it('parses "try again in 5 minutes" as relative time', () => {
     const r = parseResetTime('try again in 5 minutes');
     assert.ok(r.relative);
@@ -76,6 +85,14 @@ describe('calculateWaitMs', () => {
   it('returns fallback when parsed is null', () => {
     const wait = calculateWaitMs(null, 60, 5);
     assert.ok(Math.abs(wait - (5 * 3600 + 60) * 1000) < 2000);
+  });
+  // Fable review F6: an ambiguous hour of 12 → the pm interpretation is (12+12)%24 = 0
+  // (midnight), NOT hour 24 (which makes `new Date("…T24:…Z")` Invalid → throw → monitor
+  // crash-loop). Must return a finite wait, never throw.
+  it('does not throw on an ambiguous 12:30 (12+12 → midnight, not hour 24)', () => {
+    const now = new Date('2026-07-07T09:00:00Z');
+    const wait = calculateWaitMs({ hour: 12, minute: 30, timezone: 'UTC', ambiguous: true }, 60, 5, now);
+    assert.ok(Number.isFinite(wait) && wait > 0);
   });
   it('handles ambiguous hour by picking soonest future', () => {
     const now = new Date('2026-03-18T13:00:00Z');

--- a/test/time-parser.test.js
+++ b/test/time-parser.test.js
@@ -84,6 +84,27 @@ describe('calculateWaitMs', () => {
     );
     assert.ok(wait > 0 && wait <= 3 * 3600_000);
   });
+  // Ambiguous, BOTH interpretations past & outside grace: roll to the EARLIEST next
+  // occurrence (tomorrow's am), not the pm one. "resets 10" at 23:30 Zurich — 10pm passed
+  // 1.5h ago (outside grace), 10am passed 13.5h ago → target 10am tomorrow (~10.5h), not
+  // 10pm tomorrow (~22.5h). The grace check uses the most-recent interpretation, but the
+  // roll must use the earliest.
+  it('ambiguous both-past outside grace rolls to the earliest occurrence (am), not pm', () => {
+    const now = new Date('2026-07-07T21:30:00Z'); // 23:30 Zurich
+    const wait = calculateWaitMs(
+      { hour: 10, minute: 0, timezone: 'Europe/Zurich', ambiguous: true }, 60, 5, now
+    );
+    const hours = wait / 3600_000;
+    assert.ok(hours > 10 && hours < 11, `expected ~10.5h (10am tomorrow), got ${hours.toFixed(2)}h`);
+  });
+  // Ambiguous, most-recent interpretation just passed (within grace): retry promptly.
+  it('ambiguous within-grace (most-recent interpretation just passed) retries promptly', () => {
+    const now = new Date('2026-07-07T20:30:00Z'); // 22:30 Zurich, 30 min after the 10pm interpretation
+    const wait = calculateWaitMs(
+      { hour: 10, minute: 0, timezone: 'Europe/Zurich', ambiguous: true }, 60, 5, now
+    );
+    assert.ok(wait / 60_000 < 5, `expected a prompt retry (~margin), got ${(wait / 60_000).toFixed(1)}min`);
+  });
   it('handles relative time correctly', () => {
     const wait = calculateWaitMs({ relative: true, waitMs: 300_000 }, 60, 5);
     assert.ok(Math.abs(wait - 360_000) < 2000); // 5 min + 60s margin


### PR DESCRIPTION
> ♻️ Recreated from #35 to rebase onto the current `master`. The base branch history was cleaned up, which invalidated the fork-based PR's diff. **All commits are @romerjon's — authorship preserved**; only the base was updated (and merged cleanly, tests green). No action needed from @romerjon; superseded PR #35 will be closed with a pointer here.

---

## Problem

`calculateWaitMs` rolls **any** past reset time a full day forward:

```js
let diff = getTargetTimestamp(parsed.hour, parsed.minute) - now.getTime();
if (diff < 0) diff += 86400_000; // tomorrow
```

That's correct for a reset genuinely hours in the past, but wrong at the reset *boundary*. The monitor can settle on a limit banner minutes-to-an-hour **after** its reset — the chrome-aware anti-spam guard deliberately holds detection until the session stops working, which can push the first detection just past the reset. `diff < 0` then parks the session ~24h even though the limit has effectively cleared.

Observed live: `You've hit your session limit · resets 10am (Europe/Zurich)` detected at 10:03 Zurich → **86273s (~24h)** wait, on a box whose sessions were otherwise fine to continue right after 10am.

## Fix

A 1-hour grace window (`rollPastReset`): a reset within the last hour is treated as just-reset (`diff → 0`, so the wait is only the margin — it retries promptly and self-corrects if still limited); only a reset more than an hour past rolls to tomorrow. Applied to both the exact and ambiguous (am/pm) branches.

```
resets 10am, detected 10:03 Zurich:  60s   (was 86273s)
resets 3pm,  detected 12:48 Zurich:  ~2.2h (unchanged — future reset)
```

## Tests

Test-first: two failing boundary cases (3 min and 55 min past → prompt retry) plus a guard that a reset well over an hour past still rolls to tomorrow. The #6 timezone regressions and all future-reset behavior are unchanged. Full suite green.

Self-contained — touches only `src/time-parser.js` and its test. Surfaced while running #34 on live sessions; kept separate so it doesn't muddy that PR.