### PR TITLE
fix(monitor): re-read the reset time while waiting, shortening a fallback wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server that can be days stale, so a rotated `ANTHROPIC_API_KEY` or fresh proxy var
   quietly never reached `claude` with zero diagnostic. The degrade stays; the silence
   goes — a stderr warning now names the cause.
+- **A fallback wait is now corrected once the real reset time appears on screen.** The
+  `/rate-limit-options` menu does not always render a reset line, so confirming "Stop and
+  wait" could commit the `fallbackWaitHours` default (5h) — and the waiting branch returned
+  early on every tick and never looked at the pane again, so the banner Claude Code prints
+  immediately after confirming, which *does* carry the time, was ignored for the whole
+  fallback. Observed live: a session whose limit reset at 18:20 sat parked until 22:27 with
+  `attempts: 0`, ~4 idle hours, while the banner naming 18:20 was on screen the entire time.
+  A wait derived from an unreadable screen is now latched as a fallback and re-derived from
+  the live banner each tick until a real reset time is found; waits that already came from a
+  real reset time are never re-parsed. Confirming the menu starts a fresh retry episode, so
+  the correction still applies when the menu re-renders after a retry has been sent.
 
 ## [0.7.0] - 2026-08-13
 

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -78,14 +78,53 @@ async function checkForeground(tmuxAdapter, pane, config) {
   return { ok: false, fg, isShell };
 }
 
-function enterUsageWait(state, stripped, config) {
+// Reset text on screen → the absolute instant to wake up at. One source of truth for the
+// three callers that need it: first detection, the /rate-limit-options menu path, and the
+// mid-wait correction below. `parsed` is surfaced so callers can tell a real reset time
+// from the fallbackWaitHours default that calculateWaitMs returns for an unreadable screen.
+function usageWaitUntil(stripped, config) {
   const message = findRateLimitMessage(stripped, config.customPatterns);
-  state.lastRateLimitMessage = message;
   const parsed = message ? parseResetTime(message) : null;
-  state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
+  const until = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
+  return { message, parsed, until };
+}
+
+function enterUsageWait(state, stripped, config) {
+  const { message, until } = usageWaitUntil(stripped, config);
+  state.lastRateLimitMessage = message;
+  state.waitUntil = until;
   state.status = 'waiting';
   state._gaveUp = false;
   return 'waiting';
+}
+
+// Re-derive the wake-up from the LIVE banner while already waiting, and pull it earlier
+// when the standing wait is too long.
+//
+// A wait computed from a screen that carried no parseable reset time lands on the
+// fallbackWaitHours default — potentially hours past the real reset. The
+// /rate-limit-options menu is the common source: it renders the options but not always the
+// reset line, while the banner Claude Code prints right after confirming DOES carry the
+// time. The waiting branch returned early on every tick and never looked at the pane again,
+// so that banner was ignored for the entire fallback (observed live: "resets 6:20pm"
+// detected via the menu at 17:26, monitor parked until 22:27 with attempts:0 while the
+// banner sat on screen the whole time — ~4h of a reset session doing nothing).
+//
+// Two bounds, both load-bearing:
+//   - SHORTEN ONLY. An unreadable screen re-derives the same multi-hour fallback, and a
+//     banner drifting through the tail must never be able to postpone the retry.
+//   - Only before the first send of this episode (attempts === 0). After a send, waitUntil
+//     is the 30s cooldown — and after max-retries it is the long give-up backoff. Both are
+//     deliberately unrelated to the reset time, and re-deriving against an already-passed
+//     reset collapses them to the margin, burning every attempt in a few ticks.
+function correctUsageWait(state, stripped, config) {
+  if (state.attempts > 0) return false;
+  if (!isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) return false;
+  const { message, parsed, until } = usageWaitUntil(stripped, config);
+  if (!parsed || until >= state.waitUntil) return false;
+  state.waitUntil = until;
+  state.lastRateLimitMessage = message;
+  return true;
 }
 
 function enterOverload(state, overload, rand) {
@@ -147,13 +186,11 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
       await new Promise(r => setTimeout(r, 80));
     }
     await tmuxAdapter.sendKey(pane, 'Enter');
-    // Parse the reset time straight from the menu text, so the wait does not depend
-    // on the limit banner still being visible afterward.
-    const message = findRateLimitMessage(stripped, config.customPatterns);
-    state.lastRateLimitMessage = message;
-    const parsed = message ? parseResetTime(message) : null;
-    state.waitUntil = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
-    state.status = 'waiting';
+    // Parse the reset time straight from the menu text, so the wait does not depend on the
+    // limit banner still being visible afterward. The menu does not always RENDER a reset
+    // line, though — that lands on the fallbackWaitHours default, which correctUsageWait
+    // then pulls back in once Claude Code prints the real banner post-confirm.
+    enterUsageWait(state, stripped, config);
     state._menuCooldownUntil = Date.now() + cooldown;
     return 'menu-confirmed';
   }
