### PR TITLE
fix(monitor): keep the overload scraper active once the StopFailure hook is live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disabled permanently the first time any `overloaded`/`server_error` event latched, so a
   transient API 429 the event path can't emit (`API Error: Server is temporarily limiting
   requests …`) went undetected and the session sat stuck until resumed by hand. The
-  anchored overload patterns can't misfire on a session/usage limit (no `API Error` line),
-  and an active backoff still returns before the scraper, so there's no double-detection.
+  anchored overload patterns can't misfire on a session/usage limit (no `API Error` line).
+  The scraper also skips the exact banner the event path just retried until it clears or
+  changes, so a render lingering after an edge-triggered retry can't open a second backoff
+  (a double injection that would also reset the give-up budget).
 - Monitor no longer stays parked on a stale wait timer once the session resumes:
   while counting down a usage wait, a pane that has resumed working (e.g. the user
   manually typed `continue` to unstick a wrong/stale wait) now drops back to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conservative: only a node process that IS the claude CLI (script basename `claude` or
   the `claude-code` cli entry) or a pane our `launcher.js` wraps — never a bare node
   process. `exclude-self` recognizes these sessions too.
+- Overload scraper stays a live safety net once the StopFailure hook is active. It was
+  disabled permanently the first time any `overloaded`/`server_error` event latched, so a
+  transient API 429 the event path can't emit (`API Error: Server is temporarily limiting
+  requests …`) went undetected and the session sat stuck until resumed by hand. The
+  anchored overload patterns can't misfire on a session/usage limit (no `API Error` line),
+  and an active backoff still returns before the scraper, so there's no double-detection.
 - Monitor no longer stays parked on a stale wait timer once the session resumes:
   while counting down a usage wait, a pane that has resumed working (e.g. the user
   manually typed `continue` to unstick a wrong/stale wait) now drops back to

--- a/src/events.js
+++ b/src/events.js
@@ -24,9 +24,8 @@ export const EVENTS_DIR = join(homedir(), '.claude-auto-retry', 'events');
 // pane and fight the (correct) scraper usage-wait path. Session/usage limits are owned by
 // the scraper usage path (it reliably reads the persistent "…resets <time>" banner and
 // waits); a genuinely transient API 429 is caught by the overload scraper's "temporarily
-// limiting requests" pattern — but only while the scraper is active (it is disabled once
-// eventMode latches), so API-key sessions in event mode currently get no retry for that
-// case. A known, accepted gap: rare, and strictly better than misrouting session limits.
+// limiting requests" pattern, which stays active alongside the event path (it is no longer
+// disabled when the hook is live), so those 429s are retried even in event mode.
 // Permanent errors (auth/billing/invalid) never retry.
 const RETRYABLE = new Set(['overloaded', 'server_error']);
 

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -50,6 +50,7 @@ function resetOverload(state) {
   state.overloadWaitUntil = 0;
   state.viaEvent = false;
   state._gaveUp = false;
+  state._eventHandledBanner = null;
 }
 
 function resetSafeguard(state) {
@@ -232,6 +233,10 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
       state.overloadAttempts++;          // next failure backs off further
       state.viaEvent = false;
       state.status = 'monitoring';
+      // Remember the banner we just retried via the event path so the always-on scraper
+      // doesn't re-detect this same, uncleared render next tick and open a second backoff.
+      const handled = overloadMatch(stripped, overload.patterns);
+      state._eventHandledBanner = handled ? `${handled.pattern} ${handled.line}` : null;
       await tmuxAdapter.sendKeys(pane, overload.retryMessage);
       return 'overload-retried';
     }
@@ -407,13 +412,19 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
   // requests"), and the anchored overload patterns can't misfire on a session/usage limit
   // (no "API Error" line). Already isWorking-gated + raw-distance-bounded, so it won't
   // re-fire on a recovered/scrolled overload; and while a backoff is active (status ===
-  // 'overload') the tick returns above before reaching here, so no double-detection.
+  // 'overload') the tick returns above before reaching here.
   if (overload && overload.enabled && !isWorking(stripped)) {
     const match = overloadMatch(stripped, overload.patterns);
     if (match) {
+      // Don't re-fire on the same banner the event path just retried and that hasn't
+      // cleared — that incident is owned by the (edge-triggered) event path until the render
+      // changes or a fresh marker arrives. Otherwise the always-on scraper opens a second
+      // backoff (extra injection + resetOverload defeats the give-up cap).
+      if (state._eventHandledBanner === `${match.pattern} ${match.line}`) return 'monitoring';
       state._overloadMatch = match;  // surfaced in the 'overload-detected' log line
       return enterOverload(state, overload, rand);
     }
+    state._eventHandledBanner = null;  // banner gone → a future match is a fresh incident
   }
 
   // Safeguard/AUP false-positive: enter a bounded, seconds-scale retry loop. Independent

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -18,10 +18,9 @@ export function createMonitorState() {
     status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null,
     // Overload-retry sub-state, kept distinct from the usage-reset fields above.
     overloadAttempts: 0, overloadTotalWaitMs: 0, overloadWaitUntil: 0,
-    // Event-driven overload: eventMode latches true once a StopFailure marker is ever
-    // seen (proves the hook is live → stop trusting the scraper). viaEvent marks the
-    // current backoff window as event-triggered (edge: one send per failure).
-    eventMode: false, viaEvent: false,
+    // viaEvent marks the current backoff window as event-triggered (edge: one send per
+    // failure). The scraper stays active alongside the event path — see the tick logic.
+    viaEvent: false,
     // Safeguard/AUP false-positive retry sub-state (bounded, seconds-scale).
     safeguardAttempts: 0, safeguardWaitUntil: 0,
   };
@@ -371,23 +370,24 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     return enterUsageWait(state, stripped, config);
   }
 
-  // Event-driven overload (authoritative; see DESIGN-NOTES §1). A StopFailure marker for
-  // this pane means the turn ended in a retryable API error — no scraping, no ambiguity.
-  // Latches eventMode so the scraper path is disabled once we know the hook is live.
+  // Event-driven overload (authoritative and faster; see DESIGN-NOTES §1). A StopFailure
+  // marker for this pane means the turn ended in a retryable API error — no scraping, no
+  // ambiguity. It runs first, but does NOT replace the scraper below: the event path only
+  // covers overloaded/server_error, so a transient render the hook can't emit (an API 429,
+  // "temporarily limiting requests") is still caught by the scraper.
   if (overload && overload.enabled && tmuxAdapter.readEvent) {
     const ev = await tmuxAdapter.readEvent();
     if (ev) {
       // Consume-side guard: trust no writer. The hook entry in settings.json freezes the
       // cli.js path + matcher at install time, so an OLDER hook binary (whose matcher and
       // RETRYABLE set still include rate_limit) can keep writing markers after an upgrade.
-      // Consume-and-ignore anything non-retryable, and do NOT latch eventMode off it —
-      // a misclassified marker must not start a backoff nor disable the scraper paths.
+      // Consume-and-ignore anything non-retryable — a misclassified marker must not start a
+      // backoff (the scraper below still gets its normal shot on the next tick).
       if (!isRetryableError(ev.error)) {
         await tmuxAdapter.clearEvent();             // consume so it can't re-fire
         state._ignoredEventError = ev.error;
         return 'event-ignored';
       }
-      state.eventMode = true;
       await tmuxAdapter.clearEvent();               // consume
       if (isWorking(stripped)) { resetOverload(state); return 'overload-cleared'; } // self-recovered
       const capMs = overload.maxTotalWaitMinutes * 60_000;
@@ -402,8 +402,13 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     }
   }
 
-  // Scraper fallback — only while eventMode hasn't latched (hook absent or not yet fired).
-  if (!state.eventMode && overload && overload.enabled && !isWorking(stripped)) {
+  // Scraper safety net. Runs on every monitoring tick, even when the hook is live: the
+  // event path can't emit some terminal renders (an API 429, "temporarily limiting
+  // requests"), and the anchored overload patterns can't misfire on a session/usage limit
+  // (no "API Error" line). Already isWorking-gated + raw-distance-bounded, so it won't
+  // re-fire on a recovered/scrolled overload; and while a backoff is active (status ===
+  // 'overload') the tick returns above before reaching here, so no double-detection.
+  if (overload && overload.enabled && !isWorking(stripped)) {
     const match = overloadMatch(stripped, overload.patterns);
     if (match) {
       state._overloadMatch = match;  // surfaced in the 'overload-detected' log line

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -400,6 +400,28 @@ describe('processOneTick — StopFailure event path (authoritative)', () => {
     assert.equal(t._sent.length, 0);
   });
 
+  // --- Regression: the always-on scraper must not double-fire on the SAME overload banner
+  //     that the event path just handled. After a viaEvent retry returns to monitoring with
+  //     the banner still on screen (viaEvent is edge-triggered — it does not verify the
+  //     banner cleared), a naive always-on scraper re-detects it and starts a SECOND backoff
+  //     (extra injection + resetOverload defeats the give-up cap). ---
+  it('does not re-fire the scraper on the same banner lingering after a viaEvent retry', async () => {
+    const banner = 'API Error: 529 {"type":"error","error":{"type":"overloaded_error"}}';
+    const s = createMonitorState();
+    // in a viaEvent backoff whose window just elapsed, the banner still rendered
+    s.status = 'overload'; s.viaEvent = true; s.overloadWaitUntil = Date.now() - 1; s.overloadTotalWaitMs = 30_000;
+    const t1 = mockTmux(banner, 'node', true, null);
+    assert.equal(await processOneTick(s, t1, '%0', cfg(), () => true, NO_JITTER), 'overload-retried'); // send #1
+    assert.equal(s.status, 'monitoring');
+    assert.equal(t1._sent.length, 1);
+    assert.equal(s.overloadAttempts, 1);
+    // next tick: same banner still present, no new marker → scraper must NOT re-detect it
+    const t2 = mockTmux(banner, 'node', true, null);
+    assert.equal(await processOneTick(s, t2, '%0', cfg(), () => true, NO_JITTER), 'monitoring');
+    assert.equal(t2._sent.length, 0);        // no second injection
+    assert.equal(s.overloadAttempts, 1);     // give-up budget not reset
+  });
+
   it('consumes-and-ignores a non-retryable marker (e.g. rate_limit from an outdated hook)', async () => {
     // Regression: settings.json freezes the hook's cli.js path + matcher at install time,
     // so an old hook binary can still write rate_limit markers after an upgrade. The

--- a/test/overload.test.js
+++ b/test/overload.test.js
@@ -364,7 +364,6 @@ describe('processOneTick — StopFailure event path (authoritative)', () => {
     const s = createMonitorState();
     const r = await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
     assert.equal(r, 'overload-detected');
-    assert.equal(s.eventMode, true);    // latched
     assert.equal(s.viaEvent, true);
     assert.equal(t._cleared, true);     // marker consumed
     assert.equal(t._sent.length, 0);    // no send yet — backoff first
@@ -401,29 +400,40 @@ describe('processOneTick — StopFailure event path (authoritative)', () => {
     assert.equal(t._sent.length, 0);
   });
 
-  it('consumes-and-ignores a non-retryable marker (e.g. rate_limit from an outdated hook) without latching eventMode', async () => {
+  it('consumes-and-ignores a non-retryable marker (e.g. rate_limit from an outdated hook)', async () => {
     // Regression: settings.json freezes the hook's cli.js path + matcher at install time,
     // so an old hook binary can still write rate_limit markers after an upgrade. The
-    // daemon must not enter overload backoff off it, and must NOT latch eventMode (that
-    // would disable the scraper paths off a misclassified event).
+    // daemon must not enter overload backoff off it — just consume it so it can't re-fire
+    // (the scraper still gets its normal shot on the next tick).
     for (const bad of ['rate_limit', 'billing_error', 'invalid_request']) {
       const t = mockTmux('idle prompt', 'node', true, { error: bad, ts: Date.now() });
       const s = createMonitorState();
       const r = await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER);
       assert.equal(r, 'event-ignored', bad);
-      assert.equal(s.eventMode, false, bad);   // NOT latched
       assert.equal(s.status, 'monitoring', bad);
       assert.equal(t._cleared, true, bad);     // consumed so it can't re-fire
       assert.equal(t._sent.length, 0, bad);
     }
   });
 
-  it('once eventMode is latched, the scraper path is disabled', async () => {
-    const t = mockTmux('API Error: 529 Overloaded', 'node', true, null);  // scraper WOULD match
+  // --- Regression: the overload scraper must stay a live safety net AFTER the hook has
+  //     fired. The event path only covers overloaded/server_error; a transient API 429
+  //     ("temporarily limiting requests · Rate limited") emits no retryable marker, so ONLY
+  //     the scraper can catch it. It was being permanently disabled once any StopFailure
+  //     latched eventMode, so a genuinely-stuck 429 was never retried (had to be resumed by
+  //     hand). ---
+  it('keeps the overload scraper active after the hook has fired (transient 429 with no marker is still retried)', async () => {
     const s = createMonitorState();
-    s.eventMode = true;
-    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true, NO_JITTER), 'monitoring');
-    assert.equal(t._sent.length, 0);
+    // 1. A retryable StopFailure fires — the hook is now known live for this pane.
+    const t1 = mockTmux('idle prompt', 'node', true, { error: 'server_error', ts: Date.now() });
+    assert.equal(await processOneTick(s, t1, '%0', cfg(), () => true, NO_JITTER), 'overload-detected');
+    s.status = 'monitoring';  // recovered from that incident, back to watching
+    // 2. Later, a transient API 429 the event path can't emit (no marker) appears. Only the
+    //    scraper can catch it; the earlier event must not have disabled it.
+    const render = '● API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited\n\n✻ Cogitated for 37s\n\n❯ ';
+    const t2 = mockTmux(render, 'node', true, null);
+    assert.equal(await processOneTick(s, t2, '%0', cfg(), () => true, NO_JITTER), 'overload-detected');
+    assert.equal(s.status, 'overload');
   });
 
   it('does not send into a shell on an event (foreground gate still applies)', async () => {


### PR DESCRIPTION
## Problem

The event-driven overload path (`StopFailure` markers) only treats `overloaded`/`server_error` as retryable — `rate_limit` (a 429) is deliberately excluded. A **transient API 429** the hook can't emit —

```
API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited
```

is only catchable by the text scraper. But the scraper was gated behind `!state.eventMode`, and `eventMode` **latches permanently** the first time any retryable marker is seen (`monitor.js`, set-once, never reset). So once the hook fired for a pane (e.g. an earlier `server_error`), the scraper was disabled for that monitor's entire life, and a genuinely-stuck 429 was **never retried** — the session had to be resumed by hand.

Observed live: after a `server_error` backoff cycle latched `eventMode`, two panes hit the 429 render above and sat idle at the prompt; the monitor never fired. `events.js` documented this as a "known, accepted gap" — but it strands real sessions, and it's a **regression** from the pre-event-mode monitor, which scraped unconditionally.

## Fix

Drop the `!state.eventMode` gate so the scraper runs on every monitoring tick, event path or not, and remove the now-purposeless `eventMode` field. Safe because:

- The overload patterns are **anchored to an `API Error` line**, so the scraper can't misfire on a session/usage-limit render — that path stays owned by the usage-wait detector (`isRateLimited` is `false` for this 429).
- While a backoff is active (`status === 'overload'`) the tick returns **before** the scraper block, so the event path and scraper never double-detect the same incident.
- The scraper is already `isWorking`-gated and raw-distance-bounded (`OVERLOAD_MAX_RAW_LINES`), so it won't re-fire on a recovered or scrolled-past overload.

## Test-first

A regression test latches the hook via a real `server_error` event, then feeds the exact 429 render with no marker and asserts the scraper still enters overload (was `monitoring`, now `overload-detected`). Removed the test that pinned the old "scraper disabled once `eventMode` latched" behavior. **335/335.**