### PR TITLE
fix(patterns): anchor overload detection to an API Error line, like safeguard

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -292,17 +292,28 @@ function toRegexes(patterns) {
   return out;
 }
 
-// Returns { pattern, line } for the first overload pattern matching a tail line, else
-// null. Per-line (not whole-tail) so we can report WHICH line tripped it — invaluable
-// for diagnosing a future false positive (the original bug logged no reason at all).
+// A REAL overload always renders as an `API Error:` line ("API Error: 529 …", "API Error:
+// Server is temporarily limiting requests …", or "API Error: …" one line above a JSON
+// `overloaded_error` body). Requiring that line nearby — the same discipline safeguardMatch
+// uses — keeps the phrase patterns ("temporarily limiting requests", "overloaded_error")
+// from firing when they're merely quoted/discussed in the pane (e.g. a session explaining
+// this tool, or a chat about API errors). Mirrors SAFEGUARD_ANCHOR.
+const OVERLOAD_ANCHOR = [/\bAPI Error\b/i];
+
+// Returns { pattern, line } for the first overload pattern matching a tail line (with an
+// `API Error` line nearby), else null. Per-line (not whole-tail) so we can report WHICH
+// line tripped it — invaluable for diagnosing a future false positive (the original bug
+// logged no reason at all).
 export function overloadMatch(text, patterns = []) {
   if (!patterns || patterns.length === 0) return null;
   const lines = tail(text);
   if (!lines.join('').trim()) return null;
   const regexes = toRegexes(patterns);
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
     for (const r of regexes) {
-      if (r.test(line)) return { pattern: r.source, line: line.trim().slice(0, 200) };
+      if (r.test(lines[i]) && hasNearbyMatch(lines, i, OVERLOAD_ANCHOR)) {
+        return { pattern: r.source, line: lines[i].trim().slice(0, 200) };
+      }
     }
   }
   return null;

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -52,6 +52,23 @@ describe('detectOverload', () => {
   it('does NOT match a "status.claude.com" mention in prose/comments', () => assert.equal(detectOverload('see status.claude.com for incidents', PATS), false));
   it('does NOT match a bare "500 Internal server error" without the API Error frame', () => assert.equal(detectOverload('500 Internal server error · try again', PATS), false));
 
+  // --- Self-referential: the phrase patterns must not fire when merely quoted/discussed in
+  //     the pane (a session explaining this tool, or a chat about API errors). The real
+  //     render always carries an `API Error` line, like the safeguard path requires.
+  //     (Observed live: the tool's own diagnostic text matched /temporarily limiting requests/.) ---
+  it('does NOT match "temporarily limiting requests" in prose (no API Error nearby)', () => {
+    assert.equal(detectOverload('the "temporarily limiting requests" pattern is a built-in overload signal', PATS), false);
+  });
+  it('does NOT match a quoted "overloaded_error" in prose (no API Error nearby)', () => {
+    assert.equal(detectOverload('the overloaded_error JSON type is what we anchor on', PATS), false);
+  });
+  it('still matches the real API-429 render (API Error on the line)', () => {
+    assert.equal(detectOverload('● API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited', PATS), true);
+  });
+  it('still matches a multi-line overloaded_error body (API Error one line up)', () => {
+    assert.equal(detectOverload('API Error: 529\n{"type":"error","error":{"type":"overloaded_error"}}', PATS), true);
+  });
+
   // --- Terminal vs transient: the parens form means Claude is STILL retrying. Acting
   //     on it would interrupt Claude's own backoff. Only the colon form is terminal. ---
   it('does NOT match the transient parens retry form', () => assert.equal(detectOverload('API Error (529 {"type":"error"}) · Retrying in 5s · attempt 3/10', PATS), false));


### PR DESCRIPTION
> ♻️ Recreated from #37 to rebase onto the current `master`. The base branch history was cleaned up, which invalidated the fork-based PR's diff. **All commits are @romerjon's — authorship preserved**; only the base was updated (and merged cleanly, tests green). No action needed from @romerjon; superseded PR #37 will be closed with a pointer here.

---

## Problem

The overload phrase patterns are unanchored:

```js
// DEFAULT_OVERLOAD.patterns
'API Error:\\s*(429|500|502|503|504|529)\\b',   // anchored (has "API Error")
'overloaded_error',                              // bare phrase
'temporarily limiting requests',                 // bare phrase
```

`overloadMatch` tests each tail line against them with no context check, so a pane that merely **discusses or quotes** the phrases fires a spurious overload retry. Caught live on my box — the tool's own diagnostic output (a session explaining this very tool) matched `/temporarily limiting requests/`:

```
[INFO] Overload/transient API error detected [matched /temporarily limiting requests/ in:
       "● Key findings: ... "temporarily limiting requests" is a built-in pattern, ..."]
```

`safeguardMatch` already guards against exactly this — it requires an `API Error` line nearby (`SAFEGUARD_ANCHOR`) — but the overload path never got the same discipline.

## Fix

`overloadMatch` now requires an `API Error` line nearby (`OVERLOAD_ANCHOR`, mirroring `SAFEGUARD_ANCHOR`). Every real render satisfies it — the API-429 line and 5xx line carry `API Error` on the same line; a multi-line `overloaded_error` JSON body has `API Error` one line up (within the window). Bare prose mentions don't.

Test-first: prose mentions of `temporarily limiting requests` / `overloaded_error` no longer match; the real API-429 render and a multi-line `overloaded_error` body still do. Self-contained — only `src/patterns.js` + its test. Suite green (243).