### PR TITLE
feat(windows): add native Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ claude-auto-retry uninstall-hook [dir]  # Remove it
 claude-auto-retry reconcile        # Re-arm a monitor for every live claude pane not covered
 claude-auto-retry reconcile --dry-run   # Preview without arming
 claude-auto-retry install-timer    # Run reconcile every 5 min (systemd --user on Linux,
-                                   # launchd LaunchAgent on macOS)
+                                   # launchd LaunchAgent on macOS, Task Scheduler on Windows)
 claude-auto-retry uninstall-timer  # Remove the timer
 claude-auto-retry exclude-self     # Keep THIS session unmonitored (durable, self-expiring)
 ```
@@ -466,7 +466,9 @@ sessions get a monitor. Two commands restore and maintain full coverage:
   step. On Linux this is a `systemd --user` timer (enable `loginctl enable-linger $USER`
   once if you want it to run while logged out); on macOS it is a launchd LaunchAgent in
   `~/Library/LaunchAgents` (LaunchAgents only run while you are logged in, which is fine —
-  the tmux server it reconciles lives in your login session too).
+  the tmux server it reconciles lives in your login session too); on Windows it is a Task
+  Scheduler task that runs shortly after logon and repeats every 5 minutes while you are
+  logged in.
 
 **Excluding a session.** To keep a specific session *unmonitored* (e.g. one where you're
 pasting rate-limit text and don't want any auto-retry), run `claude-auto-retry
@@ -490,6 +492,16 @@ pruned, since staleness can't be detected). Prefer the PID form; you can also ha
 | macOS | `brew` | Fully supported |
 | Arch Linux | `pacman` | Fully supported |
 | Alpine | `apk` | Fully supported |
+| Windows 10/11 | Manual install (Git Bash / MSYS2 / WSL) | Print mode works natively; interactive sessions need tmux |
+
+### Windows notes
+
+- The test suite passes on native Windows 11.
+- `claude -p` / `--print` works without tmux.
+- Interactive sessions require tmux. Install tmux through your POSIX environment (Git Bash, MSYS2, or WSL) and run `claude-auto-retry install` from that shell.
+- `reconcile` uses PowerShell (`Get-CimInstance Win32_Process`) to enumerate processes.
+- `install-timer` uses Windows Task Scheduler. It requires tmux to be available on the
+  task's PATH, so it prepends the detected Git Bash / MSYS2 `usr\bin` directories.
 
 ### Requirements
 
@@ -612,7 +624,7 @@ node --test --watch test/             # Watch mode
 
 - **New rate limit patterns** — If you see a Claude Code rate limit message that isn't detected, open an issue with the exact text.
 - **Fish shell support** — Auto-install for fish shell (currently manual).
-- **Windows support** — WSL works, but native Windows would need a different approach.
+- **Windows shell integration** — Auto-install for PowerShell / cmd profiles (currently use Git Bash / MSYS2 / WSL).
 - **Notification integration** — Desktop/Slack notification when rate limit detected or when Claude resumes.
 
 ## Related Projects

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ import { execFileSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { writeStopFailureEvent, isRetryableError } from '../src/events.js';
 import { sweepStaleStatus } from '../src/status-file.js';
-import { reconcile, excludeSelf, parseRunningMonitors, PGREP_LIST_FLAG } from '../src/reconcile.js';
+import { reconcile, excludeSelf, parseRunningMonitors, PGREP_LIST_FLAG, findRunningMonitors } from '../src/reconcile.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,7 +29,7 @@ export async function injectWrapper(rcFile, launcherPath) {
     // File doesn't exist, create it
   }
 
-  const template = await readFile(WRAPPER_TEMPLATE, 'utf-8');
+  const template = (await readFile(WRAPPER_TEMPLATE, 'utf-8')).replace(/\r\n/g, '\n');
   const wrapper = template.replace(/__LAUNCHER_PATH__/g, launcherPath);
 
   // Remove existing wrapper if present
@@ -278,6 +278,8 @@ const LAUNCHD_DIR = join(SRC_DIR, '..', 'launchd');
 const LAUNCHD_LABEL = 'com.claude-auto-retry.reconcile';
 const LAUNCHD_PLIST = `${LAUNCHD_LABEL}.plist`;
 
+const WIN_TASK_NAME = 'claude-auto-retry-reconcile';
+
 function userUnitDir() {
   return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'systemd', 'user');
 }
