### PR TITLE
Respect $SHELL instead of hardcoding bash after tmux session exits

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -38,6 +38,18 @@ function shellEscape(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
+// After the tmux session's own claude-auto-retry process exits, the pane falls through
+// to a plain shell so the user isn't dropped straight out of tmux. Use the user's actual
+// login shell (env.SHELL) rather than a hardcoded `bash` — tmux's own `default-shell`
+// config is bypassed here because this pane is started with an explicit command, not the
+// session default. (#reported: bash-3.2 stub shown even when SHELL=/bin/zsh)
+export function buildTmuxInnerCmd(launcherPath, args, env = process.env) {
+  const escapedLauncher = shellEscape(launcherPath);
+  const escapedArgs = args.map(a => shellEscape(a)).join(' ');
+  const shell = env.SHELL || 'bash';
+  return `CLAUDE_AUTO_RETRY_ACTIVE=1 node ${escapedLauncher} ${escapedArgs}; exec ${shellEscape(shell)}`;
+}
+
 async function launchInteractive(args) {
   const claudeBin = findClaudeBinary();
   const pane = getCurrentPane();
@@ -145,9 +157,7 @@ async function createTmuxSession(args) {
   const launcherPath = __filename;
 
   // Build the command to run inside tmux
-  const escapedLauncher = shellEscape(launcherPath);
-  const escapedArgs = args.map(a => shellEscape(a)).join(' ');
-  const innerCmd = `CLAUDE_AUTO_RETRY_ACTIVE=1 node ${escapedLauncher} ${escapedArgs}; exec bash`;
+  const innerCmd = buildTmuxInnerCmd(launcherPath, args);
 
   // Build env propagation args
   // tmux -e flag requires tmux >= 3.0; for older versions, prefix env exports in the command

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveLaunchCommand } from '../src/launcher.js';
+import { resolveLaunchCommand, buildTmuxInnerCmd } from '../src/launcher.js';
 
 describe('resolveLaunchCommand', () => {
   it('spawns claude directly when no wrapper is set', () => {
@@ -28,6 +28,26 @@ describe('resolveLaunchCommand', () => {
     assert.deepEqual(
       resolveLaunchCommand('claude', [], { CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER: '  nice   ' }),
       { cmd: 'nice', cmdArgs: ['claude'] },
+    );
+  });
+});
+
+describe('buildTmuxInnerCmd', () => {
+  it('execs the user\'s $SHELL after the launcher exits, not a hardcoded bash', () => {
+    const cmd = buildTmuxInnerCmd('/path/launcher.js', [], { SHELL: '/bin/zsh' });
+    assert.match(cmd, /exec '\/bin\/zsh'$/);
+  });
+
+  it('falls back to bash when $SHELL is unset', () => {
+    const cmd = buildTmuxInnerCmd('/path/launcher.js', [], {});
+    assert.match(cmd, /exec 'bash'$/);
+  });
+
+  it('still runs the launcher with escaped path and args before the exec', () => {
+    const cmd = buildTmuxInnerCmd('/path/launcher.js', ['--resume'], { SHELL: '/bin/zsh' });
+    assert.equal(
+      cmd,
+      "CLAUDE_AUTO_RETRY_ACTIVE=1 node '/path/launcher.js' '--resume'; exec '/bin/zsh'",
     );
   });
 });


### PR DESCRIPTION
## Summary
- `createTmuxSession`'s inner command ends with `exec bash` once the launcher process exits, ignoring the user's actual login shell (`$SHELL`) and tmux's own `default-shell` config. A zsh user (or any non-bash user) gets dropped into a bare `bash-3.2` prompt inside the pane instead of their normal shell.
- Extracted the inner-command builder into an exported `buildTmuxInnerCmd` (mirroring the existing `resolveLaunchCommand` pattern) so the fix is unit-testable, and had it `exec` `env.SHELL`, falling back to `bash` only when `SHELL` is unset.

## Test plan
- [x] `npm test` — all 355 tests pass, including 3 new cases covering `buildTmuxInnerCmd` (uses `$SHELL`, falls back to `bash` when unset, still runs the launcher with escaped path/args first)