### PR TITLE
fix(reconcile): harden node-launched claude detection (#49 review follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `reconcile` claude detection follow-ups (#49 review): (1) node flags that take a
+  separate-token value (`-r`/`--require`, `--import`, `--loader`, `-e`) are skipped when
+  finding the executed script, so a preload-instrumented `node -r x …/claude` is detected
+  and a `node -r /opt/claude server.js` no longer false-matches; (2) a launcher wrapping a
+  print-mode session (`node …/wrap claude -p`) is skipped — print mode is now read from the
+  args after the `claude` subcommand token, not the wrapper's first positional; (3) a
+  launcher child is verified claude-shaped before arming, instead of trusting that the
+  launcher only ever spawns claude.
+
 ## [0.6.0] - 2026-07-11
 
 ### Added

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -213,12 +213,25 @@ export function isClaudeProc(p) {
   return basename(argv0) === CLAUDE_COMM;
 }
 
-// The executed script of a `node [flags] <script> …` invocation (skip node + its flags).
+// Node flags that take a SEPARATE-token value (`node -r ./pre.js script.js`). Skipping only
+// the flag would mistake its value for the executed script — missing a preload-instrumented
+// claude (`node -r x /path/claude`) and false-matching an unrelated one whose value path
+// ends in "claude" (`node -r /opt/claude server.js`). The `--flag=value` form carries its
+// value in one token, so it isn't listed here.
+const NODE_VALUE_FLAGS = new Set(['-r', '--require', '--import', '--loader', '-e', '--eval']);
+// Index of the executed script in a `node [flags] <script> …` token list (skip node, its
+// flags, and any separate-token flag values).
+function nodeScriptIndex(toks) {
+  let i = 1;                                       // toks[0] = "node"
+  while (i < toks.length && toks[i].startsWith('-')) {
+    i += (NODE_VALUE_FLAGS.has(toks[i]) && !toks[i].includes('=')) ? 2 : 1;
+  }
+  return i;
+}
+// The executed script of a `node [flags] <script> …` invocation.
 function nodeScript(args) {
   const toks = (args || '').trim().split(/\s+/);
-  let i = 1;                                       // toks[0] = "node"
-  while (i < toks.length && toks[i].startsWith('-')) i++;
-  return toks[i] || '';
+  return toks[nodeScriptIndex(toks)] || '';
 }
 const baseName = (p) => p.split('/').pop();
 
@@ -247,9 +260,23 @@ function isMonitorProc(p) {
 function claudeArgs(p) {
   if (p.comm === CLAUDE_COMM) return p.args;
   const toks = (p.args || '').trim().split(/\s+/);
-  let i = 1;
-  while (i < toks.length && toks[i].startsWith('-')) i++;   // past node flags
-  return ['claude', ...toks.slice(i + 1)].join(' ');        // fake command token + real args
+  return ['claude', ...toks.slice(nodeScriptIndex(toks) + 1)].join(' '); // fake cmd token + real args
+}
+// For an agent wrapper that names claude as a subcommand (`node …/happier claude -p`), the
+// claude args begin AFTER the "claude" token — so isPrintMode sees the -p that follows it,
+// which claudeArgs (stopping at the wrapper's first positional) would miss. Empty if no
+// claude token is present (then the caller falls back to claudeArgs / errs toward arming).
+function wrapperClaudeArgs(args) {
+  const toks = (args || '').trim().split(/\s+/);
+  const i = toks.findIndex(t => baseName(t) === CLAUDE_COMM);
+  return i === -1 ? '' : ['claude', ...toks.slice(i + 1)].join(' ');
+}
+// Verify a launcher's child is actually claude before arming it — don't blindly trust the
+// "launcher only ever wraps claude" invariant. It counts as claude if it is claude itself
+// (comm/argv0), the node-launched CLI, or an agent wrapper that names claude as a token.
+function looksLikeClaude(p) {
+  if (isClaudeProc(p) || isNodeClaudeCli(p)) return true;
+  return (p.args || '').trim().split(/\s+/).some(t => baseName(t) === CLAUDE_COMM);
 }
 // Print mode: `claude -p` / `claude --print` produces piped/scripted output, never an
 // interactive TUI. The wrapper never arms a monitor there; reconcile must skip it too, or
@@ -368,7 +395,11 @@ export function sessionTargetsByPane(processes, byPid, panePidToPane) {
     const pane = paneForPid(p.pid, byPid, panePidToPane);
     if (!pane || byPane.has(pane)) continue;               // a direct candidate already owns it
     const child = processes.find(c => c.ppid === p.pid && !isMonitorProc(c));
-    if (child && !isPrintMode(claudeArgs(child))) push(pane, child);
+    if (!child || !looksLikeClaude(child)) continue;       // verify claude-shaped, don't just trust
+    // Print mode through the wrapper: check the args after the "claude" subcommand token
+    // (a wrapper positional precedes the -p, which claudeArgs alone would stop short of).
+    if (isPrintMode(wrapperClaudeArgs(child.args) || claudeArgs(child))) continue;
+    push(pane, child);
   }
   return byPane;
 }

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -447,4 +447,58 @@ describe('planReconcile', () => {
     ];
     assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
   });