@@ -167,7 +204,12 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // transcript text (a flaky deploy log ABOVE a live banner), and treating that as
     // "continued" churned waiting↔user-continued forever without ever sending the retry.
     // Resumed = working signal rendered BELOW the last banner line.
-    if (Date.now() < state.waitUntil && !resumedAfterLimit(stripped, RATE_LIMIT_TAIL_LINES)) return 'waiting';
+    // Before honouring the countdown, re-read the banner: the standing wait may have been
+    // derived from a screen that never showed the reset time (see correctUsageWait).
+    const corrected = correctUsageWait(state, stripped, config);
+    if (Date.now() < state.waitUntil && !resumedAfterLimit(stripped, RATE_LIMIT_TAIL_LINES)) {
+      return corrected ? 'wait-corrected' : 'waiting';
+    }
     if (!isAlive()) return 'exit';
 
     // Stop driving the session if the limit cleared OR Claude has already resumed and
@@ -560,6 +602,11 @@ export async function startMonitor(pane, pid) {
       if (result === 'menu-confirmed') {
         const secs = Math.round((state.waitUntil - Date.now()) / 1000);
         await logger.info(`Rate-limit options menu: selected "Stop and wait for limit to reset". Waiting ${secs}s...`);
+        state.lastRateLimitMessage = null;
+      }
+      if (result === 'wait-corrected') {
+        const secs = Math.round((state.waitUntil - Date.now()) / 1000);
+        await logger.info(`Reset time re-read from the live banner: "${state.lastRateLimitMessage}". Wait shortened to ${secs}s.`);
         state.lastRateLimitMessage = null;
       }
       if (result === 'menu-unreadable') await logger.warn('Rate-limit options menu detected but its layout could not be read; not pressing Enter (would risk confirming "Upgrade your plan"). Will recheck.');

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -21,6 +21,10 @@ const OVERLOAD_INCIDENT_GAP_MS = 15 * 60_000;
 export function createMonitorState() {
   return {
     status: 'monitoring', waitUntil: 0, attempts: 0, lastRateLimitMessage: null,
+    // True while `waitUntil` came from a screen with NO parseable reset time (the
+    // fallbackWaitHours default) and is therefore still open to correction. See
+    // correctUsageWait.
+    _waitIsFallback: false,
     // Overload-retry sub-state, kept distinct from the usage-reset fields above.
     overloadAttempts: 0, overloadTotalWaitMs: 0, overloadWaitUntil: 0,
     // viaEvent marks the current backoff window as event-triggered (edge: one send per
@@ -82,49 +86,63 @@ async function checkForeground(tmuxAdapter, pane, config) {
 // three callers that need it: first detection, the /rate-limit-options menu path, and the
 // mid-wait correction below. `parsed` is surfaced so callers can tell a real reset time
 // from the fallbackWaitHours default that calculateWaitMs returns for an unreadable screen.
+// Reads the SAME chrome-aware window the isRateLimited gate reads — an unbounded scan lets
+// reset-shaped text anywhere in the capture outrank the live banner (see the tailLines note
+// on findRateLimitMessage).
 function usageWaitUntil(stripped, config) {
-  const message = findRateLimitMessage(stripped, config.customPatterns);
+  const message = findRateLimitMessage(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES);
   const parsed = message ? parseResetTime(message) : null;
   const until = Date.now() + calculateWaitMs(parsed, config.marginSeconds, config.fallbackWaitHours);
   return { message, parsed, until };
 }
 
-function enterUsageWait(state, stripped, config) {
-  const { message, until } = usageWaitUntil(stripped, config);
+// `fresh` starts a new retry episode: attempts and the give-up flag are cleared. Used by
+// the menu path, where a re-rendered /rate-limit-options menu means the session hit the
+// limit again rather than continuing the old episode.
+function enterUsageWait(state, stripped, config, { fresh = false } = {}) {
+  const { message, parsed, until } = usageWaitUntil(stripped, config);
   state.lastRateLimitMessage = message;
   state.waitUntil = until;
   state.status = 'waiting';
+  // Latch whether this wait is the fallback default rather than a real reset time. Only a
+  // fallback stays open to correction (correctUsageWait), so a wait derived from a genuine
+  // banner is never re-parsed — no window for stray reset-shaped text to move it, and none
+  // of the ~600 dead re-derivations a 5h wait would otherwise run.
+  state._waitIsFallback = !parsed;
   state._gaveUp = false;
+  if (fresh) state.attempts = 0;
   return 'waiting';
 }
 
 // Re-derive the wake-up from the LIVE banner while already waiting, and pull it earlier
-// when the standing wait is too long.
+// when the standing wait is too long. Returns the banner text on a correction, else null.
 //
 // A wait computed from a screen that carried no parseable reset time lands on the
 // fallbackWaitHours default — potentially hours past the real reset. The
 // /rate-limit-options menu is the common source: it renders the options but not always the
 // reset line, while the banner Claude Code prints right after confirming DOES carry the
 // time. The waiting branch returned early on every tick and never looked at the pane again,
-// so that banner was ignored for the entire fallback (observed live: "resets 6:20pm"
-// detected via the menu at 17:26, monitor parked until 22:27 with attempts:0 while the
-// banner sat on screen the whole time — ~4h of a reset session doing nothing).
+// so that banner was ignored for the entire fallback. See the CHANGELOG entry for the
+// observed incident.
 //
-// Two bounds, both load-bearing:
-//   - SHORTEN ONLY. An unreadable screen re-derives the same multi-hour fallback, and a
-//     banner drifting through the tail must never be able to postpone the retry.
-//   - Only before the first send of this episode (attempts === 0). After a send, waitUntil
-//     is the 30s cooldown — and after max-retries it is the long give-up backoff. Both are
-//     deliberately unrelated to the reset time, and re-deriving against an already-passed
-//     reset collapses them to the margin, burning every attempt in a few ticks.
+// Bounds, in order of how much they carry:
+//   - ONLY A FALLBACK WAIT is correctable (_waitIsFallback). Gating on the raw `attempts`
+//     counter instead both under- and over-shot: it blocked the menu-after-send flow (a
+//     menu re-rendered once attempts > 0 committed a fallback that could never be
+//     corrected — the very bug being fixed, surviving on that path) and left every
+//     correctly-derived wait exposed to re-parsing for its whole duration.
+//   - SHORTEN ONLY, by a margin (EPSILON). Never let the pane push a wake-up out.
+//   - Success clears the latch: the wait now comes from a real reset time, so it stops
+//     being a candidate and the correction logs exactly once.
+const WAIT_CORRECTION_EPSILON_MS = 1000;
 function correctUsageWait(state, stripped, config) {
-  if (state.attempts > 0) return false;
-  if (!isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) return false;
+  if (!state._waitIsFallback) return null;
+  if (!isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) return null;
   const { message, parsed, until } = usageWaitUntil(stripped, config);
-  if (!parsed || until >= state.waitUntil) return false;
+  if (!parsed || until > state.waitUntil - WAIT_CORRECTION_EPSILON_MS) return null;
   state.waitUntil = until;
-  state.lastRateLimitMessage = message;
-  return true;
+  state._waitIsFallback = false;
+  return message;
 }
 
 function enterOverload(state, overload, rand) {
@@ -190,7 +208,12 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // limit banner still being visible afterward. The menu does not always RENDER a reset
     // line, though — that lands on the fallbackWaitHours default, which correctUsageWait
     // then pulls back in once Claude Code prints the real banner post-confirm.
-    enterUsageWait(state, stripped, config);
+    //
+    // fresh: a menu we just confirmed means the session hit the limit again, so this is a
+    // new retry episode — carrying the old attempt count over left the correction blocked
+    // and, once maxRetries had been reached, published a healthy-looking countdown that
+    // gave up again on expiry without ever sending.
+    enterUsageWait(state, stripped, config, { fresh: true });
     state._menuCooldownUntil = Date.now() + cooldown;
     return 'menu-confirmed';
   }
@@ -206,9 +229,14 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // Resumed = working signal rendered BELOW the last banner line.
     // Before honouring the countdown, re-read the banner: the standing wait may have been
     // derived from a screen that never showed the reset time (see correctUsageWait).
-    const corrected = correctUsageWait(state, stripped, config);
+    // lastRateLimitMessage is set ONLY on the branch that logs it — a correction that falls
+    // through to 'retried'/'user-continued' would otherwise leave the message set for the
+    // next plain 'waiting' tick to log as a spurious fresh detection.
+    const correctedMessage = correctUsageWait(state, stripped, config);
     if (Date.now() < state.waitUntil && !resumedAfterLimit(stripped, RATE_LIMIT_TAIL_LINES)) {
-      return corrected ? 'wait-corrected' : 'waiting';
+      if (!correctedMessage) return 'waiting';
+      state.lastRateLimitMessage = correctedMessage;
+      return 'wait-corrected';
     }
     if (!isAlive()) return 'exit';
 
@@ -220,6 +248,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // whole time). Resumed ⇒ the session continued; never inject into it.
     if (!isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES) || resumedAfterLimit(stripped, RATE_LIMIT_TAIL_LINES)) {
       state.status = 'monitoring'; state.attempts = 0; state._gaveUp = false;
+      state._waitIsFallback = false;
       return 'user-continued';
     }
 
@@ -231,6 +260,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
       // perpetually-resetting countdown for a monitor that has stopped acting.
       state.waitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
       state._gaveUp = true;
+      state._waitIsFallback = false;   // give-up backoff, deliberately unrelated to the reset time
       return 'max-retries';
     }
 
@@ -254,6 +284,7 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     // (e.g. pane destroyed) still consumes a retry and avoids tight-loop errors.
     state.attempts++;
     state.waitUntil = Date.now() + 30_000;
+    state._waitIsFallback = false;   // send cooldown, deliberately unrelated to the reset time
     await tmuxAdapter.sendKeys(pane, config.retryMessage);
     return 'retried';
   }
@@ -594,20 +625,23 @@ export async function startMonitor(pane, pid) {
         pollIntervalSeconds: config.pollIntervalSeconds,
         gaveUp: !!state._gaveUp,
       }).catch(() => {});
-      if (result === 'waiting' && state.lastRateLimitMessage) {
+      // The three results that announce a new wake-up time share one shape: seconds until
+      // waitUntil, then consume the one-shot lastRateLimitMessage. Set-with-clear is an
+      // invariant — a message left behind logs as a spurious detection on a later tick.
+      const logWait = (line) => {
         const secs = Math.round((state.waitUntil - Date.now()) / 1000);
-        await logger.info(`Rate limit detected: "${state.lastRateLimitMessage}". Waiting ${secs}s...`);
+        const msg = state.lastRateLimitMessage;
         state.lastRateLimitMessage = null;
+        return logger.info(line(secs, msg));
+      };
+      if (result === 'waiting' && state.lastRateLimitMessage) {
+        await logWait((secs, msg) => `Rate limit detected: "${msg}". Waiting ${secs}s...`);
       }
       if (result === 'menu-confirmed') {
-        const secs = Math.round((state.waitUntil - Date.now()) / 1000);
-        await logger.info(`Rate-limit options menu: selected "Stop and wait for limit to reset". Waiting ${secs}s...`);
-        state.lastRateLimitMessage = null;
+        await logWait((secs) => `Rate-limit options menu: selected "Stop and wait for limit to reset". Waiting ${secs}s...`);
       }
       if (result === 'wait-corrected') {
-        const secs = Math.round((state.waitUntil - Date.now()) / 1000);
-        await logger.info(`Reset time re-read from the live banner: "${state.lastRateLimitMessage}". Wait shortened to ${secs}s.`);
-        state.lastRateLimitMessage = null;
+        await logWait((secs, msg) => `Reset time re-read from the live banner: "${msg}". Wait shortened to ${secs}s.`);
       }
       if (result === 'menu-unreadable') await logger.warn('Rate-limit options menu detected but its layout could not be read; not pressing Enter (would risk confirming "Upgrade your plan"). Will recheck.');
       if (result === 'retried') await logger.info(`Sent retry message (attempt ${state.attempts})`);

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -474,15 +474,30 @@ export function isInternalRetry(text) {
     .some((l) => INTERNAL_RETRY_PATTERNS.some((p) => p.test(l)));
 }
 
-export function findRateLimitMessage(text, customPatterns = []) {
-  const lines = stripAnsi(text).split('\n');
+// tailLines > 0 bounds the scan to the same chrome-aware window isRateLimited uses. The
+// unbounded scan reaches the FULL capture, so any non-chrome, non-echo line anywhere in
+// ~120 lines that merely *looks* like a reset ("…try again in 2 minutes…" in model prose,
+// user-typed text, a wrapped tool result past the mask's continuation gap) wins the
+// bottom-up scan over the real banner. That was survivable while this ran once at
+// detection; the monitor now re-derives during the wait, where shorten-only means the
+// earliest bogus time wins and a *correct* multi-hour wait can collapse to minutes — the
+// monitor then wakes into the still-live limit and burns its retries before the real
+// reset. Callers that gate on isRateLimited must pass the same window it read. 0 keeps the
+// full scan for print mode, where the input is process output rather than a scrolling TUI.
+export function findRateLimitMessage(text, customPatterns = [], tailLines = 0) {
+  const all = stripAnsi(text).split('\n');
   // Tool-echo mask (#63): without it, a quoted "resets 9am" in a fresh grep line below a
   // real banner would win the bottom-up scan and be parsed instead of the banner.
   // Chrome is skipped for the same reason (#61): a usage-meter statusline row
   // ("⟳ resets in 1 hr 47 min") always renders below the banner, so it won the scan —
   // and parseResetTime can't read it, turning a known reset time into the 5h fallback.
-  const mask = toolEchoMask(lines);
-  const skip = (i) => mask[i] || isChromeLine(lines[i]);
+  // The mask is computed over the FULL pane and sliced, so a block whose `● Name(` header
+  // sits above the window keeps its children masked (same discipline as isRateLimited).
+  const { start, end } = tailLines > 0 ? contentTailRange(all, tailLines)
+    : { start: 0, end: all.length };
+  const lines = all.slice(start, end);
+  const fullMask = toolEchoMask(all).slice(start, end);
+  const skip = (i) => fullMask[i] || isChromeLine(lines[i]);
 
   // Scan from the bottom up — the most recent "resets" line is the one to
   // parse. The Claude TUI never clears earlier rate-limit messages from

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createMonitorState, processOneTick } from '../src/monitor.js';
 import { DEFAULT_CONFIG } from '../src/config.js';
+import { calculateWaitMs } from '../src/time-parser.js';
 
 function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
   const t = {
@@ -118,38 +119,118 @@ describe('processOneTick', () => {
     assert.ok(s.waitUntil > Date.now());
   });
 
-  // --- Regression (#71): a wait computed from a screen with no parseable reset time
-  //     (the /rate-limit-options menu) lands on the fallbackWaitHours default and used to
-  //     stand forever, because the waiting branch returned early and never looked at the
-  //     pane again. Observed live: reset 6:20pm, monitor parked until 10:27pm with
-  //     attempts:0 while the banner carrying the real time sat on screen the whole time. ---
-  const FALLBACK_MS = (DEFAULT_CONFIG.fallbackWaitHours * 3600 + DEFAULT_CONFIG.marginSeconds) * 1000;
-  // A limit banner whose reset time is `msFromNow` away on the HOST clock (no timezone
-  // parenthetical, so parseResetTime defaults to the host zone the same way a real
-  // banner in the local zone does).
-  function bannerAt(msFromNow) {
-    const d = new Date(Date.now() + msFromNow);
-    const h = d.getHours(), m = d.getMinutes();
-    const h12 = h % 12 === 0 ? 12 : h % 12;
-    return `You've hit your session limit · resets ${h12}:${String(m).padStart(2, '0')}${h >= 12 ? 'pm' : 'am'}`;
-  }
+  // --- Regression (#71): a wait computed from a screen with no parseable reset time (the
+  //     /rate-limit-options menu) lands on the fallbackWaitHours default and used to stand
+  //     for its full duration, because the waiting branch returned early and never looked
+  //     at the pane again. See the CHANGELOG entry for the observed incident. ---
 
-  it('shortens a fallback wait once the banner with the real reset time is on screen', async () => {
-    // The live incident: menu path committed the 5h fallback, real reset was ~30min ago.
+  // Deterministic clock. Banners are rendered in the fixed-offset zone where the current
+  // instant reads as ~midday and carry that zone explicitly, so a relative offset can never
+  // cross a date boundary (a host at 00:15 rendered YESTERDAY's "11:45pm", which parses
+  // ~23.5h into the future and made these tests red for that half-hour) and no DST
+  // transition can move the answer. Etc/GMT zones have no DST; note the POSIX sign
+  // inversion — Etc/GMT+6 is UTC-6.
+  function middayZone(now = new Date()) {
+    const shift = 12 - now.getUTCHours();       // hours to add to UTC to land near 12:00
+    if (shift === 0) return 'UTC';
+    return shift > 0 ? `Etc/GMT-${shift}` : `Etc/GMT+${-shift}`;
+  }
+  function bannerAt(msFromNow, zone = middayZone()) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: zone, hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
+    }).formatToParts(new Date(Date.now() + msFromNow));
+    const h = Number(parts.find(p => p.type === 'hour').value);
+    const m = parts.find(p => p.type === 'minute').value;
+    const h12 = h % 12 === 0 ? 12 : h % 12;
+    return `You've hit your session limit · resets ${h12}:${m}${h >= 12 ? 'pm' : 'am'} (${zone})`;
+  }
+  // The real fallback, from the real code path — not a hand-copy of the formula.
+  const FALLBACK_MS = calculateWaitMs(null, DEFAULT_CONFIG.marginSeconds, DEFAULT_CONFIG.fallbackWaitHours);
+  const MENU_NO_RESET = [
+    'What do you want to do?',
+    '❯ 1. Upgrade your plan',
+    '  2. Stop and wait for limit to reset',
+    'Enter to confirm · Esc to cancel',
+  ].join('\n');
+  const marginish = () => Date.now() + (DEFAULT_CONFIG.marginSeconds + 5) * 1000;
+
+  it('menu with no reset line commits the fallback and latches it as correctable', async () => {
+    const t = mockTmux(MENU_NO_RESET);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'menu-confirmed');
+    assert.equal(s._waitIsFallback, true);
+    assert.ok(Math.abs((s.waitUntil - Date.now()) - FALLBACK_MS) < 5000,
+      `expected the fallback, got ${Math.round((s.waitUntil - Date.now()) / 1000)}s`);
+  });
+
+  it('shortens the menu fallback once the post-confirm banner appears', async () => {
+    const t = mockTmux(MENU_NO_RESET);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'menu-confirmed');
+    // Claude Code prints the banner carrying the real time; reset was ~30 min ago.
+    t.capturePane = async () => bannerAt(-30 * 60_000);
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'wait-corrected');
+    assert.equal(t._sent.length, 0);              // corrects the clock, does not send yet
+    assert.ok(s.waitUntil <= marginish(),
+      `expected a margin-sized wait, got ${Math.round((s.waitUntil - Date.now()) / 1000)}s`);
+    assert.equal(s._waitIsFallback, false);       // no longer a fallback → no re-parsing
+  });
+
+  it('corrects the menu fallback even after a retry has already been sent', async () => {
+    // The menu re-rendering means the session hit the limit again: a fresh episode. Keying
+    // the correction on the raw attempt counter blocked exactly this flow, so the
+    // post-confirm banner one minute away was ignored for the whole 5h fallback.
+    const t = mockTmux(MENU_NO_RESET);
+    const s = createMonitorState();
+    s.status = 'waiting'; s.attempts = 1; s.waitUntil = Date.now() - 1000;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'menu-confirmed');
+    assert.equal(s.attempts, 0);                  // fresh episode
+    assert.equal(s._gaveUp, false);
+    t.capturePane = async () => bannerAt(-30 * 60_000);
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'wait-corrected');
+    assert.ok(s.waitUntil <= marginish());
+  });
+
+  it('a maxed-out episode still gives up rather than looping on the same banner', async () => {
     const t = mockTmux(bannerAt(-30 * 60_000));
     const s = createMonitorState();
-    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS;
-    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'wait-corrected');
-    assert.equal(t._sent.length, 0);            // corrects the clock, does not send yet
-    // Reset already passed (inside the grace window) → wait collapses to just the margin.
-    assert.ok(s.waitUntil <= Date.now() + (DEFAULT_CONFIG.marginSeconds + 5) * 1000,
-      `expected a margin-sized wait, got ${Math.round((s.waitUntil - Date.now()) / 1000)}s`);
+    s.status = 'waiting'; s.attempts = DEFAULT_CONFIG.maxRetries; s.waitUntil = Date.now() - 1;
+    s._waitIsFallback = true;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'max-retries');
+    assert.equal(t._sent.length, 0);
+    assert.equal(s._gaveUp, true);
+    // The give-up backoff is not reset-derived; the correction must not shorten it.
+    const hold = s.waitUntil;
+    assert.equal(s._waitIsFallback, false);
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.equal(s.waitUntil, hold);
+  });
+
+  it('never re-parses a wait that came from a real reset time', async () => {
+    // Regression for the window/latch pair: reset-shaped prose ("try again in 2 minutes")
+    // drifting into the pane during a correctly-derived multi-hour wait must not collapse
+    // it — the monitor would wake into the still-live limit and burn its retries early.
+    const t = mockTmux(bannerAt(5 * 3600_000));
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.equal(s._waitIsFallback, false);
+    const derived = s.waitUntil;
+    assert.ok((derived - Date.now()) / 1000 > 4 * 3600,
+      `expected ~5h, got ${Math.round((derived - Date.now()) / 1000)}s`);
+    t.capturePane = async () => [
+      bannerAt(5 * 3600_000),
+      '',
+      '⏺ The API said to try again in 2 minutes before the limit window rolls',
+    ].join('\n');
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.equal(s.waitUntil, derived);           // untouched
+    assert.equal(t._sent.length, 0);
   });
 
   it('shortens to a still-future reset without sending', async () => {
     const t = mockTmux(bannerAt(2 * 3600_000));
     const s = createMonitorState();
-    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS;
+    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS; s._waitIsFallback = true;
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'wait-corrected');
     assert.equal(t._sent.length, 0);
     const secs = (s.waitUntil - Date.now()) / 1000;
@@ -157,35 +238,48 @@ describe('processOneTick', () => {
   });
 
   it('never LENGTHENS the wait from the banner', async () => {
-    // A banner reading later than the current wait (or drifting stale scrollback) must not
-    // push the wake-up out — that would postpone the retry indefinitely.
     const t = mockTmux(bannerAt(2 * 3600_000));
     const s = createMonitorState();
-    s.status = 'waiting'; s.waitUntil = Date.now() + 30 * 60_000;
+    s.status = 'waiting'; s.waitUntil = Date.now() + 30 * 60_000; s._waitIsFallback = true;
     const before = s.waitUntil;
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
     assert.equal(s.waitUntil, before);
   });
 
-  it('does not correct once a retry has been sent (cooldown owns the pacing)', async () => {
-    // After a send, waitUntil is the 30s cooldown; re-deriving it from a banner that is
-    // already past would collapse it to ~0 and burn every attempt in a few ticks.
+  it('does not correct the post-send cooldown', async () => {
+    // After a send, waitUntil is the 30s cooldown; re-deriving it from an already-passed
+    // reset would collapse it to the margin and burn every attempt in a few ticks.
     const t = mockTmux(bannerAt(-30 * 60_000));
     const s = createMonitorState();
-    s.status = 'waiting'; s.attempts = 1; s.waitUntil = Date.now() + FALLBACK_MS;
-    const before = s.waitUntil;
+    s.status = 'waiting'; s.waitUntil = Date.now() - 1; s._waitIsFallback = true;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'retried');
+    assert.equal(s.attempts, 1);
+    assert.equal(s._waitIsFallback, false);
+    const cooldown = s.waitUntil;
     assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
-    assert.equal(s.waitUntil, before);
-    assert.equal(t._sent.length, 0);
+    assert.equal(s.waitUntil, cooldown);
+    assert.equal(t._sent.length, 1);
   });
 
   it('sends immediately when the corrected wait has already elapsed', async () => {
     const cfg = { ...DEFAULT_CONFIG, marginSeconds: 0 };
     const t = mockTmux(bannerAt(-30 * 60_000));
     const s = createMonitorState();
-    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS;
+    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS; s._waitIsFallback = true;
     assert.equal(await processOneTick(s, t, '%0', cfg, () => true), 'retried');
     assert.equal(t._sent.length, 1);
+  });
+
+  it('a corrected wait that falls through does not log as a fresh detection', async () => {
+    // correctUsageWait used to stash the banner on state regardless of which branch won;
+    // a tick that fell through to 'retried' left it there for the next 'waiting' tick to
+    // report as a brand-new rate limit. Set-with-clear is the invariant.
+    const cfg = { ...DEFAULT_CONFIG, marginSeconds: 0 };
+    const t = mockTmux(bannerAt(-30 * 60_000));
+    const s = createMonitorState();
+    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS; s._waitIsFallback = true;
+    assert.equal(await processOneTick(s, t, '%0', cfg, () => true), 'retried');
+    assert.equal(s.lastRateLimitMessage, null);
   });
 
   // --- Regression: do not spam an already-resumed session. The usage path used to

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -118,6 +118,76 @@ describe('processOneTick', () => {
     assert.ok(s.waitUntil > Date.now());
   });
 
+  // --- Regression (#71): a wait computed from a screen with no parseable reset time
+  //     (the /rate-limit-options menu) lands on the fallbackWaitHours default and used to
+  //     stand forever, because the waiting branch returned early and never looked at the
+  //     pane again. Observed live: reset 6:20pm, monitor parked until 10:27pm with
+  //     attempts:0 while the banner carrying the real time sat on screen the whole time. ---
+  const FALLBACK_MS = (DEFAULT_CONFIG.fallbackWaitHours * 3600 + DEFAULT_CONFIG.marginSeconds) * 1000;
+  // A limit banner whose reset time is `msFromNow` away on the HOST clock (no timezone
+  // parenthetical, so parseResetTime defaults to the host zone the same way a real
+  // banner in the local zone does).
+  function bannerAt(msFromNow) {
+    const d = new Date(Date.now() + msFromNow);
+    const h = d.getHours(), m = d.getMinutes();
+    const h12 = h % 12 === 0 ? 12 : h % 12;
+    return `You've hit your session limit · resets ${h12}:${String(m).padStart(2, '0')}${h >= 12 ? 'pm' : 'am'}`;
+  }
+
+  it('shortens a fallback wait once the banner with the real reset time is on screen', async () => {
+    // The live incident: menu path committed the 5h fallback, real reset was ~30min ago.
+    const t = mockTmux(bannerAt(-30 * 60_000));
+    const s = createMonitorState();
+    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'wait-corrected');
+    assert.equal(t._sent.length, 0);            // corrects the clock, does not send yet
+    // Reset already passed (inside the grace window) → wait collapses to just the margin.
+    assert.ok(s.waitUntil <= Date.now() + (DEFAULT_CONFIG.marginSeconds + 5) * 1000,
+      `expected a margin-sized wait, got ${Math.round((s.waitUntil - Date.now()) / 1000)}s`);
+  });
+
+  it('shortens to a still-future reset without sending', async () => {
+    const t = mockTmux(bannerAt(2 * 3600_000));
+    const s = createMonitorState();
+    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'wait-corrected');
+    assert.equal(t._sent.length, 0);
+    const secs = (s.waitUntil - Date.now()) / 1000;
+    assert.ok(secs > 3600 && secs < 3 * 3600, `expected ~2h, got ${Math.round(secs)}s`);
+  });
+
+  it('never LENGTHENS the wait from the banner', async () => {
+    // A banner reading later than the current wait (or drifting stale scrollback) must not
+    // push the wake-up out — that would postpone the retry indefinitely.
+    const t = mockTmux(bannerAt(2 * 3600_000));
+    const s = createMonitorState();
+    s.status = 'waiting'; s.waitUntil = Date.now() + 30 * 60_000;
+    const before = s.waitUntil;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.equal(s.waitUntil, before);
+  });
+
+  it('does not correct once a retry has been sent (cooldown owns the pacing)', async () => {
+    // After a send, waitUntil is the 30s cooldown; re-deriving it from a banner that is
+    // already past would collapse it to ~0 and burn every attempt in a few ticks.
+    const t = mockTmux(bannerAt(-30 * 60_000));
+    const s = createMonitorState();
+    s.status = 'waiting'; s.attempts = 1; s.waitUntil = Date.now() + FALLBACK_MS;
+    const before = s.waitUntil;
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.equal(s.waitUntil, before);
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('sends immediately when the corrected wait has already elapsed', async () => {
+    const cfg = { ...DEFAULT_CONFIG, marginSeconds: 0 };
+    const t = mockTmux(bannerAt(-30 * 60_000));
+    const s = createMonitorState();
+    s.status = 'waiting'; s.waitUntil = Date.now() + FALLBACK_MS;
+    assert.equal(await processOneTick(s, t, '%0', cfg, () => true), 'retried');
+    assert.equal(t._sent.length, 1);
+  });
+
   // --- Regression: do not spam an already-resumed session. The usage path used to
   //     re-send every poll (up to maxRetries) while the limit banner lingered in
   //     scrollback after a successful resume — observed live as 5 injections into a

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -320,6 +320,28 @@ describe('stripAnsi (private-mode sequences)', () => {
 });
 
 describe('findRateLimitMessage', () => {
+  // tailLines bounds the scan to the same chrome-aware window isRateLimited reads, so a
+  // caller that gates on liveness can't then parse a line the gate never saw. The monitor
+  // re-derives the wait during a fallback, where an unbounded scan could reach a stale
+  // banner high in scrollback and (shorten-only) let the earliest stale time win.
+  it('bounds the scan to the content tail when tailLines is set', () => {
+    const text = ["You've hit your limit · resets 3pm (UTC)",
+      ...Array(14).fill('ordinary content line')].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), null);        // banner sits above the window
+    assert.ok(findRateLimitMessage(text, []).includes('3pm'));     // unbounded still reaches it
+  });
+  it('still finds a banner inside the tail window', () => {
+    const text = ['ordinary content line',
+      "You've hit your limit · resets 3pm (UTC)"].join('\n');
+    assert.ok(findRateLimitMessage(text, [], 12).includes('3pm'));
+  });
+  it('tail window skips trailing chrome rather than spending budget on it', () => {
+    // The banner is 13 raw lines up but only 1 line of real content up — the chrome-aware
+    // window must still reach it, exactly as isRateLimited does.
+    const text = ["You've hit your limit · resets 3pm (UTC)",
+      ...Array(12).fill('  ◻ a task widget row'), '❯ '].join('\n');
+    assert.ok(findRateLimitMessage(text, [], 12).includes('3pm'));
+  });
   it('returns the matching line from multiline input', () => {
     const text = 'Some output\n5-hour limit reached - resets 3pm (Europe/Dublin)\nMore output';
     assert.equal(findRateLimitMessage(text), '5-hour limit reached - resets 3pm (Europe/Dublin)');


### PR DESCRIPTION
## The bug

Observed live: a pane hit its session limit and the monitor sat in `waiting` with `attempts: 0` for ~4 hours *after* the limit had already reset.

```
status file : {"status":"waiting","waitUntil":1786224431,"attempts":0}
              waitUntil = 22:27:11 BST
banner      : "You've hit your session limit · resets 6:20pm (Europe/London)"
```

Not a detection failure — detection was fine the whole time. Running the shipped detectors against that exact pane capture:

```
isRateLimited(tail=12): true
findRateLimitMessage  : "⎿  You've hit your session limit · resets 6:20pm (Europe/London)"
parseResetTime        : {"hour":18,"minute":20,"timezone":"Europe/London","ambiguous":false}
calculateWaitMs       : 60000 ms
```

The chain:

1. The `/rate-limit-options` menu appeared at 17:26. The monitor handled it correctly — navigated to "Stop and wait for limit to reset", pressed Enter, logged `menu-confirmed`.
2. It then parsed the reset time **from that menu screen**. The menu does not always render a reset line, so `parseResetTime` returned `null` and `calculateWaitMs` took the fallback branch: `5h * 3600 + 60` = **18060s** exactly — which is what the log line said.
3. The `waiting` branch returns early on every tick while `Date.now() < waitUntil`, and never re-reads the pane. So the banner Claude Code prints *right after* confirming — which does carry the time — was ignored for the entire fallback.

A second pane took the same path 21 seconds earlier and got the same 18060s; it only recovered because the user continued it by hand.

## The fix

The `waiting` branch now re-derives the wake-up from the live banner each tick and pulls it earlier when the standing wait is too long.

Two bounds, both load-bearing:

- **Shorten only.** An unreadable screen re-derives the same multi-hour fallback, and a banner drifting through the tail must never be able to postpone the retry.
- **Only before the first send of an episode** (`attempts === 0`). After a send, `waitUntil` is the 30s cooldown; after max-retries it is the long give-up backoff. Both are deliberately unrelated to the reset time, and re-deriving against an already-passed reset collapses them to the margin — burning every attempt in a few ticks.

Also extracts `usageWaitUntil()` so first detection, the menu path and the correction share one derivation rather than a third copy.

## Verification

Replaying the real stuck state (the actual `waitUntil` value, against the actual pane capture) through the fixed monitor:

```
before : waitUntil = 08/08/2026, 22:27:11
tick 1 : wait-corrected   waitUntil = 18:45:02 (60s away)   sent: []
tick 2 : waiting                                            sent: []
tick 3 : retried          attempts = 1                      sent: ["Continue where you left off…"]
```

Corrects once, does not re-fire, does not double-send.

Five new tests in `test/monitor.test.js`: shortening to an already-passed reset, shortening to a still-future reset, never lengthening, no correction after a send, and falling straight through to the retry when the corrected wait has already elapsed.

Full suite on this branch: **421 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)