### PR TITLE
feat(macos): support reconcile + install-timer on Darwin (launchd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`reconcile` / `install-timer` / `exclude-self`** for self-healing monitor coverage: a
   monitor killed (or a `claude` started outside the wrapper) is re-armed from live tmux +
   process state, on demand or via a `systemd --user` timer (#32).
+- **macOS support for `reconcile` / `install-timer`**: the running-monitor probe now uses
+  `pgrep -lf` on Darwin (BSD pgrep prints full args with `-l`, not procps' `-a`, so
+  reconcile previously always aborted with "cannot verify coverage" on macOS), claude
+  detection falls back to the basename of argv[0] from ps `args=` (macOS `comm=` prints
+  the executable's full path truncated to 16 chars — never "claude" — so the strict
+  compare saw zero claude sessions), and
+  `install-timer` installs a launchd LaunchAgent
+  (`~/Library/LaunchAgents/com.claude-auto-retry.reconcile.plist`, `RunAtLoad` +
+  `StartInterval` 300s, `AbandonProcessGroup` so the freshly-armed detached monitors
+  survive the short-lived job, and an explicit `PATH` covering both Homebrew prefixes —
+  launchd does not inherit the login shell's PATH, so `spawn tmux` would otherwise
+  ENOENT) instead of requiring systemd. The reconcile lock's `ps -o lstart=` start token
+  is now pinned to `LC_ALL=C` so the timer (C locale) and an interactive shell (user
+  locale) always agree on lock-holder identity.
 - Safeguard/AUP false-positive auto-retry: when the model's safeguards flag a
   message ("safeguards flagged this message"), re-send a short retry up to
   `safeguard.maxRetries` times, then give up loudly once. Detection is anchored

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ When you disconnect (SSH drops, close terminal, laptop sleeps), **tmux keeps run
 - **Timezone-aware** — parses reset times with full IANA timezone support (including half-hour offsets)
 - **DST-safe** — iterative offset correction handles daylight saving transitions
 - **Safe send-keys** — verifies Claude is still the foreground process before injecting text
-- **Self-healing coverage** — `reconcile` re-arms monitors for any live `claude` session that lost one; an optional `systemd --user` timer runs it automatically ([details](#keeping-monitors-alive))
+- **Self-healing coverage** — `reconcile` re-arms monitors for any live `claude` session that lost one; an optional timer (`systemd --user` on Linux, launchd on macOS) runs it automatically ([details](#keeping-monitors-alive))
 - **Overload backoff** — detects sustained API overload (`429/500/502/503/504/529`) and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff))
 - **Safeguard retry** — auto-continues past an AUP-safeguard false-positive (often transient), capped at a few tries so a sticky flag can't loop ([details](#safeguard-retry))
 - **tmux status bar indicator** — see at a glance whether a pane is being monitored, waiting on a reset, backing off from overload, or has given up ([details](#tmux-status-bar-indicator))
@@ -404,7 +404,8 @@ claude-auto-retry uninstall-hook [dir]  # Remove it
 # Monitor coverage (see "Keeping monitors alive")
 claude-auto-retry reconcile        # Re-arm a monitor for every live claude pane not covered
 claude-auto-retry reconcile --dry-run   # Preview without arming
-claude-auto-retry install-timer    # systemd --user timer: run reconcile every 5 min
+claude-auto-retry install-timer    # Run reconcile every 5 min (systemd --user on Linux,
+                                   # launchd LaunchAgent on macOS)
 claude-auto-retry uninstall-timer  # Remove the timer
 claude-auto-retry exclude-self     # Keep THIS session unmonitored (durable, self-expiring)
 ```
@@ -446,10 +447,12 @@ sessions get a monitor. Two commands restore and maintain full coverage:
   mode sessions (`claude -p`) are skipped, and a `claude` that doesn't set its process
   title to `claude` (a bare `node` shebang) isn't detected — use the wrapper for those.
   Run it after a crash, or use `--dry-run` to see what it would do.
-- **`install-timer`** wires `reconcile` to a `systemd --user` timer that runs every 5
-  minutes, so a monitor that dies is re-armed within one interval — coverage self-heals
-  with no manual step. (Enable `loginctl enable-linger $USER` once if you want it to run
-  while logged out.)
+- **`install-timer`** wires `reconcile` to a timer that runs every 5 minutes, so a
+  monitor that dies is re-armed within one interval — coverage self-heals with no manual
+  step. On Linux this is a `systemd --user` timer (enable `loginctl enable-linger $USER`
+  once if you want it to run while logged out); on macOS it is a launchd LaunchAgent in
+  `~/Library/LaunchAgents` (LaunchAgents only run while you are logged in, which is fine —
+  the tmux server it reconciles lives in your login session too).
 
 **Excluding a session.** To keep a specific session *unmonitored* (e.g. one where you're
 pasting rate-limit text and don't want any auto-retry), run `claude-auto-retry
@@ -558,7 +561,8 @@ claude-auto-retry/
 │   ├── reconcile.js        # Re-arm monitors for all live claude panes + exclusion
 │   ├── launcher.js         # Process orchestration + signal forwarding
 │   └── wrapper.sh          # Shell function template
-├── systemd/                # systemd --user units for the reconcile timer
+├── systemd/                # systemd --user units for the reconcile timer (Linux)
+├── launchd/                # LaunchAgent plist for the reconcile timer (macOS)
 ├── test/                   # tests across the src modules
 ├── package.json
 ├── LICENSE

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ import { execFileSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { writeStopFailureEvent, isRetryableError } from '../src/events.js';
 import { sweepStaleStatus } from '../src/status-file.js';
-import { reconcile, excludeSelf, parseRunningMonitors } from '../src/reconcile.js';
+import { reconcile, excludeSelf, parseRunningMonitors, PGREP_LIST_FLAG } from '../src/reconcile.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -266,14 +266,24 @@ async function cmdUninstallHook() {
   } catch { console.log('No settings file to modify.'); }
 }
 
-// --- systemd --user timer (self-healing monitor coverage) ---
+// --- reconcile timer (self-healing monitor coverage) ---
+// Linux: systemd --user service+timer. macOS: a launchd LaunchAgent. Same cadence
+// (run shortly after login, then every 5 min), same reconcile entry point.
 
 const SYSTEMD_DIR = join(SRC_DIR, '..', 'systemd');
 const UNIT_SERVICE = 'claude-auto-retry-reconcile.service';
 const UNIT_TIMER = 'claude-auto-retry-reconcile.timer';
 
+const LAUNCHD_DIR = join(SRC_DIR, '..', 'launchd');
+const LAUNCHD_LABEL = 'com.claude-auto-retry.reconcile';
+const LAUNCHD_PLIST = `${LAUNCHD_LABEL}.plist`;
+
 function userUnitDir() {
   return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'systemd', 'user');
+}
+
+function launchAgentsDir() {
+  return join(homedir(), 'Library', 'LaunchAgents');
 }
 
 // Substitute the node/CLI paths into a unit template. The template quotes the placeholders
@@ -282,10 +292,71 @@ export function renderReconcileUnit(template, nodePath, cliPath) {
   return template.replace(/__NODE_PATH__/g, nodePath).replace(/__CLI_PATH__/g, cliPath);
 }
 
+// launchd variant: the placeholders sit inside <string> elements, so the substituted
+// paths must be XML-escaped (an '&' in an nvm dir name would otherwise corrupt the
+// plist; spaces need no quoting — each ProgramArguments <string> is one argv entry).
+function xmlEscape(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function renderReconcilePlist(template, nodePath, cliPath) {
+  return template
+    .replace(/__NODE_PATH__/g, xmlEscape(nodePath))
+    .replace(/__CLI_PATH__/g, xmlEscape(cliPath));
+}
+
+// macOS: install the reconcile LaunchAgent into ~/Library/LaunchAgents and load it via
+// launchctl bootstrap into the user's gui domain. RunAtLoad + StartInterval=300 mirror
+// the systemd timer's OnStartupSec/OnUnitActiveSec cadence.
+async function installTimerLaunchd() {
+  const dest = launchAgentsDir();
+  await mkdir(dest, { recursive: true });
+  const nodePath = process.execPath;
+  const cliPath = __filename;
+
+  let template;
+  try {
+    template = await readFile(join(LAUNCHD_DIR, LAUNCHD_PLIST), 'utf-8');
+  } catch (err) {
+    console.error(`Could not read the launchd plist template from ${LAUNCHD_DIR} (${err.code || err.message}).`);
+    console.error('If you installed from npm, upgrade to a version that ships the launchd/ directory,');
+    console.error('or run install-timer from a git checkout of the repo.');
+    process.exit(1);
+  }
+  const plistPath = join(dest, LAUNCHD_PLIST);
+  await writeFile(plistPath, renderReconcilePlist(template, nodePath, cliPath));
+
+  const domain = `gui/${process.getuid()}`;
+  // Reload cleanly if a previous version is already bootstrapped (bootstrap fails on
+  // an already-loaded label; bootout of an absent label fails — both safe to ignore).
+  try { execFileSync('launchctl', ['bootout', `${domain}/${LAUNCHD_LABEL}`], { stdio: 'ignore' }); } catch { /* not loaded */ }
+  try {
+    execFileSync('launchctl', ['bootstrap', domain, plistPath], { stdio: 'inherit' });
+  } catch {
+    console.error(`\nAgent written to ${plistPath} but loading failed. Load manually:`);
+    console.error(`  launchctl bootstrap ${domain} ${plistPath}`);
+    process.exit(1);
+  }
+  console.log(`\nLaunchAgent installed and loaded. Monitor coverage now self-heals every 5 min.`);
+  console.log(`  status:  launchctl print ${domain}/${LAUNCHD_LABEL}`);
+  console.log(`  note: LaunchAgents run only while you are logged in (fine for tmux —`);
+  console.log(`        the tmux server lives in your login session too).`);
+  console.log(`\nNote: the agent pins this Node path (${nodePath}). If you switch Node`);
+  console.log(`versions (nvm), re-run: claude-auto-retry install-timer`);
+}
+
+async function uninstallTimerLaunchd() {
+  const domain = `gui/${process.getuid()}`;
+  try { execFileSync('launchctl', ['bootout', `${domain}/${LAUNCHD_LABEL}`], { stdio: 'ignore' }); } catch { /* not loaded — fine */ }
+  try { await (await import('node:fs/promises')).unlink(join(launchAgentsDir(), LAUNCHD_PLIST)); } catch { /* absent */ }
+  console.log('LaunchAgent removed. (Already-running monitors are unaffected.)');
+}
+
 // Install the reconcile service+timer into the systemd --user unit dir, substituting the
 // node and CLI paths, then enable+start the timer. Makes monitor coverage self-healing:
-// every 5 min a missing monitor is re-armed. Requires systemd --user (Linux).
+// every 5 min a missing monitor is re-armed. systemd --user on Linux; launchd on macOS.
 async function cmdInstallTimer() {
+  if (process.platform === 'darwin') return installTimerLaunchd();
   const dest = userUnitDir();
   await mkdir(dest, { recursive: true });
   const nodePath = process.execPath;
@@ -322,6 +393,7 @@ async function cmdInstallTimer() {
 }
 
 async function cmdUninstallTimer() {
+  if (process.platform === 'darwin') return uninstallTimerLaunchd();
   try {
     execFileSync('systemctl', ['--user', 'disable', '--now', UNIT_TIMER], { stdio: 'inherit' });
   } catch { /* not enabled — fine */ }
@@ -345,7 +417,7 @@ async function cmdExcludeSelf() {
   // Kill any monitor already covering this pane so exclusion takes effect immediately.
   // Reuse parseRunningMonitors (same parser reconcile uses) instead of a bespoke one.
   try {
-    const out = execFileSync('pgrep', ['-af', 'node .*src/monitor\\.js'], { encoding: 'utf-8' });
+    const out = execFileSync('pgrep', [PGREP_LIST_FLAG, 'node .*src/monitor\\.js'], { encoding: 'utf-8' });
     const mpid = parseRunningMonitors(out).get(`${r.pane} ${r.pid}`);
     if (mpid) { try { process.kill(mpid); console.log(`Stopped existing monitor ${mpid}.`); } catch {} }
   } catch { /* no monitor running for this pane — nothing to stop */ }
@@ -419,8 +491,9 @@ switch (command) {
     console.log('                                       (--dry-run to preview). Run after a crash.');
     console.log('  claude-auto-retry exclude-self       Keep THIS session unmonitored (durable,');
     console.log('                                       by claude PID; self-expires on exit)');
-    console.log('  claude-auto-retry install-timer      Install a systemd --user timer that runs');
-    console.log('                                       reconcile every 5 min (self-healing coverage)');
+    console.log('  claude-auto-retry install-timer      Install a timer that runs reconcile every');
+    console.log('                                       5 min (self-healing coverage; systemd --user');
+    console.log('                                       on Linux, launchd LaunchAgent on macOS)');
     console.log('  claude-auto-retry uninstall-timer    Remove the reconcile timer');
     console.log('  claude-auto-retry status             Show monitor status');
     console.log('  claude-auto-retry logs               Tail today\'s log');

--- a/launchd/com.claude-auto-retry.reconcile.plist
+++ b/launchd/com.claude-auto-retry.reconcile.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- claude-auto-retry: re-arm monitors for all live claude tmux panes (macOS
+     counterpart of the systemd user units; installed by `install-timer`).
+     __NODE_PATH__ and __CLI_PATH__ are substituted (XML-escaped) at install time. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-auto-retry.reconcile</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE_PATH__</string>
+        <string>__CLI_PATH__</string>
+        <string>reconcile</string>
+    </array>
+    <!-- Mirrors KillMode=process in the systemd unit: reconcile spawns DETACHED
+         monitor processes and exits. Without AbandonProcessGroup, launchd reaps
+         everything left in the job's process group when the short-lived job
+         finishes — killing the freshly-armed monitors. -->
+    <key>AbandonProcessGroup</key>
+    <true/>
+    <!-- First run right after load (lets a just-logged-in tmux settle via the
+         reconcile lock), then every 5 min, same cadence as OnUnitActiveSec. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <!-- launchd jobs do NOT inherit the login shell's PATH (they get only the system
+         default /usr/bin:/bin:/usr/sbin:/sbin), so reconcile's `spawn tmux` would fail
+         with ENOENT on any Homebrew-installed tmux. Node itself is invoked by absolute
+         path; this PATH exists for tmux (+ps/pgrep), covering both Homebrew prefixes
+         (ARM /opt/homebrew, Intel /usr/local) ahead of the system dirs. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "type": "git",
     "url": "https://github.com/cheapestinference/claude-auto-retry"
   },
-  "files": ["bin/", "src/", "systemd/", "LICENSE", "README.md", "CHANGELOG.md", "llms.txt"]
+  "files": ["bin/", "src/", "systemd/", "launchd/", "LICENSE", "README.md", "CHANGELOG.md", "llms.txt"]
 }

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -52,10 +52,11 @@ export const LOCK_FILE = join(homedir(), '.claude-auto-retry', 'reconcile.lock')
 // as "alive" forever, wedging acquireLock at {ok:false} and silently disabling self-heal).
 // Linux: /proc/<pid>/stat field 22 (starttime; the "(comm)" field may contain spaces/parens,
 // so slice past the last ')'). Fallback (macOS/BSD, no /proc): `ps -o lstart=`. null if gone.
-// NOTE: `ps -o lstart=` is locale-dependent (LC_TIME), so on non-Linux a checker running
-// under a different locale than the writer (e.g. cron vs shell) could misjudge a live holder
-// as stale. Linux always takes the /proc path on both sides, and this tool targets
-// Linux/systemd, so it's unaffected in practice.
+// NOTE: `ps -o lstart=` renders a date, and its format is locale-dependent (LC_TIME) —
+// a checker running under a different locale than the writer (the launchd timer runs
+// with a bare C locale, an interactive shell often doesn't) would see a token mismatch
+// on a LIVE holder and wrongly steal its lock. Pinned to LC_ALL=C on both sides so
+// writer and checker always agree. (Linux always takes the /proc path and is unaffected.)
 export async function processStartToken(pid) {
   try {
     const stat = await readFile(`/proc/${pid}/stat`, 'utf-8');
@@ -63,7 +64,8 @@ export async function processStartToken(pid) {
     if (after[19]) return after[19];   // field 22 overall = index 19 after "state"
   } catch { /* not Linux, or process gone */ }
   try {
-    const { stdout } = await execFile('ps', ['-o', 'lstart=', '-p', String(pid)]);
+    const { stdout } = await execFile('ps', ['-o', 'lstart=', '-p', String(pid)],
+      { env: { ...process.env, LC_ALL: 'C' } });
     return stdout.trim() || null;
   } catch { return null; }
 }
@@ -196,6 +198,20 @@ async function readExcludeFile(path = EXCLUDE_FILE) {
 // — install the shell wrapper for those. (Matching bare "node" here would arm a monitor on
 // every unrelated node process, so it is deliberately not attempted.)
 const CLAUDE_COMM = 'claude';
+// ps `comm=` is the bare process name on Linux (procps), but on macOS/BSD it is the
+// executable's full path — TRUNCATED to 16 chars ("/Users/x/.local/bin/claude" prints
+// as "/Users/x/." or similar), so neither an exact nor a basename compare can work
+// there. Fall back to the basename of argv[0] from `args=` (untruncated): for the
+// claude CLI that is ".../bin/claude". A bare `node script.js` session still shows
+// argv[0] basename "node" and stays invisible, same as on Linux (see note above).
+function basename(s) {
+  return s.slice(s.lastIndexOf('/') + 1);
+}
+export function isClaudeProc(p) {
+  if (p.comm === CLAUDE_COMM || basename(p.comm || '') === CLAUDE_COMM) return true;
+  const argv0 = (p.args || '').trim().split(/\s+/)[0] || '';
+  return basename(argv0) === CLAUDE_COMM;
+}
 // Print mode: `claude -p` / `claude --print` produces piped/scripted output, never an
 // interactive TUI. The wrapper never arms a monitor there; reconcile must skip it too, or
 // retry text would be injected into that output (Finding 8). Only treat -p/--print as print
@@ -235,8 +251,13 @@ export function parseProcesses(out) {
   }).filter(Boolean);
 }
 
-// pgrep -af output for running monitors → Set of "pane pid" keys already covered, plus
-// the raw records so a caller can report/kill. Line: "<mpid> ... monitor.js <pane> <pid>"
+// Flag that makes pgrep print the full argument list next to each PID — procps (Linux)
+// spells it -a, BSD/macOS spells it -l (where -a instead means "include ancestors" and
+// leaves the output PID-only, which runningFromPgrep rejects as unverifiable coverage).
+export const PGREP_LIST_FLAG = process.platform === 'darwin' ? '-lf' : '-af';
+
+// pgrep full-args output for running monitors → Set of "pane pid" keys already covered,
+// plus the raw records so a caller can report/kill. Line: "<mpid> ... monitor.js <pane> <pid>"
 export function parseRunningMonitors(out) {
   const covered = new Map();  // "pane pid" -> monitorPid
   for (const line of out.split('\n')) {
@@ -261,7 +282,7 @@ export function runningFromPgrep(err, stdout) {
   }
   const covered = parseRunningMonitors(out);
   if (out.trim() && covered.size === 0) {
-    throw new Error('pgrep matched processes but printed no monitor args (needs `pgrep -a`; busybox/macOS print PIDs only). Refusing to reconcile — cannot verify coverage without risking duplicate monitors.');
+    throw new Error('pgrep matched processes but printed no monitor args (needs full-args output: `pgrep -a` on procps, `-l` on BSD/macOS; busybox prints PIDs only). Refusing to reconcile — cannot verify coverage without risking duplicate monitors.');
   }
   return covered;
 }
@@ -297,7 +318,7 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
 
   // Every interactive claude (comm === 'claude'), excluding print-mode sessions; map to
   // its pane.
-  const claudes = processes.filter(p => p.comm === CLAUDE_COMM && !(isPrintMode(p.args)));
+  const claudes = processes.filter(p => isClaudeProc(p) && !(isPrintMode(p.args)));
   const byPane = new Map();  // pane -> [claudeProc]
   for (const c of claudes) {
     const pane = paneForPid(c.pid, byPid, panePidToPane);
@@ -340,7 +361,7 @@ async function gather() {
     execFile('ps', ['-eo', 'pid=,ppid=,stat=,comm=,args=']),
   ]);
   let pgrepErr = null, monOut = '';
-  try { monOut = (await execFile('pgrep', ['-af', 'node .*src/monitor\\.js'])).stdout; }
+  try { monOut = (await execFile('pgrep', [PGREP_LIST_FLAG, 'node .*src/monitor\\.js'])).stdout; }
   catch (err) { pgrepErr = err; monOut = err.stdout || ''; }
   return {
     panes: parsePanes(panesOut),
@@ -394,7 +415,7 @@ export async function claudePidForPane(pane) {
   const { panes, processes } = await gather();
   const byPid = new Map(processes.map(p => [p.pid, p]));
   const panePidToPane = new Map(panes.map(p => [p.panePid, p.pane]));
-  const here = processes.filter(p => p.comm === CLAUDE_COMM
+  const here = processes.filter(p => isClaudeProc(p)
     && !(isPrintMode(p.args))
     && paneForPid(p.pid, byPid, panePidToPane) === pane);
   if (here.length === 0) return null;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
-import { injectWrapper, removeWrapper, MARKER_START, MARKER_END, renderReconcileUnit } from '../bin/cli.js';
+import { injectWrapper, removeWrapper, MARKER_START, MARKER_END, renderReconcileUnit, renderReconcilePlist } from '../bin/cli.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -30,10 +30,38 @@ describe('renderReconcileUnit (Finding 7)', () => {
   });
 });
 
+describe('renderReconcilePlist (macOS launchd)', () => {
+  it('substitutes and XML-escapes the node/CLI paths', () => {
+    const out = renderReconcilePlist(
+      '<string>__NODE_PATH__</string><string>__CLI_PATH__</string>',
+      '/Users/a&b/.nvm/node', '/Users/a<b>/cli.js',
+    );
+    assert.equal(out, '<string>/Users/a&amp;b/.nvm/node</string><string>/Users/a&lt;b&gt;/cli.js</string>');
+    assert.ok(!out.includes('__NODE_PATH__') && !out.includes('__CLI_PATH__'));
+  });
+  it('the shipped plist template has the placeholders and detaches monitors from the job', async () => {
+    const plist = await readFile(join(REPO_ROOT, 'launchd', 'com.claude-auto-retry.reconcile.plist'), 'utf-8');
+    assert.match(plist, /<string>__NODE_PATH__<\/string>\s*<string>__CLI_PATH__<\/string>\s*<string>reconcile<\/string>/);
+    // Same reason the systemd unit needs KillMode=process: without it the short-lived
+    // reconcile job's exit reaps the freshly-armed detached monitors.
+    assert.match(plist, /<key>AbandonProcessGroup<\/key>\s*<true\/>/);
+  });
+  it('the shipped plist sets a PATH that reaches a Homebrew tmux', async () => {
+    // launchd jobs get only the system default PATH; without both Homebrew prefixes
+    // reconcile dies with `spawn tmux ENOENT` on every timer fire.
+    const plist = await readFile(join(REPO_ROOT, 'launchd', 'com.claude-auto-retry.reconcile.plist'), 'utf-8');
+    assert.match(plist, /<key>PATH<\/key>\s*<string>[^<]*\/opt\/homebrew\/bin[^<]*\/usr\/local\/bin[^<]*<\/string>/);
+  });
+});
+
 describe('package.json files whitelist (Finding 1)', () => {
   it('includes systemd/ so install-timer works from an npm install', async () => {
     const pkg = JSON.parse(await readFile(join(REPO_ROOT, 'package.json'), 'utf-8'));
     assert.ok(pkg.files.includes('systemd/'), 'package.json "files" must include "systemd/"');
+  });
+  it('includes launchd/ so install-timer works from an npm install on macOS', async () => {
+    const pkg = JSON.parse(await readFile(join(REPO_ROOT, 'package.json'), 'utf-8'));
+    assert.ok(pkg.files.includes('launchd/'), 'package.json "files" must include "launchd/"');
   });
 });
 

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -207,6 +207,25 @@ describe('planReconcile', () => {
       [{ pane: '%1', pid: 200 }, { pane: '%2', pid: 400 }]);
   });
 
+  it('detects claude from a truncated full-path comm via argv[0] (macOS/BSD ps)', () => {
+    // macOS ps `comm=` prints the executable's full path truncated to 16 chars
+    // ("/Users/u/.local/" — never "claude"), so a comm compare sees zero claudes
+    // there; detection must fall back to the basename of argv[0] in `args=`.
+    const panes = [{ pane: '%1', panePid: 100 }];
+    const processes = [
+      { pid: 100, ppid: 1, stat: 'Ss', comm: '/bin/zsh', args: '-zsh' },
+      { pid: 200, ppid: 100, stat: 'S+', comm: '/Users/u/.local/',
+        args: '/Users/u/.local/bin/claude --dangerously-skip-permissions' },
+      // NOT claude: neither comm nor argv[0] basename is "claude"
+      { pid: 300, ppid: 100, stat: 'S', comm: '/opt/homebrew/bi',
+        args: '/opt/homebrew/bin/node server.js' },
+      { pid: 400, ppid: 100, stat: 'S', comm: '/usr/bin/not-cla',
+        args: '/usr/bin/not-claude' },
+    ];
+    const { arm } = planReconcile({ panes, processes, running: new Map() });
+    assert.deepEqual(arm, [{ pane: '%1', pid: 200 }]);
+  });
+
   it('skips a pane that already has a monitor', () => {
     const { panes, processes } = fixture();
     const running = parseRunningMonitors('9 node src/monitor.js %1 200\n');


### PR DESCRIPTION
## Problem

The self-healing coverage introduced in #32 is Linux-only in practice. On macOS:

1. **`reconcile` always aborts** with *"pgrep matched processes but printed no monitor args"*: BSD pgrep prints full argument lists with `-l`, not procps' `-a` (BSD `-a` means *include ancestors* and leaves the output PID-only, which `runningFromPgrep` correctly rejects as unverifiable coverage).
2. Even past that, **`planReconcile` sees zero claude sessions**: macOS `ps -o comm=` prints the executable's *full path truncated to 16 chars* (e.g. `/Users/u/.local/`), so the `comm === 'claude'` compare never matches.
3. **`install-timer` hard-requires `systemctl`**, so there is no self-healing timer at all.

## Changes

- **`PGREP_LIST_FLAG`** (`-lf` on Darwin, `-af` elsewhere) for the running-monitor probe, shared with `exclude-self`. The `runningFromPgrep` guard semantics are unchanged.
- **Claude detection falls back to the basename of argv[0] from `args=`** when `comm` doesn't match. A bare `node script.js` session still shows `node` and stays invisible, preserving the documented "install the wrapper for those" behavior on both platforms.
- **`install-timer` installs a launchd LaunchAgent on Darwin** (`~/Library/LaunchAgents/com.claude-auto-retry.reconcile.plist`), `RunAtLoad` + `StartInterval` 300s to mirror `OnStartupSec`/`OnUnitActiveSec`. Two launchd-specific pitfalls are handled in the template with comments:
  - `AbandonProcessGroup` — same reason the systemd unit needs `KillMode=process`: without it the short-lived job's exit reaps the freshly-armed detached monitors.
  - an explicit `PATH` covering both Homebrew prefixes — launchd does not inherit the login shell's PATH, so `spawn tmux` ENOENTs otherwise (reproduced; this made the agent exit 1 on every fire).
  - substituted node/CLI paths are XML-escaped (`renderReconcilePlist`).
- **`ps -o lstart=` (lock start token) pinned to `LC_ALL=C`** so the timer (C locale) and an interactive shell (user locale) always agree on lock-holder identity; Linux keeps taking the `/proc` path and is unaffected.
- `launchd/` added to the npm `files` whitelist; README/CHANGELOG updated.

## Verification

On macOS 15 (arm64), against a live tmux server with 4 claude sessions:

- 340/340 tests pass (new: BSD truncated-comm planning, plist rendering/escaping, template invariants incl. the PATH and `AbandonProcessGroup` keys).
- `reconcile --dry-run` correctly reports all live panes as `already monitored` / `self (excluded)`; with stripped env it reproduced both original failures before the fix.
- `install-timer` → the `RunAtLoad` fire exits 0 (`launchctl print` `last exit code = 0`); `uninstall-timer` boots the agent out and removes the plist; already-running monitors unaffected.