### PR TITLE
feat(launcher): CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER to prefix a launch wrapper (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER` env var: a prefix command prepended to each interactive
+  session (e.g. `caffeinate -i` to keep macOS awake while Claude works). Generic and opt-in —
+  unset spawns `claude` directly, unchanged (#47).
 - **Chrome-aware detection.** Limit/overload/menu detectors now skip trailing UI
   furniture (input box, footer, key hints, todo/task widget, status spinner,
   `/usage-credits` hint) before reading the live tail, so a genuine banner behind a tall

--- a/README.md
+++ b/README.md
@@ -174,6 +174,20 @@ Optional. Create `~/.claude-auto-retry.json`:
 
 All fields optional. Invalid values fall back to defaults automatically.
 
+### Launch wrapper
+
+Set `CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER` to a prefix command and it's prepended to each
+interactive session — useful for keeping a machine awake while Claude works, or any other
+per-process wrapper:
+
+```sh
+# macOS: don't sleep while a session runs
+export CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER="caffeinate -i"
+```
+
+Generic (not macOS-specific — e.g. `nice`, `chrt …` work too). Unset or blank spawns
+`claude` directly, unchanged.
+
 ## Overload backoff
 
 Separate from subscription rate limits, this fork also detects **sustained API

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -23,6 +23,17 @@ function isPrintMode(args) {
   return args.includes('-p') || args.includes('--print');
 }
 
+// Optional launch wrapper. Set CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER to a prefix command
+// (e.g. "caffeinate -i" on macOS to keep the machine awake, or "nice", "chrt …") and it is
+// prepended to the claude invocation: `<wrapper> <claudeBin> <args…>`. Generic — not tied to
+// any one OS; unset/blank spawns claude directly (unchanged default). (#47)
+export function resolveLaunchCommand(claudeBin, args, env = process.env) {
+  const wrapper = (env.CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER || '').trim();
+  if (!wrapper) return { cmd: claudeBin, cmdArgs: args };
+  const toks = wrapper.split(/\s+/);
+  return { cmd: toks[0], cmdArgs: [...toks.slice(1), claudeBin, ...args] };
+}
+
 function shellEscape(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
@@ -33,7 +44,8 @@ async function launchInteractive(args) {
 
   // CLAUDE_AUTO_RETRY_PANE is inherited by claude's child processes — notably the
   // StopFailure hook, which writes a pane-keyed event marker the monitor consumes.
-  const claude = spawn(claudeBin, args, {
+  const { cmd, cmdArgs } = resolveLaunchCommand(claudeBin, args);
+  const claude = spawn(cmd, cmdArgs, {
     stdio: 'inherit',
     env: { ...process.env, CLAUDE_AUTO_RETRY_ACTIVE: '1', ...(pane ? { CLAUDE_AUTO_RETRY_PANE: pane } : {}) },
   });
@@ -190,16 +202,20 @@ async function createTmuxSession(args) {
   }
 }
 
-// Main
-const args = process.argv.slice(2);
+// Main — only when executed directly (`node launcher.js …`), never when imported for its
+// exported helpers (e.g. resolveLaunchCommand under test).
+const isDirectRun = process.argv[1]?.endsWith('launcher.js');
+if (isDirectRun) {
+  const args = process.argv.slice(2);
 
-let exitCode;
-if (isPrintMode(args)) {
-  exitCode = await launchPrintMode(args);
-} else if (isInsideTmux()) {
-  exitCode = await launchInteractive(args);
-} else {
-  exitCode = await createTmuxSession(args);
+  let exitCode;
+  if (isPrintMode(args)) {
+    exitCode = await launchPrintMode(args);
+  } else if (isInsideTmux()) {
+    exitCode = await launchInteractive(args);
+  } else {
+    exitCode = await createTmuxSession(args);
+  }
+
+  process.exit(exitCode);
 }
-
-process.exit(exitCode);

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveLaunchCommand } from '../src/launcher.js';
+
+describe('resolveLaunchCommand', () => {
+  it('spawns claude directly when no wrapper is set', () => {
+    assert.deepEqual(
+      resolveLaunchCommand('/usr/bin/claude', ['--resume'], {}),
+      { cmd: '/usr/bin/claude', cmdArgs: ['--resume'] },
+    );
+  });
+
+  it('treats an empty/whitespace wrapper as unset', () => {
+    assert.deepEqual(
+      resolveLaunchCommand('claude', ['-c'], { CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER: '   ' }),
+      { cmd: 'claude', cmdArgs: ['-c'] },
+    );
+  });
+
+  it('prepends a wrapper command (e.g. caffeinate -i) before claude and its args', () => {
+    assert.deepEqual(
+      resolveLaunchCommand('/usr/bin/claude', ['--resume'], { CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER: 'caffeinate -i' }),
+      { cmd: 'caffeinate', cmdArgs: ['-i', '/usr/bin/claude', '--resume'] },
+    );
+  });
+
+  it('handles a bare single-token wrapper and extra whitespace', () => {
+    assert.deepEqual(
+      resolveLaunchCommand('claude', [], { CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER: '  nice   ' }),
+      { cmd: 'nice', cmdArgs: ['claude'] },
+    );
+  });
+});


### PR DESCRIPTION
Closes #47.

Adds an opt-in `CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER` env var: a prefix command prepended to the `claude` invocation for interactive sessions, so e.g. `caffeinate -i` keeps macOS awake while a session runs. Generic (works with any wrapper — `nice`, `chrt`, …), and unset/blank spawns `claude` directly (unchanged default).

- `resolveLaunchCommand(claudeBin, args, env)` — pure, tested helper (4 cases: unset, blank, multi-token wrapper, single-token + whitespace).
- Guarded the launcher's entry point behind a direct-run check so the module can be imported for its helpers/tests (it previously ran the launch flow on import).
- README + CHANGELOG. 351/351 tests.