### PR TITLE
fix(monitor): capture 120 pane lines so a banner behind a tall widget is seen (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actual poll interval, not a fixed constant).
 
 ### Fixed
+- Rate-limit banner detection now captures a taller pane (120 lines, was 50): a session-limit
+  banner pushed far up by a big task widget + input box + footer (~90 lines seen in the wild)
+  was beyond the capture window entirely and never detected, leaving the session idle past its
+  reset. The chrome-aware tail still strips furniture and a stale banner with real output below
+  it stays out, so the wider capture doesn't add false positives (#38).
 - `reconcile` now also re-arms claude sessions whose process command isn't `claude`
   (Finding 6): a claude CLI run under `node` with its process.title unset (shows comm
   `node`), and a session our own launcher wraps in an agent harness that embeds claude

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -103,10 +103,12 @@ function enterOverload(state, overload, rand) {
 export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, rand = Math.random) {
   if (!isAlive()) return 'exit';
 
-  // Capture generously (was 20): a live banner can sit far above the bottom behind a tall
-  // task widget + input box + footer. The detectors chrome-strip and tail-window this, so
-  // extra lines are free headroom; 50 clears a large widget with margin.
-  const raw = await tmuxAdapter.capturePane(pane, 50);
+  // Capture generously (was 20, then 50): a live banner can sit far above the bottom behind
+  // a tall task widget + input box + footer — ~90 lines in the wild (#38). The detectors
+  // chrome-strip and tail-window this, so extra lines are free headroom, and the capture
+  // itself bounds how far back the rate-limit scan can reach (a stale banner deeper in
+  // scrollback stays out); 120 clears a large widget with margin.
+  const raw = await tmuxAdapter.capturePane(pane, 120);
   const stripped = stripAnsi(raw);
   const overload = config.overload;
 

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -185,6 +185,29 @@ describe('processOneTick', () => {
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'user-continued');
     assert.equal(t._sent.length, 0);
   });
+
+  // --- Regression (#38): a limit banner pushed far up by a tall chrome block (a big task
+  //     widget + footer, ~90 lines) must still be captured. The detector chrome-strips the
+  //     tail, but only within the CAPTURED buffer — so the capture window has to reach past
+  //     the widget. Uses a capture mock that honours the requested line count, like real
+  //     `tmux capture-pane -S -N` (the shared mockTmux ignores it). ---
+  it('detects a limit banner behind a ~90-line chrome block (capture window)', async () => {
+    const chrome = [
+      ...Array.from({ length: 88 }, (_, i) => `  □ task item ${i}`),
+      '   … +2 completed', '  ? for shortcuts', '  Opus 4.8 | repo@dev | v2.1.201',
+    ];
+    const full = ["You've hit your session limit · resets 4:40pm (UTC)", ...chrome].join('\n');
+    const t = {
+      _sent: [],
+      capturePane: async (_p, n) => full.split('\n').slice(-n).join('\n'), // honours N
+      getPaneCommand: async () => 'node',
+      sendKeys: async (_p, x) => t._sent.push(x),
+      isClaudeForeground: async () => true,
+    };
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+  });
+
   // --- Regression (Fable review F1): a transcript line matching a working pattern
   //     (`Retrying in …`/`attempt N/M` in a flaky deploy/test log) must NOT permanently
   //     suppress detection. The monitoring path has no !isWorking gate, so a genuine live


### PR DESCRIPTION
Closes #38.

A session-limit banner pushed ~90 lines up by a big task widget + input box + footer sat beyond the 50-line capture and was never detected — the session idled past its reset (the reporter saw 9h idle once). Bump the capture 50→120.

- The chrome-aware `contentTail` still strips trailing furniture and keeps a **stale** banner (one with real output below it) out of the window, so the wider capture doesn't add false positives — verified.
- The capture itself bounds how far back the rate-limit scan reaches (no unbounded scrollback scan).
- Test uses a capture mock that honours the requested line count (the shared mock ignores it, which is why this class was untested). 352/352.

Note: #50 proposes removing the scrape from the usage-limit critical path entirely (event-driven via the hook); this hardens the scrape that's still needed for the no-hook fallback and menu detection.