+
+  // --- #49 review follow-up 1: nodeScript must skip a node flag's SEPARATE value, or it
+  //     mistakes the value for the script — missing a preload-instrumented claude and
+  //     false-matching an unrelated node process whose require path ends in "claude". ---
+  it('arms a node-launched claude started with a preload flag (node -r <mod> …/claude)', () => {
+    const panes = [{ pane: '%40', panePid: 4000 }];
+    const processes = [
+      { pid: 4000, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 4010, ppid: 4000, stat: 'Sl+', comm: 'node', args: 'node --require /opt/pre.js /home/u/.local/bin/claude --resume' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%40', pid: 4010 }]);
+  });
+  it('does NOT false-match a node process whose --require value path ends in "claude"', () => {
+    const panes = [{ pane: '%41', panePid: 4100 }];
+    const processes = [
+      { pid: 4100, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 4110, ppid: 4100, stat: 'Sl+', comm: 'node', args: 'node -r /opt/claude /app/server.js' }, // real script is server.js
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
+  });
+
+  // --- #49 review follow-up 2: a launcher wrapping print mode must be skipped — isPrintMode
+  //     stopped at the wrapper's first positional ("claude") and never saw the -p after it. ---
+  it('does NOT arm a launcher wrapping a print-mode claude (node …/wrap claude -p)', () => {
+    const panes = [{ pane: '%42', panePid: 4200 }];
+    const processes = [
+      { pid: 4200, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 4210, ppid: 4200, stat: 'Sl', comm: 'node', args: 'node /opt/car/src/launcher.js' },
+      { pid: 4220, ppid: 4210, stat: 'Sl+', comm: 'node', args: 'node /home/u/.local/bin/wrap claude -p' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
+  });
+  it('still arms a launcher wrapping an interactive claude (node …/happier claude -c)', () => {
+    const panes = [{ pane: '%43', panePid: 4300 }];
+    const processes = [
+      { pid: 4300, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 4310, ppid: 4300, stat: 'Sl', comm: 'node', args: 'node /opt/car/src/launcher.js -c' },
+      { pid: 4320, ppid: 4310, stat: 'Sl+', comm: 'node', args: 'node /home/u/.local/bin/happier claude -c' },
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, [{ pane: '%43', pid: 4320 }]);
+  });
+
+  // --- #49 review follow-up 3: don't blindly trust "the launcher only spawns claude" —
+  //     verify the child is claude-shaped, so a launcher child that isn't claude (a helper,
+  //     or a mis-detected process) doesn't get a send-keys monitor. ---
+  it('does NOT arm a launcher child that is not claude-shaped', () => {
+    const panes = [{ pane: '%44', panePid: 4400 }];
+    const processes = [
+      { pid: 4400, ppid: 1, stat: 'Ss', comm: 'bash' },
+      { pid: 4410, ppid: 4400, stat: 'Sl', comm: 'node', args: 'node /opt/car/src/launcher.js' },
+      { pid: 4420, ppid: 4410, stat: 'Sl+', comm: 'node', args: 'node /app/build.js' }, // not claude
+    ];
+    assert.deepEqual(planReconcile({ panes, processes, running: new Map() }).arm, []);
+  });
 });


### PR DESCRIPTION
Addresses the three non-blocking edge cases from your #49 review, test-first.

**1. Separate-value node flags.** `nodeScript`/`claudeArgs` skipped `-flag` tokens but not a flag's *separate-token value*, so `node -r <mod> <script>` read `<mod>` as the script. That both **missed** a preload-instrumented `node -r x …/claude` (Finding 6 re-opened for instrumented starts) and **false-matched** `node -r /opt/claude server.js`. Added `NODE_VALUE_FLAGS` (`-r`/`--require`, `--import`, `--loader`, `-e`) and a shared `nodeScriptIndex` that skips a value-flag's next token (the `--flag=value` form still carries its value in one token, so it's untouched).

**2. Launcher wrapping print mode.** `node …/wrap claude -p` was armed because `isPrintMode`, fed `claudeArgs`, stopped at the wrapper's first positional (`claude`) and never saw the `-p` after it. New `wrapperClaudeArgs` reads print mode from the args *after* the `claude` subcommand token.

**3. Launcher child trust.** Branch 3 armed the launcher's first non-monitor child without checking it. New `looksLikeClaude` (claude by comm/argv0, the node CLI, or an agent wrapper that names claude) gates it, so a non-claude child never gets a send-keys monitor.

## Test-first

Five `planReconcile` cases: preload-flag claude arms; `node -r /opt/claude server.js` does **not**; launcher + print-mode skipped; launcher + interactive still arms; non-claude launcher child skipped. Also verified against **live** process state — 12 real claude panes detected, no over/under-match. **357/357.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)