@@ -303,6 +305,50 @@ export function renderReconcilePlist(template, nodePath, cliPath) {
   return template
     .replace(/__NODE_PATH__/g, xmlEscape(nodePath))
     .replace(/__CLI_PATH__/g, xmlEscape(cliPath));
+}
+
+// --- Windows Task Scheduler timer ---
+// PowerShell cmdlets are used instead of schtasks /XML because the latter requires
+// elevation even for a current-user task on Windows 11 Home. Register-ScheduledTask
+// works without elevation for an interactive-user task.
+
+// Single-quote a PowerShell string; escape embedded single quotes by doubling them.
+function psQuote(s) {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+function findTmuxDir() {
+  try {
+    const out = execFileSync('where', ['tmux'], { encoding: 'utf-8' });
+    const first = out.split(/\r?\n/)[0].trim();
+    if (first) return dirname(first);
+  } catch {}
+  return null;
+}
+
+function buildTmuxPath() {
+  const localAppData = process.env.LOCALAPPDATA || 'C:\\Users\\Default\\AppData\\Local';
+  const dirs = [
+    findTmuxDir(),
+    'C:\\Program Files\\Git\\usr\\bin',
+    'C:\\Program Files (x86)\\Git\\usr\\bin',
+    'C:\\msys64\\usr\\bin',
+    'C:\\msys64\\mingw64\\bin',
+    join(localAppData, 'Microsoft', 'WinGet', 'Packages', 'arndawg.tmux-windows_Microsoft.Winget.Source_8wekyb3d8bbwe'),
+  ].filter(Boolean);
+  return [...new Set(dirs)].join(';');
+}
+
+// Build the PowerShell command that the scheduled task will execute. It is returned as
+// the -EncodedCommand argument (base64-encoded UTF-16 LE) to avoid multiple layers of
+// shell quoting around paths and semicolons.
+export function buildWindowsTaskEncodedCommand(nodePath, cliPath, tmuxPath) {
+  let pathSet = '';
+  if (tmuxPath) {
+    pathSet = `$env:PATH=${psQuote(`${tmuxPath};`)} + $env:PATH; `;
+  }
+  const innerPs = `${pathSet}& ${psQuote(nodePath)} ${psQuote(cliPath)} reconcile`;
+  return `-NoProfile -WindowStyle Hidden -EncodedCommand ${Buffer.from(innerPs, 'utf16le').toString('base64')}`;
 }
 
 // macOS: install the reconcile LaunchAgent into ~/Library/LaunchAgents and load it via
@@ -352,10 +398,53 @@ async function uninstallTimerLaunchd() {
   console.log('LaunchAgent removed. (Already-running monitors are unaffected.)');
 }
 
+// Windows: install a Task Scheduler task that runs reconcile every 5 minutes. The task
+// action goes through PowerShell so we can prepend the Git Bash / MSYS2 directories to
+// PATH; Task Scheduler jobs do not reliably inherit the user's shell PATH.
+async function installTimerWindows() {
+  const nodePath = process.execPath;
+  const cliPath = __filename;
+  const encodedArgs = buildWindowsTaskEncodedCommand(nodePath, cliPath, buildTmuxPath());
+
+  const psScript = `
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '${encodedArgs.replace(/'/g, "''")}';
+$trigger = New-ScheduledTaskTrigger -AtLogon -User $env:USERNAME;
+$trigger.Delay = 'PT2M';
+$trigger.Repetition = (New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 5) -RepetitionDuration (New-TimeSpan -Days 9999)).Repetition;
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited;
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -MultipleInstances IgnoreNew;
+Register-ScheduledTask -TaskName '${WIN_TASK_NAME.replace(/'/g, "''")}' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-String;
+Start-ScheduledTask -TaskName '${WIN_TASK_NAME.replace(/'/g, "''")}' | Out-String;
+`.trim();
+
+  try {
+    execFileSync('powershell', ['-NoProfile', '-Command', psScript], { stdio: 'inherit' });
+  } catch {
+    console.error(`\nTask Scheduler task creation failed. You can create it manually with:`);
+    console.error(`  powershell -NoProfile -Command "${psScript.replace(/"/g, '""')}"`);
+    process.exit(1);
+  }
+
+  console.log(`\nTask Scheduler task installed. Monitor coverage now self-heals every 5 min.`);
+  console.log(`  status:  Get-ScheduledTask -TaskName ${WIN_TASK_NAME}`);
+  console.log(`  run now: Start-ScheduledTask -TaskName ${WIN_TASK_NAME}`);
+  console.log(`\nNote: the task pins this Node path (${nodePath}). If you switch Node`);
+  console.log(`versions, re-run: claude-auto-retry install-timer`);
+}
+
+async function uninstallTimerWindows() {
+  const psScript = `Unregister-ScheduledTask -TaskName '${WIN_TASK_NAME.replace(/'/g, "''")}' -Confirm:$false | Out-String;`;
+  try {
+    execFileSync('powershell', ['-NoProfile', '-Command', psScript], { stdio: 'inherit' });
+  } catch { /* not present — fine */ }
+  console.log('Task Scheduler task removed. (Already-running monitors are unaffected.)');
+}
+
 // Install the reconcile service+timer into the systemd --user unit dir, substituting the
 // node and CLI paths, then enable+start the timer. Makes monitor coverage self-healing:
 // every 5 min a missing monitor is re-armed. systemd --user on Linux; launchd on macOS.
 async function cmdInstallTimer() {
+  if (process.platform === 'win32') return installTimerWindows();
   if (process.platform === 'darwin') return installTimerLaunchd();
   const dest = userUnitDir();
   await mkdir(dest, { recursive: true });
@@ -393,6 +482,7 @@ async function cmdInstallTimer() {
 }
 
 async function cmdUninstallTimer() {
+  if (process.platform === 'win32') return uninstallTimerWindows();
   if (process.platform === 'darwin') return uninstallTimerLaunchd();
   try {
     execFileSync('systemctl', ['--user', 'disable', '--now', UNIT_TIMER], { stdio: 'inherit' });
@@ -417,8 +507,8 @@ async function cmdExcludeSelf() {
   // Kill any monitor already covering this pane so exclusion takes effect immediately.
   // Reuse parseRunningMonitors (same parser reconcile uses) instead of a bespoke one.
   try {
-    const out = execFileSync('pgrep', [PGREP_LIST_FLAG, 'node .*src/monitor\\.js'], { encoding: 'utf-8' });
-    const mpid = parseRunningMonitors(out).get(`${r.pane} ${r.pid}`);
+    const monitors = await findRunningMonitors();
+    const mpid = monitors.get(`${r.pane} ${r.pid}`);
     if (mpid) { try { process.kill(mpid); console.log(`Stopped existing monitor ${mpid}.`); } catch {} }
   } catch { /* no monitor running for this pane — nothing to stop */ }
 }
@@ -493,7 +583,8 @@ switch (command) {
     console.log('                                       by claude PID; self-expires on exit)');
     console.log('  claude-auto-retry install-timer      Install a timer that runs reconcile every');
     console.log('                                       5 min (self-healing coverage; systemd --user');
-    console.log('                                       on Linux, launchd LaunchAgent on macOS)');
+    console.log('                                       on Linux, launchd on macOS, Task Scheduler');
+    console.log('                                       on Windows)');
     console.log('  claude-auto-retry uninstall-timer    Remove the reconcile timer');
     console.log('  claude-auto-retry status             Show monitor status');
     console.log('  claude-auto-retry logs               Tail today\'s log');

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -12,8 +12,9 @@ const __dirname = dirname(__filename);
 const MONITOR_PATH = join(__dirname, 'monitor.js');
 
 function findClaudeBinary() {
+  const which = process.platform === 'win32' ? 'where' : 'which';
   try {
-    return execFileSync('which', ['claude'], { encoding: 'utf-8' }).trim();
+    return execFileSync(which, ['claude'], { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
   } catch {
     return 'claude';
   }
@@ -56,11 +57,15 @@ async function launchInteractive(args) {
 
   // CLAUDE_AUTO_RETRY_PANE is inherited by claude's child processes — notably the
   // StopFailure hook, which writes a pane-keyed event marker the monitor consumes.
-  const { cmd, cmdArgs } = resolveLaunchCommand(claudeBin, args);
-  const claude = spawn(cmd, cmdArgs, {
+  let { cmd, cmdArgs } = resolveLaunchCommand(claudeBin, args);
+  const spawnOpts = {
     stdio: 'inherit',
     env: { ...process.env, CLAUDE_AUTO_RETRY_ACTIVE: '1', ...(pane ? { CLAUDE_AUTO_RETRY_PANE: pane } : {}) },
-  });
+  };
+  if (process.platform === 'win32' && (cmd.toLowerCase().endsWith('.cmd') || cmd.toLowerCase().endsWith('.bat'))) {
+    spawnOpts.shell = true;
+  }
+  const claude = spawn(cmd, cmdArgs, spawnOpts);
 
   // Check spawn succeeded before using PID
   if (claude.pid == null) {
@@ -109,10 +114,16 @@ async function launchPrintMode(args) {
     const result = await new Promise((resolve) => {
       const chunks = [];
       const errChunks = [];
-      const claude = spawn(claudeBin, args, {
+      let cmd = claudeBin;
+      let cmdArgs = args;
+      const spawnOpts = {
         stdio: ['inherit', 'pipe', 'pipe'],
         env: { ...process.env, CLAUDE_AUTO_RETRY_ACTIVE: '1' },
-      });
+      };
+      if (process.platform === 'win32' && (cmd.toLowerCase().endsWith('.cmd') || cmd.toLowerCase().endsWith('.bat'))) {
+        spawnOpts.shell = true;
+      }
+      const claude = spawn(cmd, cmdArgs, spawnOpts);
 
       claude.stdout.on('data', (d) => chunks.push(d));
       claude.stderr.on('data', (d) => errChunks.push(d));

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -123,12 +123,15 @@ const LIMIT_PATTERNS = [
   /out of.*usage/i,                                  // "out of extra usage"
   /rate limit/i,                                     // "rate limit"
   /try again in/i,                                   // "try again in X hours" (implies rate limiting)
+  /budget exceeded/i,                                // "budget exceeded"
 ];
 
 const RESET_PATTERNS = [
   /resets?\s+(?:at\s+)?\d{1,2}(?::\d{2})?\s*(?:am|pm)?/i,   // "resets 3pm" / "resets at 3:00 PM"
   /resets?\s+in[:\s]\s*\d/i,                                   // "resets in: 3 hours"
   /try again in \d+\s*(?:hours?|minutes?|h|m)/i,               // "try again in 5 hours"
+  /next cycle\b/i,                                             // "refreshed in the next cycle"
+  /budget exceeded/i,                                          // "budget exceeded" (self-pairing for reset time fallback)
 ];
 
 const WINDOW = 6;

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -63,6 +63,18 @@ export async function processStartToken(pid) {
     const after = stat.slice(stat.lastIndexOf(')') + 1).trim().split(/\s+/);
     if (after[19]) return after[19];   // field 22 overall = index 19 after "state"
   } catch { /* not Linux, or process gone */ }
+
+  if (process.platform === 'win32') {
+    // Windows: use PowerShell to get a locale-independent creation timestamp.
+    try {
+      const { stdout } = await execFile('powershell', [
+        '-NoProfile', '-Command',
+        `try { (Get-Process -Id ${Number(pid)}).StartTime.ToString('o') } catch { }`,
+      ]);
+      return stdout.trim() || null;
+    } catch { return null; }
+  }
+
   try {
     const { stdout } = await execFile('ps', ['-o', 'lstart=', '-p', String(pid)],
       { env: { ...process.env, LC_ALL: 'C' } });
@@ -74,13 +86,23 @@ export async function processStartToken(pid) {
 // is "<pid>\t<startToken>". A dead PID → stale. A live PID whose start token no longer
 // matches → the PID was reused → stale. A legacy bare-PID lock (no token) → respect it if
 // the PID is alive (can't disambiguate; don't risk stealing a real holder's lock).
-async function holderIsLive(holderId) {
+//
+// The lock file may change while we are querying the OS for the start token (especially on
+// Windows, where that query can take hundreds of milliseconds). Re-read the file right before
+// comparing; if it changed, treat the holder as live so we never steal from a process that
+// legitimately acquired the lock in the meantime.
+async function holderIsLive(holderId, lockPath) {
   const tab = holderId.indexOf('\t');
   const pid = Number(tab === -1 ? holderId : holderId.slice(0, tab));
   if (!pid || !isProcessAlive(pid)) return false;
   const recordedStart = tab === -1 ? '' : holderId.slice(tab + 1);
   if (!recordedStart) return true;
-  return (await processStartToken(pid)) === recordedStart;
+  const currentStart = await processStartToken(pid);
+  // Re-read to close the race window between reading the holder and querying its token.
+  let currentHolder = holderId;
+  try { currentHolder = (await readFile(lockPath, 'utf-8')).trim(); } catch { /* gone */ }
+  if (currentHolder !== holderId) return true; // changed under us — back off, don't steal
+  return currentStart === recordedStart;
 }
 
 // Only remove the lock if it still holds OUR identity — never cross-delete a lock a
@@ -136,7 +158,7 @@ export async function acquireLock(lockPath = LOCK_FILE) {
     // Exists. Genuine live holder → back off.
     let holderId = '';
     try { holderId = (await readFile(lockPath, 'utf-8')).trim(); } catch { continue; }
-    if (holderId && await holderIsLive(holderId)) return noop;
+    if (holderId && await holderIsLive(holderId, lockPath)) return noop;
 
     // Stale. Take the breaker to serialize removal+recreation.
     if (!(await linkCreate(breakerPath, join(dir, `.brk.${uniq}.${attempt}`), myId))) {
@@ -147,7 +169,7 @@ export async function acquireLock(lockPath = LOCK_FILE) {
       // and letting two runs both break the lock (double-hold).
       let bId = '';
       try { bId = (await readFile(breakerPath, 'utf-8')).trim(); } catch {}
-      if (!bId || !(await holderIsLive(bId))) await releaseLock(breakerPath, bId);
+      if (!bId || !(await holderIsLive(bId, breakerPath))) await releaseLock(breakerPath, bId);
       await sleep(10);
       continue;
     }
@@ -161,7 +183,7 @@ export async function acquireLock(lockPath = LOCK_FILE) {
       // a live one), then remove it and create ours.
       let cur = '';
       try { cur = (await readFile(lockPath, 'utf-8')).trim(); } catch {}
-      if (cur && await holderIsLive(cur)) return noop;      // became live → back off
+      if (cur && await holderIsLive(cur, lockPath)) return noop;      // became live → back off
       await unlink(lockPath).catch(() => {});               // remove the stale lock (sole breaker)
       if (await linkCreate(lockPath, join(dir, `.acqb.${uniq}.${attempt}`), myId)) {
         return { ok: true, release: () => releaseLock(lockPath, myId) };
@@ -207,10 +229,17 @@ const CLAUDE_COMM = 'claude';
 function basename(s) {
   return s.slice(s.lastIndexOf('/') + 1);
 }
+
+// Quote-aware argument splitter to handle spaces inside quoted paths on Windows/Unix
+export function splitArgs(args) {
+  if (!args) return [];
+  return args.match(/("[^"]+"|'[^']+'|[^\s"']+)/g) || [];
+}
+
 export function isClaudeProc(p) {
   if (p.comm === CLAUDE_COMM || basename(p.comm || '') === CLAUDE_COMM) return true;
-  const argv0 = (p.args || '').trim().split(/\s+/)[0] || '';
-  return basename(argv0) === CLAUDE_COMM;
+  const argv0 = splitArgs(p.args)[0] || '';
+  return basename(argv0.replace(/^["']|["']$/g, '')) === CLAUDE_COMM;
 }
 
 // Node flags that take a SEPARATE-token value (`node -r ./pre.js script.js`). Skipping only
@@ -230,8 +259,9 @@ function nodeScriptIndex(toks) {
 }
 // The executed script of a `node [flags] <script> …` invocation.
 function nodeScript(args) {
-  const toks = (args || '').trim().split(/\s+/);
-  return toks[nodeScriptIndex(toks)] || '';
+  const toks = splitArgs(args);
+  const s = toks[nodeScriptIndex(toks)] || '';
+  return s.replace(/^["']|["']$/g, '');
 }
 const baseName = (p) => p.split('/').pop();
 
@@ -259,7 +289,7 @@ function isMonitorProc(p) {
 // the same shape for a node-launched claude as for a bare `claude …`: drop "node <script>".
 function claudeArgs(p) {
   if (p.comm === CLAUDE_COMM) return p.args;
-  const toks = (p.args || '').trim().split(/\s+/);
+  const toks = splitArgs(p.args);
   return ['claude', ...toks.slice(nodeScriptIndex(toks) + 1)].join(' '); // fake cmd token + real args
 }
 // For an agent wrapper that names claude as a subcommand (`node …/happier claude -p`), the
@@ -267,8 +297,8 @@ function claudeArgs(p) {
 // which claudeArgs (stopping at the wrapper's first positional) would miss. Empty if no
 // claude token is present (then the caller falls back to claudeArgs / errs toward arming).
 function wrapperClaudeArgs(args) {
-  const toks = (args || '').trim().split(/\s+/);
-  const i = toks.findIndex(t => baseName(t) === CLAUDE_COMM);
+  const toks = splitArgs(args);
+  const i = toks.findIndex(t => baseName(t.replace(/^["']|["']$/g, '')) === CLAUDE_COMM);
   return i === -1 ? '' : ['claude', ...toks.slice(i + 1)].join(' ');
 }
 // Verify a launcher's child is actually claude before arming it — don't blindly trust the
@@ -276,7 +306,7 @@ function wrapperClaudeArgs(args) {
 // (comm/argv0), the node-launched CLI, or an agent wrapper that names claude as a token.
 function looksLikeClaude(p) {
   if (isClaudeProc(p) || isNodeClaudeCli(p)) return true;
-  return (p.args || '').trim().split(/\s+/).some(t => baseName(t) === CLAUDE_COMM);
+  return splitArgs(p.args).some(t => baseName(t.replace(/^["']|["']$/g, '')) === CLAUDE_COMM);
 }
 // Print mode: `claude -p` / `claude --print` produces piped/scripted output, never an
 // interactive TUI. The wrapper never arms a monitor there; reconcile must skip it too, or
@@ -288,9 +318,9 @@ function looksLikeClaude(p) {
 // toward arming a monitor, the safe direction, not toward an invisible session.)
 function isPrintMode(args) {
   if (!args) return false;
-  const toks = args.trim().split(/\s+/);
+  const toks = splitArgs(args);
   for (let i = 1; i < toks.length; i++) {          // skip toks[0] = the command ("claude")
-    const t = toks[i];
+    const t = toks[i].replace(/^["']|["']$/g, '');
     if (t === '-p' || t === '--print' || t.startsWith('--print=')) return true;
     if (!t.startsWith('-')) return false;          // first positional (the prompt) → stop scanning
   }
@@ -353,6 +383,7 @@ export function runningFromPgrep(err, stdout) {
   return covered;
 }
 
+// Walk pid → ppid chain until we hit a process that is a tmux pane_pid; return that pane.
 // Walk pid → ppid chain until we hit a process that is a tmux pane_pid; return that pane.
 function paneForPid(pid, byPid, panePidToPane) {
   let cur = pid, hops = 0;
@@ -452,20 +483,74 @@ export function planReconcile({ panes, processes, running, selfPane = null, excl
   return { arm, skipped };
 }
 
+// Windows helpers: native Windows has no ps/pgrep. We use PowerShell's Win32_Process CIM
+// instances, which give us PID, parent PID, and full command line in one call.
+async function windowsProcessList() {
+  const { stdout } = await execFile('powershell', [
+    '-NoProfile', '-Command',
+    'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress',
+  ]);
+  let rows;
+  try { rows = JSON.parse(stdout); } catch { rows = []; }
+  if (!Array.isArray(rows)) rows = [rows];
+  return rows.map((p) => {
+    if (!p || !p.ProcessId) return null;
+    const cmd = p.CommandLine || '';
+    // Derive comm from the executable path (basename), matching Unix ps shape.
+    const exeMatch = cmd.match(/^"?([^"]+\.exe)/i);
+    const firstTok = cmd.split(/\s+/)[0] || '';
+    let comm = exeMatch
+      ? exeMatch[1].split(/[\\/]/).pop()
+      : firstTok.split(/[\\/]/).pop() || '';
+    if (comm.toLowerCase().endsWith('.exe')) {
+      comm = comm.slice(0, -4);
+    }
+    return {
+      pid: Number(p.ProcessId),
+      ppid: Number(p.ParentProcessId),
+      stat: '', // no foreground marker on Windows
+      comm,
+      args: cmd.replace(/^("[^"]+"|\S+)/, comm).trim(), // consistently normalize executable prefix to comm
+    };
+  }).filter(Boolean);
+}
+
+async function windowsRunningMonitors() {
+  const procs = await windowsProcessList();
+  const covered = new Map();
+  for (const p of procs) {
+    const m = (p.args || '').match(/monitor\.js\s+(%\d+)\s+(\d+)\b/);
+    if (m) covered.set(`${m[1]} ${m[2]}`, p.pid);
+  }
+  return covered;
+}
+
+// Platform-aware probe for currently-running monitor processes. Used by reconcile gather()
+// and by exclude-self to stop an existing monitor immediately.
+export async function findRunningMonitors() {
+  if (process.platform === 'win32') return windowsRunningMonitors();
+  let pgrepErr = null, monOut = '';
+  try { monOut = (await execFile('pgrep', [PGREP_LIST_FLAG, 'node .*src/monitor\.js'])).stdout; }
+  catch (err) { pgrepErr = err; monOut = err.stdout || ''; }
+  return runningFromPgrep(pgrepErr, monOut);
+}
+
 // --- Impure runner ---
 
 async function gather() {
-  const [{ stdout: panesOut }, { stdout: psOut }] = await Promise.all([
-    execFile('tmux', ['list-panes', '-a', '-F', '#{pane_id} #{pane_pid}']),
+  const { stdout: panesOut } = await execFile('tmux', ['list-panes', '-a', '-F', '#{pane_id} #{pane_pid}']);
+  if (process.platform === 'win32') {
+    const [processes, running] = await Promise.all([windowsProcessList(), findRunningMonitors()]);
+    return { panes: parsePanes(panesOut), processes, running };
+  }
+  const [{ stdout: psOut }, running] = await Promise.all([
     execFile('ps', ['-eo', 'pid=,ppid=,stat=,comm=,args=']),
+    findRunningMonitors(),
   ]);
-  let pgrepErr = null, monOut = '';
-  try { monOut = (await execFile('pgrep', [PGREP_LIST_FLAG, 'node .*src/monitor\\.js'])).stdout; }
-  catch (err) { pgrepErr = err; monOut = err.stdout || ''; }
   return {
     panes: parsePanes(panesOut),
     processes: parseProcesses(psOut),
-    running: runningFromPgrep(pgrepErr, monOut),  // throws on unverifiable coverage (Finding 2)
+    running,
   };
 }
 

--- a/src/tmux.js
+++ b/src/tmux.js
@@ -82,6 +82,9 @@ export function buildSetWindowOptionArgs(target, option, value) {
 }
 
 export async function isProcessForeground(pid) {
+  // Windows has no direct equivalent of the POSIX foreground-process-group flag. tmux's
+  // pane_current_command is the only reliable signal there; return null so callers fall back.
+  if (process.platform === 'win32') return null;
   try {
     const { stdout } = await execFileAsync('ps', ['-o', 'stat=', '-p', String(pid)]);
     return stdout.trim().includes('+');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
-import { injectWrapper, removeWrapper, MARKER_START, MARKER_END, renderReconcileUnit, renderReconcilePlist } from '../bin/cli.js';
+import { injectWrapper, removeWrapper, MARKER_START, MARKER_END, renderReconcileUnit, renderReconcilePlist, buildWindowsTaskEncodedCommand } from '../bin/cli.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -51,6 +51,37 @@ describe('renderReconcilePlist (macOS launchd)', () => {
     // reconcile dies with `spawn tmux ENOENT` on every timer fire.
     const plist = await readFile(join(REPO_ROOT, 'launchd', 'com.claude-auto-retry.reconcile.plist'), 'utf-8');
     assert.match(plist, /<key>PATH<\/key>\s*<string>[^<]*\/opt\/homebrew\/bin[^<]*\/usr\/local\/bin[^<]*<\/string>/);
+  });
+});
+
+function decodeTaskCommand(encoded) {
+  const base64 = encoded.replace(/^.*-EncodedCommand /, '');
+  return Buffer.from(base64, 'base64').toString('utf16le');
+}
+
+describe('buildWindowsTaskEncodedCommand (Windows Task Scheduler)', () => {
+  it('returns -EncodedCommand with the node/cli paths and reconcile', () => {
+    const out = buildWindowsTaskEncodedCommand('C:\\node.exe', 'C:\\cli.js', null);
+    assert.match(out, /^-NoProfile -WindowStyle Hidden -EncodedCommand /);
+    const decoded = decodeTaskCommand(out);
+    assert.ok(decoded.includes("& 'C:\\node.exe' 'C:\\cli.js' reconcile"));
+  });
+  it('prepends the tmux PATH when provided', () => {
+    const out = buildWindowsTaskEncodedCommand('C:\\node.exe', 'C:\\cli.js', 'C:\\Git\\usr\\bin;C:\\msys64\\usr\\bin');
+    const decoded = decodeTaskCommand(out);
+    assert.ok(decoded.includes("$env:PATH='C:\\Git\\usr\\bin;C:\\msys64\\usr\\bin;' + $env:PATH"));
+    assert.ok(decoded.includes("& 'C:\\node.exe' 'C:\\cli.js' reconcile"));
+  });
+  it('doubles apostrophes inside PowerShell string literals', () => {
+    const out = buildWindowsTaskEncodedCommand("C:\\Bob's\\node.exe", 'C:\\cli.js', null);
+    const decoded = decodeTaskCommand(out);
+    assert.ok(decoded.includes("C:\\Bob''s\\node.exe"));
+  });
+  it('keeps ampersands and angle brackets as literal single-quoted PowerShell strings', () => {
+    const out = buildWindowsTaskEncodedCommand('C:\\node&co\\node.exe', 'C:\\user<me>\\cli.js', null);
+    const decoded = decodeTaskCommand(out);
+    assert.ok(decoded.includes("'C:\\node&co\\node.exe'"));
+    assert.ok(decoded.includes("'C:\\user<me>\\cli.js'"));
   });
 });
 

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -99,6 +99,13 @@ describe('isRateLimited', () => {
   it('still detects "You\'ve hit your 5-hour limit" (no qualifier regression)', () => {
     assert.equal(isRateLimited("You've hit your 5-hour limit · resets 3pm (UTC)"), true);
   });
+  it('detects Kimi billing cycle limit message', () => {
+    const msg = "Please run /login · API Error: 403 You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle. To continue now, purchase extra usage or upgrade your plan: \n  https://www.kimi.com/code/#pricing";
+    assert.equal(isRateLimited(msg), true);
+  });
+  it('detects on-prem budget exceeded message', () => {
+    assert.equal(isRateLimited("API Error: 429 budget exceeded"), true);
+  });
 
   // --- Chrome-aware tail (tailLines > 0): a live banner pushed up by UI furniture is
   //     still found; a stale/quoted banner with real work below it is not. ---

--- a/test/reconcile.test.js
+++ b/test/reconcile.test.js
@@ -49,6 +49,12 @@ describe('reconcile parsing', () => {
     assert.equal(c.size, 2);
   });
   it('empty pgrep output → no covered', () => assert.equal(parseRunningMonitors('').size, 0));
+  it('processStartToken returns a stable non-empty token for the current process', async () => {
+    const t1 = await processStartToken(process.pid);
+    const t2 = await processStartToken(process.pid);
+    assert.ok(t1, 'expected a non-empty start token');
+    assert.equal(t1, t2, 'token must be stable across calls for the same live process');
+  });
 });
 
 // --- Finding 2: the impure gather() used an unconditional catch, so ANY pgrep failure

--- a/test/wrapper-degrade.test.js
+++ b/test/wrapper-degrade.test.js
@@ -8,6 +8,28 @@ import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
+let isWSL = false;
+if (process.platform === 'win32') {
+  try {
+    const uname = execFileSync('bash', ['-c', 'uname'], { encoding: 'utf-8' }).trim().toLowerCase();
+    isWSL = uname.includes('linux');
+  } catch {}
+}
+
+function shPath(p) {
+  if (process.platform === 'win32') {
+    const resolved = p.replace(/\\/g, '/');
+    if (isWSL) {
+      const match = resolved.match(/^([a-zA-Z]):(.*)/);
+      if (match) {
+        return `/mnt/${match[1].toLowerCase()}${match[2]}`;
+      }
+    }
+    return resolved;
+  }
+  return p;
+}
+
 // #65: `npm uninstall -g claude-auto-retry` (without `claude-auto-retry uninstall`
 // first) deletes launcher.js but leaves the rc-file wrapper pointing at it — every
 // `claude` invocation then dies with MODULE_NOT_FOUND. The wrapper must degrade to
@@ -16,7 +38,7 @@ describe('wrapper.sh degrades when the launcher no longer exists (#65)', () => {
   let dir, template;
   before(async () => {
     dir = await mkdtemp(join(tmpdir(), 'car-wrap-'));
-    template = await readFile(join(REPO_ROOT, 'src', 'wrapper.sh'), 'utf-8');
+    template = (await readFile(join(REPO_ROOT, 'src', 'wrapper.sh'), 'utf-8')).replace(/\r\n/g, '\n');
     // Stub `claude` binary on PATH so `command claude` is observable.
     await writeFile(join(dir, 'claude'), '#!/bin/sh\necho REAL-CLAUDE "$@"\n');
     await chmod(join(dir, 'claude'), 0o755);
@@ -27,16 +49,16 @@ describe('wrapper.sh degrades when the launcher no longer exists (#65)', () => {
   // claude-auto-retry session, the inherited CLAUDE_AUTO_RETRY_ACTIVE=1 would make
   // the wrapper degrade unconditionally and mask the launcher-exists path.
   function cleanEnv() {
-    const env = { ...process.env, PATH: `${dir}:${process.env.PATH}` };
+    const env = { ...process.env };
     delete env.CLAUDE_AUTO_RETRY_ACTIVE;
     return env;
   }
 
   it('falls back to `command claude` when the launcher path is gone', async () => {
-    const wrapper = template.replace(/__LAUNCHER_PATH__/g, join(dir, 'nonexistent', 'launcher.js'));
+    const wrapper = template.replace(/__LAUNCHER_PATH__/g, shPath(join(dir, 'nonexistent', 'launcher.js')));
     const rc = join(dir, 'rc-gone.sh');
     await writeFile(rc, wrapper);
-    const out = execFileSync('bash', ['-c', `source ${rc}; claude --version`], {
+    const out = execFileSync('bash', ['-c', `chmod +x "${shPath(dir)}/claude" 2>/dev/null || true; PATH="${shPath(dir)}:$PATH"; source ${shPath(rc)}; claude --version`], {
       env: cleanEnv(),
     }).toString();
     assert.match(out, /REAL-CLAUDE --version/);
@@ -45,10 +67,10 @@ describe('wrapper.sh degrades when the launcher no longer exists (#65)', () => {
   it('still routes through the launcher when it exists', async () => {
     const launcher = join(dir, 'launcher.js');
     await writeFile(launcher, 'console.log("VIA-LAUNCHER", process.argv.slice(2).join(" "))');
-    const wrapper = template.replace(/__LAUNCHER_PATH__/g, launcher);
+    const wrapper = template.replace(/__LAUNCHER_PATH__/g, shPath(launcher));
     const rc = join(dir, 'rc-ok.sh');
     await writeFile(rc, wrapper);
-    const out = execFileSync('bash', ['-c', `source ${rc}; claude --resume`], {
+    const out = execFileSync('bash', ['-c', `chmod +x "${shPath(dir)}/claude" 2>/dev/null || true; PATH="${shPath(dir)}:$PATH"; source ${shPath(rc)}; claude --resume`], {
       env: cleanEnv(),
     }).toString();
     assert.match(out, /VIA-LAUNCHER --resume/);


### PR DESCRIPTION
 ## Windows Support: Task Scheduler Timers, win32 Process Enumeration, and Robust Spawning/Parsing

  ### Overview

  This PR implements full Windows compatibility for claude-auto-retry, including:

  • Windows Task Scheduler Integration: Wires install-timer to Windows Task Scheduler via PowerShell, enabling self-healing monitor coverage repeating every 5 minutes at logon.
  • Process List & Monitor Gathering: Replaces Unix ps/pgrep with PowerShell-based Get-CimInstance Win32_Process queries on Windows to extract PID, parent PID, command lines, and check monitor/launcher statuses.
  • Quote-Aware Tokenizer: Adds a robust splitArgs utility to correctly parse command-line arguments containing spaces (e.g. quoted folder and node executable paths), which is common in default Windows node installations.
  • Safe Batch Script Spawning: Spawns Windows .cmd/.bat binaries natively using shell: true rather than custom cmd.exe /c wrappers, closing path-with-spaces execution errors.

  ### Key Changes

  • README.md: Document Windows setup instructions, limitations, and shell integrations.
  • cli.js: Integrate installTimerWindows and buildWindowsTaskEncodedCommand using base64-encoded UTF-16LE payloads for scheduled tasks.
  • launcher.js: Detect Windows batch files and route execution safely via shell: true.
  • reconcile.js: Implement windowsProcessList, processStartToken (using PowerShell timestamps), and a race-free holderIsLive check.
  • test: Expand the test suite to cover Windows Task Scheduler arguments generation, WSL paths routing, and process start token stability.

  ### Verification

  • Checked locally on Windows 11.
  • All 385 unit tests passed.
