### PR TITLE
fix(reconcile): detect node-launched and launcher-wrapped claude sessions (Finding 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actual poll interval, not a fixed constant).
 
 ### Fixed
+- `reconcile` now also re-arms claude sessions whose process command isn't `claude`
+  (Finding 6): a claude CLI run under `node` with its process.title unset (shows comm
+  `node`), and a session our own launcher wraps in an agent harness that embeds claude
+  (e.g. `happier claude`) — both were invisible to the `comm === 'claude'` match, so the
+  self-healing timer never re-armed them once their monitor died. Detection stays
+  conservative: only a node process that IS the claude CLI (script basename `claude` or
+  the `claude-code` cli entry) or a pane our `launcher.js` wraps — never a bare node
+  process. `exclude-self` recognizes these sessions too.
 - Monitor no longer stays parked on a stale wait timer once the session resumes:
   while counting down a usage wait, a pane that has resumed working (e.g. the user
   manually typed `continue` to unstick a wrong/stale wait) now drops back to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `customPatterns` are matched against the raw last-N lines (unchanged from pre-#34
   semantics), not the chrome-skipped view — the user owns their own tradeoff (#34).
-- Removed the dead `CLAUDE_COMMANDS` constant; documented that reconcile matches
-  `comm === 'claude'` (a bare-`node` session without `process.title` isn't detected) (#32).
+- Removed the dead `CLAUDE_COMMANDS` constant (#32). Reconcile's session detection was
+  since extended beyond `comm === 'claude'` to also cover node-launched and launcher-wrapped
+  claude — see the Finding 6 entry under Fixed.
 
 ## [0.5.1] - 2026-06-30
 

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -192,11 +192,11 @@ async function readExcludeFile(path = EXCLUDE_FILE) {
   return pruneExcludeEntries(entries);
 }
 
-// Reconcile matches a session by `comm === 'claude'`, which works because Claude Code
-// sets its process.title to "claude". A session launched via a `#!/usr/bin/env node`
-// shebang that does NOT set process.title shows comm "node" and is invisible to reconcile
-// — install the shell wrapper for those. (Matching bare "node" here would arm a monitor on
-// every unrelated node process, so it is deliberately not attempted.)
+// Reconcile matches a session three ways (Finding 6). The primary is `comm === 'claude'`,
+// which works because Claude Code sets its process.title to "claude". Two more cover the
+// cases that used to be invisible — a session whose title isn't set (shows comm "node")
+// and one our own launcher embeds in an agent wrapper — WITHOUT matching bare "node" (that
+// would arm a monitor on every unrelated node process). See isNodeClaudeCli / isLauncher.
 const CLAUDE_COMM = 'claude';
 // ps `comm=` is the bare process name on Linux (procps), but on macOS/BSD it is the
 // executable's full path — TRUNCATED to 16 chars ("/Users/x/.local/bin/claude" prints
@@ -211,6 +211,45 @@ export function isClaudeProc(p) {
   if (p.comm === CLAUDE_COMM || basename(p.comm || '') === CLAUDE_COMM) return true;
   const argv0 = (p.args || '').trim().split(/\s+/)[0] || '';
   return basename(argv0) === CLAUDE_COMM;
+}
+
+// The executed script of a `node [flags] <script> …` invocation (skip node + its flags).
+function nodeScript(args) {
+  const toks = (args || '').trim().split(/\s+/);
+  let i = 1;                                       // toks[0] = "node"
+  while (i < toks.length && toks[i].startsWith('-')) i++;
+  return toks[i] || '';
+}
+const baseName = (p) => p.split('/').pop();
+
+// A node process that IS the claude CLI even though comm shows "node" (process.title unset
+// — exactly Finding 6's shebang case). The executed SCRIPT is the discriminator: its
+// basename is "claude", or it is the claude-code package cli entry. Never a generic node
+// process (`node server.js`), and never a bare "claude" appearing as an argument.
+function isNodeClaudeCli(p) {
+  if (p.comm !== 'node') return false;
+  const s = nodeScript(p.args);
+  return s !== '' && (baseName(s) === 'claude' || /claude-code\/(?:.*\/)?cli\.(?:js|mjs|cjs)$/.test(s));
+}
+// Our own launcher (`node …/src/launcher.js`). It only ever wraps a claude session, so its
+// presence in a pane is a zero-false-positive marker — used to reach an agent wrapper that
+// embeds claude (e.g. `happier claude`, comm "node") which no comm/script check would find.
+function isLauncher(p) {
+  return p.comm === 'node' && baseName(nodeScript(p.args)) === 'launcher.js';
+}
+// The detached monitor we spawn (`node …/src/monitor.js <pane> <pid>`). Excluded when
+// picking a launcher's session child so we never target the monitor as the session.
+function isMonitorProc(p) {
+  return p.comm === 'node' && baseName(nodeScript(p.args)) === 'monitor.js';
+}
+// The claude-relative arg string, so isPrintMode (which skips arg[0] = the command) sees
+// the same shape for a node-launched claude as for a bare `claude …`: drop "node <script>".
+function claudeArgs(p) {
+  if (p.comm === CLAUDE_COMM) return p.args;
+  const toks = (p.args || '').trim().split(/\s+/);
+  let i = 1;
+  while (i < toks.length && toks[i].startsWith('-')) i++;   // past node flags
+  return ['claude', ...toks.slice(i + 1)].join(' ');        // fake command token + real args
 }
 // Print mode: `claude -p` / `claude --print` produces piped/scripted output, never an
 // interactive TUI. The wrapper never arms a monitor there; reconcile must skip it too, or
@@ -299,6 +338,41 @@ function paneForPid(pid, byPid, panePidToPane) {
   return null;
 }
 
+// Map each tmux pane to its candidate claude session process(es). Shared by planReconcile
+// (arming) and claudePidForPane (exclude-self) so both see the same sessions. Detection:
+//   1. comm === 'claude'                — Claude Code with process.title set (the common case)
+//   2. isNodeClaudeCli                  — the claude CLI run under node with title unset (F6)
+//   3. our launcher wrapping an agent   — target the launcher's spawned child (not the monitor)
+// (1)/(2) are direct; (3) only fills panes with no direct candidate, so a plain
+// launcher→claude chain isn't double-counted (the claude child is already a direct hit).
+export function sessionTargetsByPane(processes, byPid, panePidToPane) {
+  const byPane = new Map();
+  const push = (pane, proc) => {
+    if (!pane) return;
+    if (!byPane.has(pane)) byPane.set(pane, []);
+    byPane.get(pane).push(proc);
+  };
+  for (const p of processes) {
+    // Direct claude: comm 'claude', or a macOS full-path/truncated-comm claude reached via
+    // argv0 (isClaudeProc). Node-launched claude CLI (comm 'node') via isNodeClaudeCli.
+    const direct = isClaudeProc(p);
+    const nodeCli = !direct && isNodeClaudeCli(p);
+    if (!direct && !nodeCli) continue;
+    // Print-mode arg shape: a direct claude's own args (isPrintMode skips arg0); a
+    // node-launched one must be normalized ("node <script> …" → "claude …") first.
+    if (isPrintMode(nodeCli ? claudeArgs(p) : p.args)) continue;
+    push(paneForPid(p.pid, byPid, panePidToPane), p);
+  }
+  for (const p of processes) {
+    if (!isLauncher(p)) continue;
+    const pane = paneForPid(p.pid, byPid, panePidToPane);
+    if (!pane || byPane.has(pane)) continue;               // a direct candidate already owns it
+    const child = processes.find(c => c.ppid === p.pid && !isMonitorProc(c));
+    if (child && !isPrintMode(claudeArgs(child))) push(pane, child);
+  }
+  return byPane;
+}
+
 // --- Pure planning ---
 // Given tmux panes, ps processes, and already-running monitors, decide which
 // (pane, claudePid) pairs need a monitor armed. Handles pane-id reuse: when >1 claude
@@ -316,16 +390,10 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
   // monitor whose target pid has exited already shuts itself down (isAlive check).
   const coveredPanes = new Set([...running.keys()].map(k => k.split(' ')[0]));
 
-  // Every interactive claude (comm === 'claude'), excluding print-mode sessions; map to
-  // its pane.
-  const claudes = processes.filter(p => isClaudeProc(p) && !(isPrintMode(p.args)));
-  const byPane = new Map();  // pane -> [claudeProc]
-  for (const c of claudes) {
-    const pane = paneForPid(c.pid, byPid, panePidToPane);
-    if (!pane) continue;
-    if (!byPane.has(pane)) byPane.set(pane, []);
-    byPane.get(pane).push(c);
-  }
+  // Every interactive claude session, mapped to its pane (comm 'claude', a macOS
+  // full-path/argv0 claude, a node-launched claude CLI, or an agent our launcher wraps),
+  // excluding print-mode sessions.
+  const byPane = sessionTargetsByPane(processes, byPid, panePidToPane);
 
   const arm = [], skipped = [];
   for (const [pane, procs] of byPane) {
@@ -415,9 +483,7 @@ export async function claudePidForPane(pane) {
   const { panes, processes } = await gather();
   const byPid = new Map(processes.map(p => [p.pid, p]));
   const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
-  const here = processes.filter(p => isClaudeProc(p)
-    && !(isPrintMode(p.args))
-    && paneForPid(p.pid, byPid, panePidToPane) === pane);
+  const here = sessionTargetsByPane(processes, byPid, panePidToPane).get(pane) || [];
   if (here.length === 0) return null;
   return (here.find(p => p.stat.includes('+')) ?? here.sort((a, b) => b.pid - a.pid)[0]).pid;
 }

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -387,4 +387,64 @@ describe('planReconcile', () => {
     const { arm } = planReconcile({ panes, processes, running: new Map() });
     assert.deepEqual(arm, [{ pane: '%1', pid: 200 }]);
   });
+
+  // --- Finding 6: reconcile matched only `comm === 'claude'`, so a claude session whose
+  //     process.title isn't set (shows comm "node") or one embedded by our own launcher in
+  //     an agent wrapper (e.g. `happier claude`, comm "node") was invisible — never
+  //     re-armed by the self-healing timer once its monitor died. Detect these too, but
+  //     conservatively: only a node process that IS the claude CLI, or a pane our launcher
+  //     wraps — never a bare node process. ---
+  it('arms a node-launched claude CLI whose comm shows "node" (process.title unset)', () => {
+    const panes = [{ pane: '%5', panePid: 500 }];
+    const processes = [
+      { pid: 500, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 510, ppid: 500, stat: 'Sl+', comm: 'node', args: 'node /home/u/.local/bin/claude --resume' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%5', pid: 510 }]);
+  });
+  it('arms a claude-code cli.js run directly under node', () => {
+    const panes = [{ pane: '%5', panePid: 500 }];
+    const processes = [
+      { pid: 500, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 510, ppid: 500, stat: 'Sl+', comm: 'node', args: 'node /x/node_modules/@anthropic-ai/claude-code/cli.js' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%5', pid: 510 }]);
+  });
+  it('arms a launcher-wrapped agent that embeds claude (e.g. happier), targeting the launcher child', () => {
+    const panes = [{ pane: '%6', panePid: 600 }];
+    const processes = [
+      { pid: 600, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 610, ppid: 600, stat: 'Sl', comm: 'node', args: 'node /opt/car/src/launcher.js -c' },
+      { pid: 620, ppid: 610, stat: 'Sl+', comm: 'node', args: 'node /home/u/.local/bin/happier claude -c' },
+      { pid: 615, ppid: 610, stat: 'Sl', comm: 'node', args: 'node /opt/car/src/monitor.js %6 620' }, // detached monitor — not the session
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%6', pid: 620 }]);
+  });
+  it('does NOT arm a bare node process (dev server / build tool)', () => {
+    const panes = [{ pane: '%7', panePid: 700 }, { pane: '%8', panePid: 800 }];
+    const processes = [
+      { pid: 700, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 710, ppid: 700, stat: 'Sl+', comm: 'node', args: 'node /app/server.js' },
+      { pid: 800, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 810, ppid: 800, stat: 'Sl+', comm: 'node', args: 'node /app/build.js claude-prod' }, // "claude" only in an arg, not the script
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
+  });
+  it('does not double-arm a plain launcher→claude chain (one monitor, the real claude pid)', () => {
+    const panes = [{ pane: '%8', panePid: 800 }];
+    const processes = [
+      { pid: 800, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 810, ppid: 800, stat: 'Sl', comm: 'node', args: 'node /opt/car/src/launcher.js' },
+      { pid: 820, ppid: 810, stat: 'Sl+', comm: 'claude', args: 'claude' },  // detected directly by comm
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%8', pid: 820 }]);
+  });
+  it('skips a node-launched claude in print mode (-p)', () => {
+    const panes = [{ pane: '%5', panePid: 500 }];
+    const processes = [
+      { pid: 500, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 510, ppid: 500, stat: 'Rl+', comm: 'node', args: 'node /home/u/.local/bin/claude -p "summarize"' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
+  });
 });


### PR DESCRIPTION
## Problem (closes Finding 6 from the #32 review)

`reconcile` identifies sessions by `comm === 'claude'` only. Two real launches show a different comm and were **invisible** — so the self-healing timer never re-armed them once their monitor died:

1. **A claude CLI run under node with `process.title` unset** → comm `node` (the exact shebang case the review flagged).
2. **A session our own launcher wraps in an agent harness that embeds claude** — e.g. `node …/src/launcher.js` → `node …/happier claude` — comm `node`, with the real claude only appearing deeper (or later, during startup). Observed live: a `happier`-launched pane was skipped by `reconcile` during that window.

The old `CLAUDE_COMMANDS = ['claude','node']` constant was dead code; the review asked to "honor the constant or delete it and document the limitation." This honors it — conservatively.

## Fix

Two detectors alongside the existing comm match, shared by `planReconcile` (arming) and `claudePidForPane` (`exclude-self`) via a new `sessionTargetsByPane`:

- **`isNodeClaudeCli`** — a node process whose executed **script** is the claude CLI (basename `claude`, or the `claude-code` package `cli.{js,mjs,cjs}` entry). The script is the discriminator, so `node server.js`, `node build.js claude-prod`, or a bare "claude" as an argument never match.
- **`isLauncher`** — our own `node …/src/launcher.js`, a zero-false-positive marker (it only ever wraps claude). Only fills a pane with **no** direct candidate, and targets the launcher's spawned child (skipping the detached `monitor.js`), matching what the launcher armed at start — so a plain launcher→claude chain isn't double-counted.

Print mode stays skipped (a `claudeArgs` normalizer drops the `node <script>` prefix so `isPrintMode` sees the same shape as a bare `claude …`).

## Test-first

Six `planReconcile` cases: node-launched CLI, `claude-code/cli.js`, a launcher-wrapped agent (targets the child), a plain launcher→claude chain (no double-arm), print mode, and the critical **negative** (`node server.js` / `node build.js claude-prod` must NOT arm). Also verified against **live** process state — all 12 real claude panes detected, zero false positives. **341/341.**