### PR TITLE
fix: prevent timezone date shift in absolute time parsing

### DIFF
--- a/src/time-parser.js
+++ b/src/time-parser.js
@@ -82,7 +82,7 @@ export function calculateWaitMs(parsed, marginSeconds = 60, fallbackHours = 5, n
 
     // Construct target date string and parse as UTC as initial guess
     const targetStr = `${y}-${String(mo + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}T${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00`;
-    const naiveUtc = new Date(targetStr + 'Z');
+    const naiveUtc = new Date(targetStr);
 
     // Iterative correction: format the guess in the target TZ,
     // compare with desired h:m, adjust, repeat up to 3 times for DST convergence


### PR DESCRIPTION
Fixes a bug where absolute reset times are parsed as UTC (Z), causing the target date to shift to the next day in non-UTC timezones (e.g. JST), resulting in an incorrect 24h+ wait duration. Removing the 'Z' suffix allows Date to be parsed in the local timezone first, avoiding timezone-related date rollover during the initial guess.