### PR TITLE
fix: whitelist tmux launch environment

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -38,6 +38,24 @@ function shellEscape(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
+// Only propagate the minimum environment needed for a healthy Claude/tmux launch.
+// This avoids copying every shell secret into a long-lived tmux session while still
+// preserving the auth/config vars the launcher actually depends on.
+export const TMUX_SESSION_ENV_VARS = [
+  'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL', 'LC_CTYPE',
+  'CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER', 'CLAUDE_CONFIG_DIR',
+  'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'HTTP_PROXY', 'HTTPS_PROXY',
+  'NO_PROXY', 'NODE_OPTIONS', 'NVM_DIR', 'NODE_PATH',
+];
+
+export function buildTmuxSessionEnv(env = process.env) {
+  const out = {};
+  for (const key of TMUX_SESSION_ENV_VARS) {
+    if (env[key] != null && env[key] !== '') out[key] = env[key];
+  }
+  return out;
+}
+
 // After the tmux session's own claude-auto-retry process exits, the pane falls through
 // to a plain shell so the user isn't dropped straight out of tmux. Use the user's actual
 // login shell (env.SHELL) rather than a hardcoded `bash` — tmux's own `default-shell`
@@ -164,22 +182,17 @@ async function createTmuxSession(args) {
   const tmuxVer = getTmuxVersion();
   let newSessionArgs;
 
+  const sessionEnv = buildTmuxSessionEnv();
   if (tmuxVer >= 3.0) {
     const envArgs = [];
-    for (const [k, v] of Object.entries(process.env)) {
-      if (k.startsWith('TMUX')) continue;
-      if (v == null) continue;
+    for (const [k, v] of Object.entries(sessionEnv)) {
       envArgs.push('-e', `${k}=${v}`);
     }
     newSessionArgs = ['new-session', '-d', '-s', sessionName, ...envArgs, innerCmd];
   } else {
-    // For tmux < 3.0: export critical env vars inline in the command
-    const criticalVars = ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG',
-      'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'HTTP_PROXY', 'HTTPS_PROXY',
-      'NO_PROXY', 'NODE_OPTIONS', 'NVM_DIR', 'NODE_PATH'];
-    const exports = criticalVars
-      .filter(k => process.env[k])
-      .map(k => `export ${k}=${shellEscape(process.env[k])}`)
+    // For tmux < 3.0: export the same safe env subset inline in the command.
+    const exports = Object.entries(sessionEnv)
+      .map(([k, v]) => `export ${k}=${shellEscape(v)}`)
       .join('; ');
     const fullCmd = exports ? `${exports}; ${innerCmd}` : innerCmd;
     newSessionArgs = ['new-session', '-d', '-s', sessionName, fullCmd];

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveLaunchCommand, buildTmuxInnerCmd } from '../src/launcher.js';
+import { resolveLaunchCommand, buildTmuxInnerCmd, buildTmuxSessionEnv } from '../src/launcher.js';
 
 describe('resolveLaunchCommand', () => {
   it('spawns claude directly when no wrapper is set', () => {
@@ -29,6 +29,38 @@ describe('resolveLaunchCommand', () => {
       resolveLaunchCommand('claude', [], { CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER: '  nice   ' }),
       { cmd: 'nice', cmdArgs: ['claude'] },
     );
+  });
+});
+
+describe('buildTmuxSessionEnv', () => {
+  it('keeps only the safe tmux launch env and drops unrelated secrets', () => {
+    const env = {
+      PATH: '/usr/bin',
+      HOME: '/Users/ocean',
+      SHELL: '/bin/zsh',
+      LANG: 'en_US.UTF-8',
+      CLAUDE_CONFIG_DIR: '/tmp/claude',
+      CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER: 'caffeinate -i',
+      ANTHROPIC_API_KEY: 'sk-ant-123',
+      OPENAI_API_KEY: 'sk-openai-456',
+      GITHUB_TOKEN: 'ghp_secret',
+      AWS_SECRET_ACCESS_KEY: 'super-secret',
+    };
+
+    assert.deepEqual(buildTmuxSessionEnv(env), {
+      PATH: '/usr/bin',
+      HOME: '/Users/ocean',
+      SHELL: '/bin/zsh',
+      LANG: 'en_US.UTF-8',
+      CLAUDE_CONFIG_DIR: '/tmp/claude',
+      CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER: 'caffeinate -i',
+      ANTHROPIC_API_KEY: 'sk-ant-123',
+      OPENAI_API_KEY: 'sk-openai-456',
+    });
+  });
+
+  it('omits empty values', () => {
+    assert.deepEqual(buildTmuxSessionEnv({ PATH: '/usr/bin', ANTHROPIC_API_KEY: '' }), { PATH: '/usr/bin' });
   });
 });
 


### PR DESCRIPTION
## Summary
- Stop exporting the full shell environment into tmux-launched Claude sessions
- Keep only the small set of variables the launcher actually needs
- Reduce accidental local secret exposure by excluding unrelated env vars from the tmux session

## Changes
- Introduced a safe tmux session environment whitelist
- Added coverage to ensure unrelated secrets such as `GITHUB_TOKEN` and `AWS_SECRET_ACCESS_KEY` are not forwarded

## Verification
- `npm test` → 380 passed, 0 failed
