### PR TITLE
fix(patterns): prefer a live banner over reset-shaped prose below it (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   …` matches ordinary English — so a model sentence ("The API said to try again in 2
   minutes …") or the user's own question, rendered *below* the banner it discusses, stole
   the parse and turned a 5-hour wait into ~3 minutes. The monitor then woke into the
-  still-live limit and burned `maxRetries` before the real reset. The discriminator is
-  position within the line, not vocabulary: Claude Code *renders* a banner's limit and
-  reset clauses as the leading content of a line (behind at most the `⎿`/`└`/`⚠`/`·` echo
-  glyphs), while prose carries the same words mid-sentence — the discipline the
-  spend-limit banner already uses, generalised. Lines that merely mention a limit are now
-  skipped over, so the banner above them wins. Eligibility is decided per line and never
-  by inspecting a neighbour, which keeps the bottom-up scan — and therefore freshness —
-  exactly as it was: a stale banner still loses to any newer one below it. Anything the
-  scan does not recognise as a render falls through to the previous behaviour rather than
-  to no match at all.
+  still-live limit and burned `maxRetries` before the real reset. The discriminator is the
+  shape of the line, not its vocabulary, and it is stated as a *veto*: a reset-shaped line
+  stays eligible unless it carries a message/prompt glyph (`⏺`/`●`/`❯`) or a sentence
+  running on past the reset clause ("…try again in 2 minutes, so I'll wait"), which is what
+  catches prose whose wrapped continuation happens to begin with the clause. Lines that
+  merely mention a limit are vetoed, so the banner above them wins. Eligibility is decided
+  per line and never by inspecting a neighbour, which keeps the bottom-up scan — and
+  therefore freshness — as it was: a stale banner still loses to any newer render below it,
+  including renders this file does not recognise. Anything vetoed falls through to the
+  previous behaviour rather than to no match at all.
 - **The org/monthly spend-limit banner is now detected (#71).** Team/org accounts (and
   individual accounts whose extra-usage budget is exhausted) get "You've hit your org's
   monthly spend limit · run /usage-credits …" — undetected for two independent reasons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the parse and turned a 5-hour wait into ~3 minutes. The monitor then woke into the
   still-live limit and burned `maxRetries` before the real reset. The discriminator is the
   shape of the line, not its vocabulary, and it is stated as a *veto*: a reset-shaped line
-  stays eligible unless it is the user's input row (`❯`/`>`), ends in sentence punctuation,
-  runs on past the reset clause ("…resets 9am tomorrow according to the header"), or sits on
-  a message bullet introducing something other than a limit or reset clause. The last two
-  are what catch prose whose *wrapped* continuation happens to begin with the clause. Lines
-  that merely mention a limit are vetoed, so the banner above them wins. Eligibility is decided
-  per line and never by inspecting a neighbour, which keeps the bottom-up scan — and
-  therefore freshness — as it was: a stale banner still loses to any newer render below it,
-  including renders this file does not recognise. Anything vetoed falls through to the
-  previous behaviour rather than to no match at all.
+  stays eligible unless something marks it as conversation — the user's input row (`❯`/`>`),
+  sentence punctuation, a run-on past the reset clause ("…resets 9am tomorrow according to
+  the header"), or a message bullet introducing something other than a limit or reset
+  clause. The last two are what catch prose whose *wrapped* continuation happens to begin
+  with the clause. Eligibility is decided per line and never by inspecting a neighbour, so
+  the bottom-up scan — and therefore freshness — is unchanged, and anything vetoed falls
+  through to the previous behaviour rather than to no match at all.
+
+  Every signal except the prompt glyph is subordinate to whether the line **names a limit**:
+  a line that does is treated as a render however it is punctuated, glyphed or trailed. That
+  ordering is the correction to this change's own first three revisions, each of which
+  claimed the veto "only demotes what it can positively identify" and then demoted real
+  renders three ways — period-terminated banners ("Rate limit exceeded. Please try again in
+  5 hours."), banners with an inline hint ("· resets 5:20pm · /upgrade to increase your
+  limits"), and the API-error render whose vocabulary is underscored (`rate_limit_error`).
+  The two errors do not cost the same: returning prose parses a *short* wait, which is a
+  fallback and so gets revisited (#70), while returning a stale banner parses a *long* one
+  that latches non-correctable. Doubt therefore resolves toward the fresher line.
+
+  **Known boundary:** prose that names a limit *itself* — "⏺ You've hit your usage limit, so
+  try again in 2 minutes." — is per-line indistinguishable from a render and still outranks
+  the banner. This is unchanged from previous behaviour rather than introduced here, and it
+  is the recoverable direction of the two. Also unchanged: an unglyphed, unpunctuated
+  continuation that begins with the clause and ends within two words (`│  try again in 20
+  minutes  │`), which cannot be separated from a wrapped banner line (`  resets 8:40pm
+  (Europe/London)`) without dropping the only line carrying the time.
 - **The org/monthly spend-limit banner is now detected (#71).** Team/org accounts (and
   individual accounts whose extra-usage budget is exhausted) get "You've hit your org's
   monthly spend limit · run /usage-credits …" — undetected for two independent reasons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A live banner is no longer outranked by reset-shaped prose below it (#73).** The
+  reset-message scan returned the lowest reset-shaped line in the pane, and `try again in
+  …` matches ordinary English — so a model sentence ("The API said to try again in 2
+  minutes …") or the user's own question, rendered *below* the banner it discusses, stole
+  the parse and turned a 5-hour wait into ~3 minutes. The monitor then woke into the
+  still-live limit and burned `maxRetries` before the real reset. The discriminator is
+  position within the line, not vocabulary: Claude Code *renders* a banner's limit and
+  reset clauses as the leading content of a line (behind at most the `⎿`/`└`/`⚠`/`·` echo
+  glyphs), while prose carries the same words mid-sentence — the discipline the
+  spend-limit banner already uses, generalised. Lines that merely mention a limit are now
+  skipped over, so the banner above them wins. Eligibility is decided per line and never
+  by inspecting a neighbour, which keeps the bottom-up scan — and therefore freshness —
+  exactly as it was: a stale banner still loses to any newer one below it. Anything the
+  scan does not recognise as a render falls through to the previous behaviour rather than
+  to no match at all.
 - **The org/monthly spend-limit banner is now detected (#71).** Team/org accounts (and
   individual accounts whose extra-usage budget is exhausted) get "You've hit your org's
   monthly spend limit · run /usage-credits …" — undetected for two independent reasons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the parse and turned a 5-hour wait into ~3 minutes. The monitor then woke into the
   still-live limit and burned `maxRetries` before the real reset. The discriminator is the
   shape of the line, not its vocabulary, and it is stated as a *veto*: a reset-shaped line
-  stays eligible unless it carries a message/prompt glyph (`⏺`/`●`/`❯`) or a sentence
-  running on past the reset clause ("…try again in 2 minutes, so I'll wait"), which is what
-  catches prose whose wrapped continuation happens to begin with the clause. Lines that
-  merely mention a limit are vetoed, so the banner above them wins. Eligibility is decided
+  stays eligible unless it is the user's input row (`❯`/`>`), ends in sentence punctuation,
+  runs on past the reset clause ("…resets 9am tomorrow according to the header"), or sits on
+  a message bullet introducing something other than a limit or reset clause. The last two
+  are what catch prose whose *wrapped* continuation happens to begin with the clause. Lines
+  that merely mention a limit are vetoed, so the banner above them wins. Eligibility is decided
   per line and never by inspecting a neighbour, which keeps the bottom-up scan — and
   therefore freshness — as it was: a stale banner still loses to any newer render below it,
   including renders this file does not recognise. Anything vetoed falls through to the

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -153,25 +153,54 @@ const RESET_PATTERNS = [
   /try again in \d+\s*(?:hours?|minutes?|h|m)/i,               // "try again in 5 hours"
 ];
 
-// --- Render shapes vs prose (#73) ---
+// --- Renders vs prose (#73) ---
 // A pane line may MENTION a limit or a reset time without BEING one. `/try again in/i` is
 // plain English, so "The API said to try again in 2 minutes before the window rolls" — or
 // the user's own "it told me to try again in 2 minutes, is that right?" — is reset-shaped,
 // and renders BELOW the banner it discusses, where a bottom-up scan finds it first.
 //
-// The discriminator is position within the line, not vocabulary: Claude Code RENDERS these
-// as the leading content of a line (behind at most the ⎿/└/⚠/· echo glyphs it prefixes
-// banners with), while prose carries the same words mid-sentence. This is the discipline
-// SPEND_LIMIT already uses for #71, generalised to the two halves of a banner.
+// The discriminator is the SHAPE of the line, not its vocabulary, and it is stated as a
+// VETO: a reset-shaped line is eligible unless something marks it as conversation. Stated
+// the other way round — an allowlist of known banner shapes — every render this file does
+// not recognise is demoted, including a LIVE one sitting below a stale banner, which is
+// worse than the pre-#73 behavior it replaces ("Claude usage limit reached. Resets at 2pm"
+// below "… resets 11:30am" would hand the monitor the stale time, and #70's latch would
+// then mark it non-correctable). A veto only ever demotes lines it can positively identify,
+// so an unrecognised render keeps the freshness ordering it had before.
 //
-// Deliberately NOT anchored to the message-bullet glyphs (⏺/●) or the prompt glyph (❯):
-// those introduce model output and user input respectively — exactly the lines #73 is
-// about — whereas a banner render uses the echo glyphs or no prefix at all.
-const RENDER_GLYPHS = '(?:[⎿└⚠·•]\\s*)*';
-const LINE_LEADS_WITH_LIMIT = new RegExp(
-  `^\\s*${RENDER_GLYPHS}(?:(?:you'?ve\\s+)?(?:hit|exceeded|reached)\\s+(?:your|the)\\s|\\d+-hour limit|(?:usage|rate)\\s+limit\\b)`, 'i');
-const LINE_LEADS_WITH_RESET = new RegExp(
-  `^\\s*${RENDER_GLYPHS}(?:please\\s+)?(?:resets?\\b|try again in\\b)`, 'i');
+// Two per-line signals, no neighbour lookups:
+//
+//   1. THE MESSAGE GLYPHS. ⏺/● introduce model output and ❯/> the user's own input —
+//      exactly the lines #73 is about. A banner renders behind the echo glyphs (⎿/└/⚠/·)
+//      or with no prefix at all, so it is never marked.
+//   2. WHAT FOLLOWS THE RESET CLAUSE. A render stops at the time, give or take a timezone
+//      qualifier ("· resets 3pm (UTC)", "resets 3am NY", "Please try again in 5 hours").
+//      A sentence keeps going: "…try again in 2 minutes, so I'll wait for that",
+//      "…resets 9am tomorrow according to the header". This is the half that catches prose
+//      whose WRAPPED continuation happens to begin with the clause — tmux capture-pane is
+//      called without -J (src/tmux.js), so a wrap arrives as its own line and a rule keyed
+//      on what LEADS the line sees "  try again in 2 minutes, so I'll wait" as a render.
+const MESSAGE_GLYPH = /^\s*[⏺●❯>]\s/;
+const RESET_TAIL_WORDS = 2;                          // "(Europe/London)" → 0, "NY" → 1
+
+// Text after the reset clause, or null when the line carries no reset time at all.
+function resetClauseTail(line) {
+  let end = -1;
+  for (const p of RESET_PATTERNS) {
+    const m = p.exec(line);
+    if (m) end = Math.max(end, m.index + m[0].length);
+  }
+  return end === -1 ? null : line.slice(end);
+}
+
+function isProseLine(line) {
+  if (MESSAGE_GLYPH.test(line)) return true;
+  const tail = resetClauseTail(line);
+  if (tail === null) return false;
+  // Parenthesised qualifiers are furniture, and punctuation/box-drawing is not a word.
+  const words = tail.replace(/\([^)]*\)/g, ' ').split(/[^\p{L}\p{N}\/:+_-]+/u).filter(Boolean);
+  return words.length > RESET_TAIL_WORDS;
+}
 
 // The spend-limit banner (#71) is the one render allowed to skip the reset-time anchor:
 // "You've hit your org's monthly spend limit · run /usage-credits …" carries NO reset,
@@ -539,30 +568,33 @@ export function findRateLimitMessage(text, customPatterns = [], tailLines = 0) {
   const fullMask = toolEchoMask(all).slice(start, end);
   const skip = (i) => fullMask[i] || isChromeLine(lines[i]);
   const isReset = (i) => RESET_PATTERNS.some(p => p.test(lines[i]));
-  // A line PRESENTS a reset time (rather than mentioning one) when the reset clause leads
-  // it, or when the line leads with the limit itself — the one-line banner form,
-  // "You've hit your session limit · resets 5:20pm".
-  const presentsReset = (i) => isReset(i)
-    && (LINE_LEADS_WITH_RESET.test(lines[i]) || LINE_LEADS_WITH_LIMIT.test(lines[i]));
+  // A line PRESENTS a reset time rather than mentioning one unless its shape marks it as
+  // conversation — a message/prompt glyph, or a sentence continuing past the clause.
+  const presentsReset = (i) => isReset(i) && !isProseLine(lines[i]);
 
   // Scan from the bottom up — the most recent line is the live one. The Claude TUI never
   // clears earlier rate-limit messages from scrollback, so a forward scan would lock onto
   // a stale line (an old "resets 11:30am" lingering above a fresh "resets 4:30pm").
   //
   // Freshness stays the outer rule; what #73 changes is which lines are eligible. Prose
-  // ABOUT a limit is skipped over, so it can no longer outrank the banner above it — but
+  // ABOUT a limit is vetoed, so it can no longer outrank the banner above it — but
   // eligibility is decided per line, never by looking at a neighbour. An earlier fix
   // attempt qualified a candidate by searching for a limit line nearby, which inverted
   // freshness (every reset it could return lay at or above the candidate), let prose that
   // merely contained "usage limit" act as the qualifier, and chained two WINDOWs into a
   // 12-line reach. Per-line eligibility has none of those failure modes.
+  //
+  // This pass can still reach past a lower line — that is the point — so the veto has to
+  // stay narrow enough that it only ever passes over conversation. Widening it into "does
+  // this look like a banner I know" is what re-introduces the freshness inversion, one
+  // unrecognised render at a time.
   for (let i = lines.length - 1; i >= 0; i--) {
     if (skip(i)) continue;
     if (presentsReset(i)) return lines[i].trim();
   }
 
-  // Nothing on screen presents a reset time. Everything below is the pre-#73 behavior
-  // unchanged, so a render this file does not recognise degrades to exactly what it
+  // Every reset-shaped line on screen was vetoed. Everything below is the pre-#73 behavior
+  // unchanged, so a pane made only of talk about a limit degrades to exactly what the scan
   // returned before rather than to null.
   for (let i = lines.length - 1; i >= 0; i--) {
     if (skip(i)) continue;

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -168,38 +168,62 @@ const RESET_PATTERNS = [
 // then mark it non-correctable). A veto only ever demotes lines it can positively identify,
 // so an unrecognised render keeps the freshness ordering it had before.
 //
-// Two per-line signals, no neighbour lookups:
+// Three per-line signals, no neighbour lookups:
 //
-//   1. THE MESSAGE GLYPHS. ⏺/● introduce model output and ❯/> the user's own input —
-//      exactly the lines #73 is about. A banner renders behind the echo glyphs (⎿/└/⚠/·)
-//      or with no prefix at all, so it is never marked.
-//   2. WHAT FOLLOWS THE RESET CLAUSE. A render stops at the time, give or take a timezone
-//      qualifier ("· resets 3pm (UTC)", "resets 3am NY", "Please try again in 5 hours").
-//      A sentence keeps going: "…try again in 2 minutes, so I'll wait for that",
-//      "…resets 9am tomorrow according to the header". This is the half that catches prose
-//      whose WRAPPED continuation happens to begin with the clause — tmux capture-pane is
-//      called without -J (src/tmux.js), so a wrap arrives as its own line and a rule keyed
-//      on what LEADS the line sees "  try again in 2 minutes, so I'll wait" as a render.
-const MESSAGE_GLYPH = /^\s*[⏺●❯>]\s/;
+//   1. THE PROMPT GLYPH. ❯/> introduce the user's own input, which is never a render.
+//   2. SENTENCE PUNCTUATION. A render does not end in ./?/! — "· resets 3pm (UTC)" — while
+//      a sentence does, including one whose WRAPPED continuation happens to begin with the
+//      clause ("  try again in 2 minutes, so I'll wait."). tmux capture-pane is called
+//      without -J (src/tmux.js), so a wrap arrives as its own line: a rule keyed on what
+//      LEADS the line would read that continuation as a render.
+//   3. WHAT FOLLOWS THE RESET CLAUSE. A render stops at the time, give or take a timezone
+//      qualifier or the rest of a compound duration ("· resets 3pm (UTC)", "resets 3am NY",
+//      "resets in 3 hours 15 minutes"). A sentence keeps going: "…resets 9am tomorrow
+//      according to the header".
+//
+// The message bullets ⏺/● are NOT a signal on their own: #63's fixture has a live banner
+// rendering as "● You've hit your session limit · resets 2:10am", so vetoing the glyph
+// demotes a real render. They mark a line only when what follows them is not a limit or
+// reset clause — i.e. the bullet introduces a sentence ABOUT one. That test is an exemption
+// inside the veto and can only ever RESCUE a line, so it carries none of the allowlist's
+// freshness risk: a render it fails to recognise is judged by signals 2 and 3 as before.
+const PROMPT_GLYPH = /^\s*[❯>]/;
+const BULLET_GLYPH = /^\s*[⏺●]\s/;
+const BULLET_LEADS_WITH_CLAUSE = new RegExp(
+  `^\\s*[⏺●]\\s*(?:(?:you'?ve\\s+)?(?:hit|exceeded|reached)\\s+(?:your|the)\\s|\\d+-hour limit`
+  + `|(?:usage|rate)\\s+limit\\b|(?:please\\s+)?(?:resets?\\b|try again in\\b))`, 'i');
+const SENTENCE_END = /[.?!]["'’”)\]]?\s*$/;
 const RESET_TAIL_WORDS = 2;                          // "(Europe/London)" → 0, "NY" → 1
+// The clause matchers stop at the first unit ("resets in 3", "try again in 4 hours"), so the
+// rest of a compound duration is part of the clause, not the start of a sentence.
+const DURATION_TAIL = /^(?:\s*(?:and|&|\d+|h|hrs?|hours?|m|mins?|minutes?|s|secs?|seconds?)\b)+/i;
+// Scanned globally: a dual-limit render ("5-hour limit resets 3pm, weekly limit resets 9am
+// Monday") must be measured from its LAST clause, including when both use the same matcher.
+const RESET_PATTERNS_G = RESET_PATTERNS.map((p) => new RegExp(p.source, `${p.flags}g`));
 
-// Text after the reset clause, or null when the line carries no reset time at all.
+// Text after the last reset clause, or null when the line carries no reset time at all.
 function resetClauseTail(line) {
   let end = -1;
-  for (const p of RESET_PATTERNS) {
-    const m = p.exec(line);
-    if (m) end = Math.max(end, m.index + m[0].length);
+  for (const p of RESET_PATTERNS_G) {
+    p.lastIndex = 0;
+    for (let m = p.exec(line); m !== null; m = p.exec(line)) end = Math.max(end, m.index + m[0].length);
   }
   return end === -1 ? null : line.slice(end);
 }
 
-function isProseLine(line) {
-  if (MESSAGE_GLYPH.test(line)) return true;
+// True when the line PRESENTS a reset time rather than mentioning one — the eligibility
+// test for findRateLimitMessage's first pass. Also answers "does this line carry a reset
+// time at all", so the clause matchers run once per line rather than twice.
+function presentsResetTime(line) {
   const tail = resetClauseTail(line);
   if (tail === null) return false;
-  // Parenthesised qualifiers are furniture, and punctuation/box-drawing is not a word.
-  const words = tail.replace(/\([^)]*\)/g, ' ').split(/[^\p{L}\p{N}\/:+_-]+/u).filter(Boolean);
-  return words.length > RESET_TAIL_WORDS;
+  if (PROMPT_GLYPH.test(line)) return false;
+  if (BULLET_GLYPH.test(line) && !BULLET_LEADS_WITH_CLAUSE.test(line)) return false;
+  if (SENTENCE_END.test(line)) return false;
+  // Parenthesised qualifiers are furniture; punctuation and box-drawing are not words.
+  const words = tail.replace(DURATION_TAIL, ' ').replace(/\([^)]*\)/g, ' ')
+    .split(/[^\p{L}\p{N}\/:+_-]+/u).filter((w) => /[\p{L}\p{N}]/u.test(w));
+  return words.length <= RESET_TAIL_WORDS;
 }
 
 // The spend-limit banner (#71) is the one render allowed to skip the reset-time anchor:
@@ -568,9 +592,7 @@ export function findRateLimitMessage(text, customPatterns = [], tailLines = 0) {
   const fullMask = toolEchoMask(all).slice(start, end);
   const skip = (i) => fullMask[i] || isChromeLine(lines[i]);
   const isReset = (i) => RESET_PATTERNS.some(p => p.test(lines[i]));
-  // A line PRESENTS a reset time rather than mentioning one unless its shape marks it as
-  // conversation — a message/prompt glyph, or a sentence continuing past the clause.
-  const presentsReset = (i) => isReset(i) && !isProseLine(lines[i]);
+  const presentsReset = (i) => presentsResetTime(lines[i]);
 
   // Scan from the bottom up — the most recent line is the live one. The Claude TUI never
   // clears earlier rate-limit messages from scrollback, so a forward scan would lock onto

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -184,14 +184,27 @@ const RESET_PATTERNS = [
 // The message bullets ⏺/● are NOT a signal on their own: #63's fixture has a live banner
 // rendering as "● You've hit your session limit · resets 2:10am", so vetoing the glyph
 // demotes a real render. They mark a line only when what follows them is not a limit or
-// reset clause — i.e. the bullet introduces a sentence ABOUT one. That test is an exemption
-// inside the veto and can only ever RESCUE a line, so it carries none of the allowlist's
-// freshness risk: a render it fails to recognise is judged by signals 2 and 3 as before.
+// reset clause — i.e. the bullet introduces a sentence ABOUT one. Being an exemption rather
+// than an allowlist does NOT by itself make it safe, which is the trap this originally fell
+// into: the veto's other two signals do not fire on a bulleted render, so a render the
+// exemption fails to recognise is not "judged as before" — it is demoted, and the stale
+// banner above it wins. The rescue test therefore has to be as wide as the file's own idea
+// of what names a limit, which is why it asks LIMIT_PATTERNS instead of restating it.
 const PROMPT_GLYPH = /^\s*[❯>]/;
 const BULLET_GLYPH = /^\s*[⏺●]\s/;
-const BULLET_LEADS_WITH_CLAUSE = new RegExp(
-  `^\\s*[⏺●]\\s*(?:(?:you'?ve\\s+)?(?:hit|exceeded|reached)\\s+(?:your|the)\\s|\\d+-hour limit`
-  + `|(?:usage|rate)\\s+limit\\b|(?:please\\s+)?(?:resets?\\b|try again in\\b))`, 'i');
+// "Names a limit" is asked of LIMIT_PATTERNS rather than re-enumerated here. Spelling the
+// phrasings out a second time made the exemption an ALLOWLIST, which is the freshness
+// inversion in slow motion: it recognised "● You've hit your session limit …" but not
+// "● Claude usage limit reached · resets 2pm", "● Session limit reached · resets 9pm",
+// "⏺ Your 5-hour limit resets 3pm" or "● You're out of extra usage · resets 3pm" — every
+// one of them a phrase LIMIT_PATTERNS already carries, and every one of them demoted in
+// favour of whatever stale banner sat above it. One source of truth, so a render the file
+// learns to recognise anywhere is recognised here too.
+// `try again in` is excluded: it is a RESET clause in limit clothing ("⏺ I will try again
+// in 3 minutes" is prose), so it must not vouch for a line on its own.
+const NAMES_A_LIMIT = LIMIT_PATTERNS.filter((p) => !/try again in/.test(p.source));
+// The bullet may also be followed directly by the reset clause itself, with no limit named.
+const BULLET_LEADS_WITH_CLAUSE = /^\s*[⏺●]\s*(?:please\s+)?(?:resets?\b|try again in\b)/i;
 const SENTENCE_END = /[.?!]["'’”)\]]?\s*$/;
 const RESET_TAIL_WORDS = 2;                          // "(Europe/London)" → 0, "NY" → 1
 // The clause matchers stop at the first unit ("resets in 3", "try again in 4 hours"), so the
@@ -218,7 +231,8 @@ function presentsResetTime(line) {
   const tail = resetClauseTail(line);
   if (tail === null) return false;
   if (PROMPT_GLYPH.test(line)) return false;
-  if (BULLET_GLYPH.test(line) && !BULLET_LEADS_WITH_CLAUSE.test(line)) return false;
+  if (BULLET_GLYPH.test(line) && !BULLET_LEADS_WITH_CLAUSE.test(line)
+      && !NAMES_A_LIMIT.some((p) => p.test(line))) return false;
   if (SENTENCE_END.test(line)) return false;
   // Parenthesised qualifiers are furniture; punctuation and box-drawing are not words.
   const words = tail.replace(DURATION_TAIL, ' ').replace(/\([^)]*\)/g, ' ')

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -136,7 +136,13 @@ function contentTail(lines, n, maxRaw = Infinity) {
 //   "· resets 3pm (UTC)"
 // Detection: find a "limit" line and a "resets" line within 6 lines of each other.
 
-const LIMIT_PATTERNS = [
+// Declared as two named subsets rather than one list the #73 code then re-derives by
+// grepping regex SOURCE text: `LIMIT_PATTERNS.filter(p => !/try again in/.test(p.source))`
+// reads the implementation of a pattern to decide what it means, so rewording the retry
+// hint once (`/try again (?:in|at)/`) would silently stop excluding it and let a retry hint
+// vouch for a line as if it named a limit. The subsets say which is which; LIMIT_PATTERNS
+// stays the union, so every existing caller is unchanged.
+const LIMIT_NAME_PATTERNS = [
   // Qualifier tokens admit possessives — "hit your org's monthly spend limit" (#71).
   /(?:hit|exceeded|reached).*(?:your|the)\s*(?:[\w'’-]+\s+){0,3}limit/i,  // "hit/exceeded/reached your [session|weekly|5-hour] limit"
   /\d+-hour limit/i,                                // "5-hour limit"
@@ -144,8 +150,14 @@ const LIMIT_PATTERNS = [
   /usage limit/i,                                    // "usage limit"
   /out of.*usage/i,                                  // "out of extra usage"
   /rate limit/i,                                     // "rate limit"
+];
+// A retry hint is a RESET clause in limit clothing: "⏺ I will try again in 3 minutes" is
+// prose. It counts as a limit for detection (a pane saying it is rate-limited) but must
+// never, on its own, vouch for a line being a render.
+const RETRY_HINT_PATTERNS = [
   /try again in/i,                                   // "try again in X hours" (implies rate limiting)
 ];
+const LIMIT_PATTERNS = [...LIMIT_NAME_PATTERNS, ...RETRY_HINT_PATTERNS];
 
 const RESET_PATTERNS = [
   /resets?\s+(?:at\s+)?\d{1,2}(?::\d{2})?\s*(?:am|pm)?/i,   // "resets 3pm" / "resets at 3:00 PM"
@@ -165,12 +177,23 @@ const RESET_PATTERNS = [
 // not recognise is demoted, including a LIVE one sitting below a stale banner, which is
 // worse than the pre-#73 behavior it replaces ("Claude usage limit reached. Resets at 2pm"
 // below "… resets 11:30am" would hand the monitor the stale time, and #70's latch would
-// then mark it non-correctable). A veto only ever demotes lines it can positively identify,
-// so an unrecognised render keeps the freshness ordering it had before.
+// then mark it non-correctable).
 //
-// Three per-line signals, no neighbour lookups:
+// "A veto only demotes what it can positively identify, so an unrecognised render keeps the
+// freshness ordering it had before" is the property this is FOR — but being a veto does not
+// establish it, and stating it that way concealed three violations for three revisions. A
+// signal that fires on a real render demotes it whichever direction the rule is phrased in.
+// What actually holds the property is the ordering below: everything except the prompt glyph
+// is subordinate to whether the line names a limit.
 //
-//   1. THE PROMPT GLYPH. ❯/> introduce the user's own input, which is never a render.
+// Four per-line signals, no neighbour lookups:
+//
+//   0. NAMING A LIMIT. Checked FIRST (after the prompt glyph) and rescues the line outright:
+//      signals 2-4 are evidence of prose, and prose is all they may veto. This is what the
+//      first three revisions got wrong — each demoted a render that plainly named a limit.
+//   1. THE PROMPT GLYPH. ❯/> introduce the user's own input, which is never a render — the
+//      one signal that outranks naming a limit, since the user typing about their own limit
+//      is the #73 report's second half.
 //   2. SENTENCE PUNCTUATION. A render does not end in ./?/! — "· resets 3pm (UTC)" — while
 //      a sentence does, including one whose WRAPPED continuation happens to begin with the
 //      clause ("  try again in 2 minutes, so I'll wait."). tmux capture-pane is called
@@ -181,31 +204,53 @@ const RESET_PATTERNS = [
 //      "resets in 3 hours 15 minutes"). A sentence keeps going: "…resets 9am tomorrow
 //      according to the header".
 //
-// The message bullets ⏺/● are NOT a signal on their own: #63's fixture has a live banner
-// rendering as "● You've hit your session limit · resets 2:10am", so vetoing the glyph
-// demotes a real render. They mark a line only when what follows them is not a limit or
-// reset clause — i.e. the bullet introduces a sentence ABOUT one. Being an exemption rather
-// than an allowlist does NOT by itself make it safe, which is the trap this originally fell
-// into: the veto's other two signals do not fire on a bulleted render, so a render the
-// exemption fails to recognise is not "judged as before" — it is demoted, and the stale
-// banner above it wins. The rescue test therefore has to be as wide as the file's own idea
-// of what names a limit, which is why it asks LIMIT_PATTERNS instead of restating it.
+// WHY THE SIGNALS ARE ORDERED THE WAY THEY ARE — the two errors do not cost the same.
+// Returning prose parses a SHORT wait: the monitor wakes early, finds the limit still
+// live, and re-derives. Returning a stale banner parses a LONG one — and because a stale
+// line parses, `_waitIsFallback` is false (monitor.js:111) and only fallbacks are
+// correctable (:139), so #70's latch refuses to revisit it. Under-waiting self-corrects;
+// over-waiting is unrecoverable until the wait expires. Every signal below therefore only
+// ever fires where the line is unambiguously conversation, and a line that NAMES a limit
+// is treated as a render — the prompt glyph excepted, since the user's own input row is
+// never a render whatever it says.
+//
+// This is the correction to the first three cuts of this fix, all of which stated the
+// invariant as "a veto only demotes what it can positively identify" and then broke it
+// three ways: SENTENCE_END demoted every period-terminated render ("Rate limit exceeded.
+// Please try again in 5 hours."), the tail budget demoted every render with an inline hint
+// ("· resets 5:20pm · /upgrade to increase your limits"), and the bullet veto demoted the
+// API-error render whose vocabulary is underscored. Each one identified a RENDER and
+// demoted it. Making "names a limit" a uniform rescue is what actually holds the invariant.
+//
+// The message bullets are NOT a signal on their own: #63's fixture has a live banner
+// rendering as "● You've hit your session limit · resets 2:10am". They mark a line only
+// when nothing else on it says "render" — i.e. the bullet introduces a sentence ABOUT a
+// limit rather than a limit.
 const PROMPT_GLYPH = /^\s*[❯>]/;
-const BULLET_GLYPH = /^\s*[⏺●]\s/;
-// "Names a limit" is asked of LIMIT_PATTERNS rather than re-enumerated here. Spelling the
-// phrasings out a second time made the exemption an ALLOWLIST, which is the freshness
-// inversion in slow motion: it recognised "● You've hit your session limit …" but not
-// "● Claude usage limit reached · resets 2pm", "● Session limit reached · resets 9pm",
-// "⏺ Your 5-hour limit resets 3pm" or "● You're out of extra usage · resets 3pm" — every
-// one of them a phrase LIMIT_PATTERNS already carries, and every one of them demoted in
-// favour of whatever stale banner sat above it. One source of truth, so a render the file
-// learns to recognise anywhere is recognised here too.
-// `try again in` is excluded: it is a RESET clause in limit clothing ("⏺ I will try again
-// in 3 minutes" is prose), so it must not vouch for a line on its own.
-const NAMES_A_LIMIT = LIMIT_PATTERNS.filter((p) => !/try again in/.test(p.source));
+// One class, shared with TOOL_ECHO_HEADER below, which already knew all three glyphs while
+// the veto knew two — leaving "∙ It said to try again in 2 minutes" eligible when the
+// identical ⏺ line was vetoed.
+const MESSAGE_GLYPH = '[●⏺∙]';
+const BULLET_GLYPH = new RegExp(`^\\s*${MESSAGE_GLYPH}\\s`);
+// "Names a limit" is asked of the declared subset, so a phrasing the file learns anywhere
+// is recognised here too. Restating the phrasings made this an ALLOWLIST once already: it
+// knew "● You've hit your session limit …" but not "● Claude usage limit reached · resets
+// 2pm", "● Session limit reached · resets 9pm", "⏺ Your 5-hour limit resets 3pm" or
+// "● You're out of extra usage · resets 3pm" — each a phrase LIMIT_PATTERNS already carried,
+// each demoted under whatever stale banner sat above it.
+// Plus the API's own underscored vocabulary, which `● API Error: 429 rate_limit_error, try
+// again in 15 minutes` renders and `/rate limit/i` cannot reach. It is added HERE rather
+// than to LIMIT_NAME_PATTERNS deliberately: the rescue can only ever make a line eligible,
+// so widening it cannot demote anything, whereas widening LIMIT_PATTERNS would widen
+// isRateLimited too — and `rate_limit_error` occurs in source, JSON error bodies and grep
+// output, which measurably flipped whole panes to "limited" when tried that way.
+const API_LIMIT_VOCAB = /rate[_-]limit/i;            // "rate_limit_error", "rate-limited"
+const NAMES_A_LIMIT = [...LIMIT_NAME_PATTERNS, API_LIMIT_VOCAB];
 // The bullet may also be followed directly by the reset clause itself, with no limit named.
-const BULLET_LEADS_WITH_CLAUSE = /^\s*[⏺●]\s*(?:please\s+)?(?:resets?\b|try again in\b)/i;
-const SENTENCE_END = /[.?!]["'’”)\]]?\s*$/;
+const BULLET_LEADS_WITH_CLAUSE = new RegExp(`^\\s*${MESSAGE_GLYPH}\\s*(?:please\\s+)?(?:resets?\\b|try again in\\b)`, 'i');
+// Closers repeat: `.”)` ends "It failed (the API said “try again in 2 minutes.”)". Renders
+// carry no [.?!] before a closer, so consuming a run of them costs nothing.
+const SENTENCE_END = /[.?!]["'’”)\]]*\s*$/;
 const RESET_TAIL_WORDS = 2;                          // "(Europe/London)" → 0, "NY" → 1
 // The clause matchers stop at the first unit ("resets in 3", "try again in 4 hours"), so the
 // rest of a compound duration is part of the clause, not the start of a sentence.
@@ -215,11 +260,23 @@ const DURATION_TAIL = /^(?:\s*(?:and|&|\d+|h|hrs?|hours?|m|mins?|minutes?|s|secs
 const RESET_PATTERNS_G = RESET_PATTERNS.map((p) => new RegExp(p.source, `${p.flags}g`));
 
 // Text after the last reset clause, or null when the line carries no reset time at all.
+// The explicit lastIndex advance is a guard, not an optimisation: a `g` pattern that can
+// match empty never advances, so `exec` would re-return the same zero-length match forever.
+// No current RESET_PATTERN can match empty, but one gaining an optional-only branch would
+// hang the monitor rather than mis-parse a line — this loop runs over untrusted pane text
+// on the hot path. It does NOT cover the other way to hang this loop: a non-global `exec`
+// ignores lastIndex outright and always restarts at 0, so the `g` in RESET_PATTERNS_G above
+// is load-bearing for termination, not just for finding the last clause. Mutation testing
+// hangs on that mutant rather than failing it; the dual-limit test is what pins the flag.
 function resetClauseTail(line) {
   let end = -1;
   for (const p of RESET_PATTERNS_G) {
     p.lastIndex = 0;
-    for (let m = p.exec(line); m !== null; m = p.exec(line)) end = Math.max(end, m.index + m[0].length);
+    for (let m = p.exec(line); m !== null; m = p.exec(line)) {
+      const next = m.index + m[0].length;
+      end = Math.max(end, next);
+      p.lastIndex = Math.max(next, m.index + 1);
+    }
   }
   return end === -1 ? null : line.slice(end);
 }
@@ -230,9 +287,14 @@ function resetClauseTail(line) {
 function presentsResetTime(line) {
   const tail = resetClauseTail(line);
   if (tail === null) return false;
+  // Absolute: the input row is the user's, whatever it says about limits.
   if (PROMPT_GLYPH.test(line)) return false;
-  if (BULLET_GLYPH.test(line) && !BULLET_LEADS_WITH_CLAUSE.test(line)
-      && !NAMES_A_LIMIT.some((p) => p.test(line))) return false;
+  // Uniform rescue, ahead of every remaining signal. Each of those signals is evidence of
+  // prose, and prose is all they may veto — a line naming a limit is a render however it is
+  // punctuated, glyphed, or trailed. See the cost argument above: this is the direction the
+  // errors are allowed to fall.
+  if (NAMES_A_LIMIT.some((p) => p.test(line))) return true;
+  if (BULLET_GLYPH.test(line) && !BULLET_LEADS_WITH_CLAUSE.test(line)) return false;
   if (SENTENCE_END.test(line)) return false;
   // Parenthesised qualifiers are furniture; punctuation and box-drawing are not words.
   const words = tail.replace(DURATION_TAIL, ' ').replace(/\([^)]*\)/g, ' ')
@@ -277,7 +339,7 @@ function hasNearbyMatch(lines, idx, patterns, mask = null) {
 // truncated) across rows leaves its continuation unmasked, and "full pane" means the
 // captured pane — a result block taller than the monitor's ~120-line capture leaves its
 // header outside the capture entirely, and the leading children are unmasked again.
-const TOOL_ECHO_HEADER = /^\s*[●⏺∙]\s*\S+\(/;   // "● Bash(grep …", "⏺ Read(file …"
+const TOOL_ECHO_HEADER = new RegExp(`^\\s*${MESSAGE_GLYPH}\\s*\\S+\\(`);   // "● Bash(grep …", "⏺ Read(file …"
 const TOOL_ECHO_RESULT = /^\s*[⎿└]/;             // "  ⎿  3"
 export function toolEchoMask(lines) {
   const mask = new Array(lines.length).fill(false);
@@ -620,10 +682,12 @@ export function findRateLimitMessage(text, customPatterns = [], tailLines = 0) {
   // merely contained "usage limit" act as the qualifier, and chained two WINDOWs into a
   // 12-line reach. Per-line eligibility has none of those failure modes.
   //
-  // This pass can still reach past a lower line — that is the point — so the veto has to
-  // stay narrow enough that it only ever passes over conversation. Widening it into "does
-  // this look like a banner I know" is what re-introduces the freshness inversion, one
-  // unrecognised render at a time.
+  // This pass can still reach past a lower line — that is the point — so every line it
+  // passes over had better be conversation. The failure mode is asymmetric: skipping a real
+  // render costs a stale, LATCHED wait (see presentsResetTime), while stopping on prose
+  // costs a short one that #70 revisits. So the prose signals are kept subordinate to the
+  // limit name rather than being tuned to recognise banners — "does this look like a banner
+  // I know" is what inverts freshness, one unrecognised render at a time.
   for (let i = lines.length - 1; i >= 0; i--) {
     if (skip(i)) continue;
     if (presentsReset(i)) return lines[i].trim();

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -153,6 +153,26 @@ const RESET_PATTERNS = [
   /try again in \d+\s*(?:hours?|minutes?|h|m)/i,               // "try again in 5 hours"
 ];
 
+// --- Render shapes vs prose (#73) ---
+// A pane line may MENTION a limit or a reset time without BEING one. `/try again in/i` is
+// plain English, so "The API said to try again in 2 minutes before the window rolls" — or
+// the user's own "it told me to try again in 2 minutes, is that right?" — is reset-shaped,
+// and renders BELOW the banner it discusses, where a bottom-up scan finds it first.
+//
+// The discriminator is position within the line, not vocabulary: Claude Code RENDERS these
+// as the leading content of a line (behind at most the ⎿/└/⚠/· echo glyphs it prefixes
+// banners with), while prose carries the same words mid-sentence. This is the discipline
+// SPEND_LIMIT already uses for #71, generalised to the two halves of a banner.
+//
+// Deliberately NOT anchored to the message-bullet glyphs (⏺/●) or the prompt glyph (❯):
+// those introduce model output and user input respectively — exactly the lines #73 is
+// about — whereas a banner render uses the echo glyphs or no prefix at all.
+const RENDER_GLYPHS = '(?:[⎿└⚠·•]\\s*)*';
+const LINE_LEADS_WITH_LIMIT = new RegExp(
+  `^\\s*${RENDER_GLYPHS}(?:(?:you'?ve\\s+)?(?:hit|exceeded|reached)\\s+(?:your|the)\\s|\\d+-hour limit|(?:usage|rate)\\s+limit\\b)`, 'i');
+const LINE_LEADS_WITH_RESET = new RegExp(
+  `^\\s*${RENDER_GLYPHS}(?:please\\s+)?(?:resets?\\b|try again in\\b)`, 'i');
+
 // The spend-limit banner (#71) is the one render allowed to skip the reset-time anchor:
 // "You've hit your org's monthly spend limit · run /usage-credits …" carries NO reset,
 // yet both reporters confirmed the underlying 5h block resets and waiting works. With no
@@ -518,17 +538,39 @@ export function findRateLimitMessage(text, customPatterns = [], tailLines = 0) {
   const lines = all.slice(start, end);
   const fullMask = toolEchoMask(all).slice(start, end);
   const skip = (i) => fullMask[i] || isChromeLine(lines[i]);
+  const isReset = (i) => RESET_PATTERNS.some(p => p.test(lines[i]));
+  // A line PRESENTS a reset time (rather than mentioning one) when the reset clause leads
+  // it, or when the line leads with the limit itself — the one-line banner form,
+  // "You've hit your session limit · resets 5:20pm".
+  const presentsReset = (i) => isReset(i)
+    && (LINE_LEADS_WITH_RESET.test(lines[i]) || LINE_LEADS_WITH_LIMIT.test(lines[i]));
 
-  // Scan from the bottom up — the most recent "resets" line is the one to
-  // parse. The Claude TUI never clears earlier rate-limit messages from
-  // scrollback, so a forward scan would lock onto a stale line (e.g. an old
-  // "resets 11:30am" lingering above a fresh "resets 4:30pm").
+  // Scan from the bottom up — the most recent line is the live one. The Claude TUI never
+  // clears earlier rate-limit messages from scrollback, so a forward scan would lock onto
+  // a stale line (an old "resets 11:30am" lingering above a fresh "resets 4:30pm").
+  //
+  // Freshness stays the outer rule; what #73 changes is which lines are eligible. Prose
+  // ABOUT a limit is skipped over, so it can no longer outrank the banner above it — but
+  // eligibility is decided per line, never by looking at a neighbour. An earlier fix
+  // attempt qualified a candidate by searching for a limit line nearby, which inverted
+  // freshness (every reset it could return lay at or above the candidate), let prose that
+  // merely contained "usage limit" act as the qualifier, and chained two WINDOWs into a
+  // 12-line reach. Per-line eligibility has none of those failure modes.
   for (let i = lines.length - 1; i >= 0; i--) {
     if (skip(i)) continue;
-    if (RESET_PATTERNS.some(p => p.test(lines[i]))) return lines[i].trim();
+    if (presentsReset(i)) return lines[i].trim();
   }
 
-  // Fallback: any "limit" line, also scanned from the bottom.
+  // Nothing on screen presents a reset time. Everything below is the pre-#73 behavior
+  // unchanged, so a render this file does not recognise degrades to exactly what it
+  // returned before rather than to null.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (skip(i)) continue;
+    if (isReset(i)) return lines[i].trim();
+  }
+
+  // Fallback: any "limit" line, also scanned from the bottom. Renders carrying no reset at
+  // all land here — the spend-limit banner (#71).
   for (let i = lines.length - 1; i >= 0; i--) {
     if (skip(i)) continue;
     if (LIMIT_PATTERNS.some(p => p.test(lines[i]))) return lines[i].trim();

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -229,6 +229,38 @@ describe('processOneTick', () => {
     });
   }
 
+  // --- The other direction, found in review: a real render DEMOTED below a stale banner.
+  //     This is the worse failure of the two. The stale time parses, so `_waitIsFallback`
+  //     is false and #70's correctUsageWait refuses to revisit it — the monitor sits on a
+  //     ~24h wait it cannot shorten. (Prose winning commits a SHORT wait, which is a
+  //     fallback and does get revisited.) Each shape below is one the veto used to claim. ---
+  for (const [label, shape] of [
+    ['a period-terminated render', (b) => `${b}.`],
+    ['a bulleted period-terminated render', (b) => `● ${b}.`],
+    ['a render with an inline upgrade hint', (b) => `${b} · /upgrade to increase your limits`],
+  ]) {
+    it(`derives the wait from ${label}, not the stale banner above it`, async () => {
+      const stale = bannerAt(-5 * 60_000);        // just passed → rolls ~24h
+      const live = shape(bannerAt(2 * 3600_000));
+      const t = mockTmux([stale, 'some ordinary output line', live].join('\n'));
+      const s = createMonitorState();
+      assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+      const secs = (s.waitUntil - Date.now()) / 1000;
+      assert.ok(secs < 3 * 3600, `expected ~2h from the live render, got ${Math.round(secs)}s`);
+      assert.equal(s._waitIsFallback, false);
+    });
+  }
+  it('derives the wait from the bulleted API-error render, not the stale banner above it', async () => {
+    // `/rate limit/i` cannot reach `rate_limit_error` and "API Error:" leads the line, so
+    // the ● was the whole verdict until the rescue learned the API's own vocabulary.
+    const t = mockTmux([bannerAt(-5 * 60_000), 'some ordinary output line',
+      '● API Error: 429 rate_limit_error, try again in 15 minutes'].join('\n'));
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    const secs = (s.waitUntil - Date.now()) / 1000;
+    assert.ok(secs < 3 * 3600, `expected ~15min from the live render, got ${Math.round(secs)}s`);
+  });
+
   it('never re-parses a wait that came from a real reset time', async () => {
     // Regression for the window/latch pair: reset-shaped prose ("try again in 2 minutes")
     // drifting into the pane during a correctly-derived multi-hour wait must not collapse

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -212,6 +212,10 @@ describe('processOneTick', () => {
   for (const [label, prose] of [
     ['model prose', '⏺ The API said to try again in 2 minutes before the limit window rolls'],
     ['user-typed text', '❯ it told me to try again in 2 minutes, is that right?'],
+    // The wrap lands right before the clause, so "try again in 2 minutes …" is what leads
+    // the line — tmux capture-pane is unjoined, so this is one pane line, not a fragment.
+    ['wrapped model prose', ['⏺ The API told me the window is nearly over and that I should',
+      '  try again in 2 minutes, so I will wait for that.'].join('\n')],
   ]) {
     it(`derives the wait from the banner, not ${label} below it (#73)`, async () => {
       const t = mockTmux([bannerAt(5 * 3600_000), '', prose].join('\n'));

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -206,6 +206,25 @@ describe('processOneTick', () => {
     assert.equal(s.waitUntil, hold);
   });
 
+  // --- #73 at the level the bug actually hurt: the wait itself. Reset-shaped prose below
+  //     a live banner used to win the parse, committing ~3min instead of ~5h — the monitor
+  //     then woke into the still-live limit and burned maxRetries before the real reset. ---
+  for (const [label, prose] of [
+    ['model prose', '⏺ The API said to try again in 2 minutes before the limit window rolls'],
+    ['user-typed text', '❯ it told me to try again in 2 minutes, is that right?'],
+  ]) {
+    it(`derives the wait from the banner, not ${label} below it (#73)`, async () => {
+      const t = mockTmux([bannerAt(5 * 3600_000), '', prose].join('\n'));
+      const s = createMonitorState();
+      assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+      const secs = (s.waitUntil - Date.now()) / 1000;
+      assert.ok(secs > 4 * 3600, `expected ~5h from the banner, got ${Math.round(secs)}s`);
+      // Parsed from a real reset time, so #70's latch correctly marks it non-correctable.
+      assert.equal(s._waitIsFallback, false);
+      assert.equal(t._sent.length, 0);
+    });
+  }
+
   it('never re-parses a wait that came from a real reset time', async () => {
     // Regression for the window/latch pair: reset-shaped prose ("try again in 2 minutes")
     // drifting into the pane during a correctly-derived multi-hour wait must not collapse

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -431,6 +431,58 @@ describe('findRateLimitMessage', () => {
       '  resets 9:00am tomorrow according to the header.'];
     assert.equal(findRateLimitMessage([BANNER, '', ...wrapped].join('\n'), [], 12), BANNER);
   });
+  it('WRAPPED prose ending AT the clause cannot win either', () => {
+    // The tail is empty here, so only the full stop marks it — a render never ends in one.
+    const wrapped = ['⏺ I checked the header and the limit', '  resets 3pm.'];
+    assert.equal(findRateLimitMessage([BANNER, '', ...wrapped].join('\n'), [], 12), BANNER);
+  });
+
+  // --- Shapes the veto must NOT claim. Each of these is a real render that the pre-#73
+  //     scan returned; demoting one hands the monitor whatever stale line sits above it. ---
+  const STALE = "You've hit your limit · resets 11:30am (UTC)";
+  it('a banner rendered on a message bullet is not vetoed (#63 fixture)', () => {
+    // "API errors render with the same ● glyph but never as `Name(...)`" — test/tool-echo.
+    // The bullet marks a line only when what follows it is not a limit or reset clause.
+    const live = "● You've hit your session limit · resets 2:10am (Australia/Melbourne)";
+    assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
+  });
+  it('a compound duration is not read as a sentence carrying on', () => {
+    // The clause matcher stops at the first unit ("resets in 3"), leaving "hours 15 minutes"
+    // in the tail — three words, and the whole budget, spent on the duration itself.
+    for (const live of ["You've hit your limit · resets in 3 hours 15 minutes",
+      'Please try again in 4 hours and 12 minutes']) {
+      assert.equal(findRateLimitMessage([STALE, 'output', live].join('\n'), [], 12), live);
+    }
+  });
+  it('a dual-limit render is measured from its last clause, same matcher twice', () => {
+    const live = '5-hour limit resets 3pm, weekly limit resets 9am Monday';
+    assert.equal(findRateLimitMessage([STALE, 'output', live].join('\n'), [], 12), live);
+  });
+  it('a separator does not count as one of the tail words', () => {
+    for (const live of ['5-hour limit reached · resets 3pm - see above',
+      '5-hour limit reached · resets 3pm / 10:30 UTC']) {
+      assert.equal(findRateLimitMessage([STALE, 'output', live].join('\n'), [], 12), live);
+    }
+  });
+  it('typed text still loses when the prompt glyph carries no space', () => {
+    assert.equal(findRateLimitMessage([BANNER, 'output', '>try again in 2 minutes ok?'].join('\n'), [], 12), BANNER);
+  });
+
+  // --- One case per signal, shaped so the other two do not fire: each of these is vetoed
+  //     by exactly one of the prompt glyph, the message bullet, and the tail budget. ---
+  it('an unpunctuated instruction at the prompt cannot win', () => {
+    assert.equal(findRateLimitMessage([BANNER, '', '❯ try again in 5 minutes'].join('\n'), [], 12), BANNER);
+  });
+  it('an unpunctuated sentence on a message bullet cannot win', () => {
+    assert.equal(findRateLimitMessage([BANNER, '', '⏺ It said to try again in 2 minutes'].join('\n'), [], 12), BANNER);
+  });
+  it('an unpunctuated wrapped continuation cannot win', () => {
+    // The wrap lands before the clause and the sentence runs on into the NEXT line, so
+    // neither glyph nor full stop is on this one — only the tail marks it.
+    const wrapped = ['⏺ Your session limit is still live and it',
+      '  resets 9:00am tomorrow according to the header', '  of the transcript'];
+    assert.equal(findRateLimitMessage([BANNER, '', ...wrapped].join('\n'), [], 12), BANNER);
+  });
   it('a short question at the prompt cannot win', () => {
     // Nothing but the prompt glyph marks this one: the sentence ends at the clause, so the
     // tail signal alone would accept "❯ so it resets 5pm?" as a render.

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -446,6 +446,49 @@ describe('findRateLimitMessage', () => {
     const live = "● You've hit your session limit · resets 2:10am (Australia/Melbourne)";
     assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
   });
+  // The bullet exemption is an ALLOWLIST of limit phrasings, so it recognises only the
+  // wordings enumerated in BULLET_LEADS_WITH_CLAUSE. Every render below is one this file
+  // already treats as real — each phrase comes straight out of LIMIT_PATTERNS — but none
+  // of them leads with a phrase the exemption lists, so the bullet condemns them and the
+  // STALE banner above wins. That is the freshness inversion the veto is documented as
+  // never introducing ("Widening it into 'does this look like a banner I know' is what
+  // re-introduces the freshness inversion, one unrecognised render at a time"), reached
+  // by narrowing instead. The bullet is the ONLY discriminator: strip it and each line
+  // wins, which is what the second assertion pins.
+  for (const live of [
+    '● Claude usage limit reached · resets 2pm',        // /limit reached/, /usage limit/
+    '● Session limit reached · resets 9pm',             // /limit reached/
+    '⏺ Your 5-hour limit resets 3pm',                   // /\d+-hour limit/ — not bullet-leading
+    "● You're out of extra usage · resets 3pm",         // /out of.*usage/
+  ]) {
+    it(`a message bullet does not demote a real render: ${live.slice(0, 34)}…`, () => {
+      assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
+      const bare = live.replace(/^[⏺●]\s*/, '');
+      assert.equal(findRateLimitMessage([STALE, 'some output', bare].join('\n'), [], 12), bare,
+        'without the bullet this same line wins — the bullet is the only discriminator');
+    });
+  }
+
+  // OPEN — deliberately left red-as-todo rather than fixed, because there is no free answer.
+  // SENTENCE_END is load-bearing: dropping it un-vetoes "⏺ You've hit your usage limit, so
+  // try again in 2 minutes." (pinned above) and the wrapped-prose case, both of which are
+  // renders by every other available signal. Fixing this needs a discriminator that does not
+  // exist yet, not a tweak — so it is recorded here as a known demotion rather than papered
+  // over. Flip back to `it(` once a signal separating the two is found.
+  it.todo('a full stop does not demote a real render', () => {
+    // SENTENCE_END vetoes any reset-shaped line ending in .?!, but renders do end in a full
+    // stop — the #71 fixture pinned below in this same file is "You've hit your monthly
+    // spend limit." A period is punctuation, not evidence of prose, and treating it as the
+    // signal hands the monitor the stale line above.
+    for (const live of ["You've hit your session limit · resets 5:20pm.",
+      "● You've hit your session limit · resets 5:20pm."]) {
+      assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
+      const bare = live.replace(/\.$/, '');
+      assert.equal(findRateLimitMessage([STALE, 'some output', bare].join('\n'), [], 12), bare,
+        'without the full stop this same line wins — the period is the only discriminator');
+    }
+  });
+
   it('a compound duration is not read as a sentence carrying on', () => {
     // The clause matcher stops at the first unit ("resets in 3"), leaving "hours 15 minutes"
     // in the tail — three words, and the whole budget, spent on the duration itself.

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -391,12 +391,62 @@ describe('findRateLimitMessage', () => {
     const text = ['Rate limit hit. Resets at 4pm', '', PROSE].join('\n');
     assert.equal(findRateLimitMessage(text, [], 12), 'Rate limit hit. Resets at 4pm');
   });
-  it('a render whose limit phrase does NOT lead falls through to the old behavior', () => {
-    // Known limit of the shape rule: "Claude usage limit reached…" buries the phrase behind
-    // a word, so it is not eligible and the historical bottom-up scan takes over — i.e.
-    // unchanged from before this fix, never worse. Pinned so the boundary is visible.
+  it('a render whose limit phrase does NOT lead is still preferred over prose', () => {
+    // "Claude usage limit reached…" buries the phrase behind a word, so no allowlist of
+    // banner shapes reaches it. The rule is a veto instead: the line says nothing that
+    // marks it as conversation, so it stays eligible.
     const text = ['Claude usage limit reached. Resets at 2pm', '', PROSE].join('\n');
-    assert.equal(findRateLimitMessage(text, [], 12), PROSE);
+    assert.equal(findRateLimitMessage(text, [], 12), 'Claude usage limit reached. Resets at 2pm');
+  });
+  it('a stale banner never outranks an unrecognised render below it', () => {
+    // The freshness inversion an allowlist would introduce, and the reason the rule is a
+    // veto. Demoting every render this file doesn't know hands the monitor the stale time —
+    // and #70's latch, seeing a parsed result, marks it non-correctable.
+    const text = ["You've hit your limit · resets 11:30am (UTC)", 'output',
+      'API Error: rate_limit_error, try again in 15 minutes'].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), 'API Error: rate_limit_error, try again in 15 minutes');
+  });
+  it('a timezone-qualified render is not mistaken for prose', () => {
+    // The veto's second signal counts what follows the reset clause; a bare timezone word
+    // ("resets 3am NY", the #6 fixture) is furniture, not a sentence carrying on.
+    const text = ['5-hour limit reached - resets 3am NY', '', PROSE].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), '5-hour limit reached - resets 3am NY');
+  });
+  it('a parenthesised timezone does not spend the tail budget', () => {
+    // Qualifiers in brackets are furniture whatever their length — "(NZDT, UTC+13)" would
+    // otherwise consume the whole budget and veto a real render.
+    const banner = 'Rate limit hit. Resets at 11:40pm Auckland (NZDT, UTC+13)';
+    assert.equal(findRateLimitMessage([banner, '', PROSE].join('\n'), [], 12), banner);
+  });
+  it('WRAPPED prose whose continuation line begins with the clause cannot win', () => {
+    // tmux capture-pane is unjoined, so a wrapped sentence arrives as its own line — and
+    // the wrap can land right before "try again in …", which is then what LEADS the line.
+    // The sentence continuing past the clause is what marks it.
+    const wrapped = ['⏺ The API told me the window is nearly over and that I should',
+      '  try again in 2 minutes, so I will wait for that.'];
+    assert.equal(findRateLimitMessage([BANNER, '', ...wrapped].join('\n'), [], 12), BANNER);
+  });
+  it('WRAPPED prose continuing past a reset time cannot win', () => {
+    const wrapped = ['⏺ Your session limit is still live and it',
+      '  resets 9:00am tomorrow according to the header.'];
+    assert.equal(findRateLimitMessage([BANNER, '', ...wrapped].join('\n'), [], 12), BANNER);
+  });
+  it('a short question at the prompt cannot win', () => {
+    // Nothing but the prompt glyph marks this one: the sentence ends at the clause, so the
+    // tail signal alone would accept "❯ so it resets 5pm?" as a render.
+    const typed = '❯ so it resets 5pm?';
+    assert.equal(findRateLimitMessage([BANNER, '', typed].join('\n'), [], 12), BANNER);
+  });
+  it('a render carrying both clauses is measured from the LAST one', () => {
+    // "· resets 3pm … or try again in 5 hours" — measuring the tail from the first clause
+    // would read the second as a sentence running on and veto a real banner.
+    const banner = "You've hit your limit · resets 3pm (UTC), or try again in 5 hours";
+    assert.equal(findRateLimitMessage([banner, '', PROSE].join('\n'), [], 12), banner);
+  });
+  it('typed text carrying no prompt glyph cannot win', () => {
+    // Submitted input re-renders without ❯ in some layouts; the sentence shape still marks it.
+    const typed = 'try again in 2 minutes was what it said, right?';
+    assert.equal(findRateLimitMessage([BANNER, '', typed].join('\n'), [], 12), BANNER);
   });
   it('a "5-hour limit" render is preferred over prose', () => {
     const text = ['5-hour limit reached - resets 3pm (Europe/Dublin)', '', PROSE].join('\n');

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -860,6 +860,25 @@ describe('a banner that names /usage-credits inline is content, not chrome', () 
       ['⏺ You can run /usage-credits when you hit your usage limit', '', '❯ '],
     ]) assert.equal(isRateLimited(pane.join('\n'), [], 12), false);
   });
+  it('outranks a STALE banner above it — the #74 composition', () => {
+    // The composition of #75 (which made this line content rather than chrome, and is now
+    // in master) with #73's per-line eligibility veto below. One of that veto's signals is
+    // a budget on how many words may follow the reset clause, and EVERY inline-hint banner
+    // busts it ("· run /usage-credits to finish" is four) — so the render #75 made
+    // parseable is exactly the shape the veto would demote. It only bites when something
+    // stale sits above the banner, which is why the single-line test above cannot see it,
+    // and demotion is the unrecoverable direction: the stale time PARSES, so
+    // `_waitIsFallback` is false and #70's correctUsageWait never revisits the ~24h wait
+    // it latches.
+    //
+    // The veto resolves it by asking "does the line name a limit" ahead of the tail budget.
+    // Verified against both heads of that work while it was still a separate branch: at
+    // d0a0e16 this pane returned the stale banner, at ab302d6 it returns the live line —
+    // so this test fails against the shape of the bug and passes against the fix.
+    const pane = ["You've hit your limit · resets 11:30am (UTC)", '● wrote some code',
+      inlineHint, '', '❯ '].join('\n');
+    assert.equal(findRateLimitMessage(pane, [], 12), inlineHint);
+  });
   it('still treats the companion ROW as chrome', () => {
     // Anchored, not abandoned: the hint leading its line is still furniture, indented or
     // behind an echo marker, or the tail budget goes on it instead of on the banner.

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -320,6 +320,107 @@ describe('stripAnsi (private-mode sequences)', () => {
 });
 
 describe('findRateLimitMessage', () => {
+  // --- #73: a line may MENTION a limit or reset time without BEING one. `try again in …`
+  //     is plain English, so model output or a user's own message — which renders BELOW the
+  //     banner it discusses — stole the bottom-up scan and turned a 5h wait into ~3min.
+  //     Eligibility is now per-line: the clause must LEAD the line, or the line must lead
+  //     with the limit itself. Freshness (bottom-up) is unchanged. ---
+  const PROSE  = '⏺ The API said to try again in 2 minutes before the limit window rolls';
+  const TYPED  = '❯ it told me to try again in 2 minutes, is that right?';
+  const BANNER = "You've hit your session limit · resets 5:20pm (Europe/London)";
+
+  it('prefers the one-line banner over model prose below it (#73)', () => {
+    assert.equal(findRateLimitMessage([BANNER, '', PROSE].join('\n'), [], 12), BANNER);
+  });
+  it('prefers the one-line banner over user-typed text below it (#73)', () => {
+    assert.equal(findRateLimitMessage([BANNER, '', TYPED].join('\n'), [], 12), BANNER);
+  });
+  it('prefers the banner over SEVERAL reset-shaped prose lines below it (#73)', () => {
+    // The realistic shape of the report: the model says it, then the user asks about it.
+    // With one prose line any "is a limit nearby" rule looks like it works; with two, a
+    // rule that lets prose qualify itself is exposed.
+    assert.equal(findRateLimitMessage([BANNER, '', PROSE, TYPED].join('\n'), [], 12), BANNER);
+  });
+  it('prose carrying BOTH a limit phrase and a retry hint cannot outrank the banner', () => {
+    // Self-vouching: this line satisfies the limit and reset vocabularies at once, so any
+    // rule keyed on vocabulary rather than position accepts it.
+    const selfVouching = "⏺ You've hit your usage limit, so try again in 2 minutes.";
+    assert.equal(findRateLimitMessage([BANNER, '', selfVouching].join('\n'), [], 12), BANNER);
+  });
+  it('prefers the multi-line render over prose below it (#73)', () => {
+    const text = ["⚠ You've hit your limit", '· resets 3pm (UTC)', PROSE].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), '· resets 3pm (UTC)');
+  });
+  it('still resolves the multi-line render with nothing below it', () => {
+    const text = ["⚠ You've hit your limit", '· resets 3pm (UTC)'].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), '· resets 3pm (UTC)');
+  });
+  it('still returns standalone terse API wording with no banner in sight', () => {
+    assert.equal(findRateLimitMessage('Please try again in 5 hours', [], 12), 'Please try again in 5 hours');
+  });
+  it('a terse line below a stale banner still wins — freshness is not inverted', () => {
+    // The fix must not reach backwards. "Please try again in 15 minutes" leads its line, so
+    // it is eligible and, being lower, it is the live one.
+    const text = ["You've hit your limit · resets 11:30am (UTC)", 'output',
+      'Please try again in 15 minutes'].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), 'Please try again in 15 minutes');
+  });
+  it('still returns reset-shaped prose when nothing else presents a reset', () => {
+    // Degrade to the historical behavior rather than to null.
+    assert.equal(findRateLimitMessage(PROSE, [], 12), PROSE);
+  });
+
+  // Freshness, pinned THROUGH the new eligibility pass (prose below, so the pass is what
+  // resolves each of these rather than the old bottom-up scan).
+  it('a stale banner loses to a fresher banner below it, prose notwithstanding', () => {
+    const text = ["You've hit your limit · resets 11:30am (UTC)",
+      "You've hit your limit · resets 4:30pm (UTC)", PROSE].join('\n');
+    assert.ok(findRateLimitMessage(text, [], 12).includes('4:30pm'));
+  });
+  it('a stale one-line banner loses to a fresher multi-line render, prose notwithstanding', () => {
+    const text = ["You've hit your limit · resets 11:30am (UTC)",
+      "⚠ You've hit your limit", '· resets 3pm (UTC)', PROSE].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), '· resets 3pm (UTC)');
+  });
+  it('the ⎿-prefixed banner from the original report is preferred over prose', () => {
+    // The exact render from the incident: Claude Code echoes the banner as a child line.
+    const banner = "  ⎿  You've hit your session limit · resets 6:20pm (Europe/London)";
+    assert.equal(findRateLimitMessage([banner, '', PROSE].join('\n'), [], 12), banner.trim());
+  });
+  it('a "rate limit" render is preferred over prose', () => {
+    const text = ['Rate limit hit. Resets at 4pm', '', PROSE].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), 'Rate limit hit. Resets at 4pm');
+  });
+  it('a render whose limit phrase does NOT lead falls through to the old behavior', () => {
+    // Known limit of the shape rule: "Claude usage limit reached…" buries the phrase behind
+    // a word, so it is not eligible and the historical bottom-up scan takes over — i.e.
+    // unchanged from before this fix, never worse. Pinned so the boundary is visible.
+    const text = ['Claude usage limit reached. Resets at 2pm', '', PROSE].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), PROSE);
+  });
+  it('a "5-hour limit" render is preferred over prose', () => {
+    const text = ['5-hour limit reached - resets 3pm (Europe/Dublin)', '', PROSE].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), '5-hour limit reached - resets 3pm (Europe/Dublin)');
+  });
+  it('a limit-leading line carrying NO reset time is not eligible', () => {
+    // Eligibility needs a reset time to hand to the parser; leading with a limit phrase is
+    // not enough, or prose that merely opens with "rate limit …" would be returned and
+    // parse to null, discarding the real time above it.
+    const text = ["You've hit your limit · resets 4:30pm (UTC)", '', 'rate limit questions are common'].join('\n');
+    assert.ok(findRateLimitMessage(text, [], 12).includes('4:30pm'));
+  });
+  it('works in print mode too, where the scan is unbounded', () => {
+    assert.equal(findRateLimitMessage([BANNER, '', PROSE].join('\n'), [], 0), BANNER);
+  });
+  it('a reset time quoted inside a tool result cannot win the eligibility pass', () => {
+    // The tool-echo mask (#63) must still apply to the new pass. The quoted line has to sit
+    // BELOW the real one to test anything: put it above and the bottom-up scan reaches the
+    // real banner first, so the assertion passes even with the mask disabled.
+    const text = ['· resets 4:30pm (UTC)', '● Bash(grep resets)',
+      '  ⎿  · resets 9am (UTC)'].join('\n');
+    assert.equal(findRateLimitMessage(text, [], 12), '· resets 4:30pm (UTC)');
+  });
+
   // tailLines bounds the scan to the same chrome-aware window isRateLimited reads, so a
   // caller that gates on liveness can't then parse a line the gate never saw. The monitor
   // re-derives the wait during a fallback, where an unbounded scan could reach a stale

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -469,23 +469,61 @@ describe('findRateLimitMessage', () => {
     });
   }
 
-  // OPEN — deliberately left red-as-todo rather than fixed, because there is no free answer.
-  // SENTENCE_END is load-bearing: dropping it un-vetoes "⏺ You've hit your usage limit, so
-  // try again in 2 minutes." (pinned above) and the wrapped-prose case, both of which are
-  // renders by every other available signal. Fixing this needs a discriminator that does not
-  // exist yet, not a tweak — so it is recorded here as a known demotion rather than papered
-  // over. Flip back to `it(` once a signal separating the two is found.
-  it.todo('a full stop does not demote a real render', () => {
-    // SENTENCE_END vetoes any reset-shaped line ending in .?!, but renders do end in a full
-    // stop — the #71 fixture pinned below in this same file is "You've hit your monthly
-    // spend limit." A period is punctuation, not evidence of prose, and treating it as the
-    // signal hands the monitor the stale line above.
+  // --- The three master-vs-branch behavioural diffs found in review. Each is the same
+  //     failure this fix exists to prevent, reached from the other side: a real render
+  //     demoted, so the STALE banner above it wins — and because the stale line PARSES,
+  //     `_waitIsFallback` is false (monitor.js:111) and only fallbacks are correctable
+  //     (:139), so the wrong wait latches and the monitor wakes early into a live limit.
+  //     Every one of these is a line the pre-#73 scan returned. ---
+  it('a full stop does not demote a real render', () => {
+    // SENTENCE_END vetoed any reset-shaped line ending in .?!, but renders do end in a full
+    // stop — this file's own #71 fixture is "You've hit your monthly spend limit." A period
+    // is punctuation, not evidence of prose.
+    for (const live of ["You've hit your session limit · resets 5:20pm.",
+      "● You've hit your session limit · resets 5:20pm.",
+      'Rate limit exceeded. Please try again in 5 hours.',
+      'Claude usage limit reached. Your limit will reset at 6pm (Asia/Kolkata).']) {
+      assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
+    }
+  });
+  it('a full stop is the only discriminator — the same line bare still wins', () => {
     for (const live of ["You've hit your session limit · resets 5:20pm.",
       "● You've hit your session limit · resets 5:20pm."]) {
-      assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
       const bare = live.replace(/\.$/, '');
-      assert.equal(findRateLimitMessage([STALE, 'some output', bare].join('\n'), [], 12), bare,
-        'without the full stop this same line wins — the period is the only discriminator');
+      assert.equal(findRateLimitMessage([STALE, 'some output', bare].join('\n'), [], 12), bare);
+    }
+  });
+  it('the bullet does not demote the API-error render (underscored vocabulary)', () => {
+    // `/rate limit/i` does not reach `rate_limit_error`, and `API Error:` leads the line so
+    // the clause-leading rescue misses it too — leaving the bullet as the whole verdict. The
+    // pinning test above carries the same wording WITHOUT the ●, which is what let this pass:
+    // toolEchoMask's own comment documents that real API errors render `● API Error: …`.
+    const live = '● API Error: 429 rate_limit_error, try again in 15 minutes';
+    assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
+  });
+  it('a limit-naming render survives a tail longer than the budget', () => {
+    // The tail budget is a prose signal, and prose is what it may veto. A render that NAMES
+    // a limit is a render however long its inline hint runs. The second of these is the shape
+    // #75 turns from chrome into content: every inline-hint banner has a >2-word tail, so the
+    // day both land, this veto would demote exactly the render #75 makes parseable.
+    for (const live of ["You've hit your session limit · resets 5:20pm · /upgrade to increase your limits",
+      "You've hit your limit · resets 5:20pm (UTC) · run /usage-credits to finish"]) {
+      assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
+    }
+  });
+
+  // --- Residual prose shapes the veto let through, reported alongside the three above. ---
+  it('stacked closers still end a sentence', () => {
+    // `.”)` — SENTENCE_END allowed a single optional closer, so a quote inside a paren ran
+    // past it. Renders carry no [.?!] before a closer, so widening costs nothing.
+    const prose = 'It failed (the API said “try again in 2 minutes.”)';
+    assert.equal(findRateLimitMessage([BANNER, '', prose].join('\n'), [], 12), BANNER);
+  });
+  it('the ∙ message glyph marks a line the same as ⏺ and ●', () => {
+    // TOOL_ECHO_HEADER already knows [●⏺∙]; the veto knew only two of the three.
+    for (const glyph of ['⏺', '●', '∙']) {
+      assert.equal(findRateLimitMessage([BANNER, '', `${glyph} It said to try again in 2 minutes`].join('\n'), [], 12),
+        BANNER, `${glyph} should mark the line as a message`);
     }
   });
 

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -323,8 +323,11 @@ describe('findRateLimitMessage', () => {
   // --- #73: a line may MENTION a limit or reset time without BEING one. `try again in …`
   //     is plain English, so model output or a user's own message — which renders BELOW the
   //     banner it discusses — stole the bottom-up scan and turned a 5h wait into ~3min.
-  //     Eligibility is now per-line: the clause must LEAD the line, or the line must lead
-  //     with the limit itself. Freshness (bottom-up) is unchanged. ---
+  //     Eligibility is now per-line, stated as a veto: a reset-shaped line stays eligible
+  //     unless something marks it as conversation. Every one of those signals is subordinate
+  //     to whether the line NAMES a limit — except the prompt glyph, which is absolute —
+  //     because demoting a real render costs a stale, latched wait while stopping on prose
+  //     costs a short one that #70 revisits. Freshness (bottom-up) is unchanged. ---
   const PROSE  = '⏺ The API said to try again in 2 minutes before the limit window rolls';
   const TYPED  = '❯ it told me to try again in 2 minutes, is that right?';
   const BANNER = "You've hit your session limit · resets 5:20pm (Europe/London)";
@@ -341,11 +344,23 @@ describe('findRateLimitMessage', () => {
     // rule that lets prose qualify itself is exposed.
     assert.equal(findRateLimitMessage([BANNER, '', PROSE, TYPED].join('\n'), [], 12), BANNER);
   });
-  it('prose carrying BOTH a limit phrase and a retry hint cannot outrank the banner', () => {
-    // Self-vouching: this line satisfies the limit and reset vocabularies at once, so any
-    // rule keyed on vocabulary rather than position accepts it.
-    const selfVouching = "⏺ You've hit your usage limit, so try again in 2 minutes.";
-    assert.equal(findRateLimitMessage([BANNER, '', selfVouching].join('\n'), [], 12), BANNER);
+  it('BOUNDARY: prose that names a limit itself still outranks the banner (parity with master)', () => {
+    // NOT fixed, and deliberately so — see the cost argument in patterns.js. A line naming a
+    // limit is rescued from every prose signal, which is what stops the veto demoting real
+    // renders; the price is that a message paraphrasing the banner is indistinguishable from
+    // one per line. Both variants below already lose on master, so this is a scope limit of
+    // #73's fix, not a regression — and the error falls the recoverable way: the short wait
+    // is a fallback, so #70's correctUsageWait revisits it, where a stale banner would latch.
+    for (const selfVouching of ["⏺ You've hit your usage limit, so try again in 2 minutes.",
+      "⏺ You've hit your usage limit, try again in 2 minutes"]) {
+      assert.equal(findRateLimitMessage([BANNER, '', selfVouching].join('\n'), [], 12), selfVouching);
+    }
+  });
+  it('the same prose at the prompt IS vetoed — the input row is never a render', () => {
+    // The prompt glyph is the one absolute signal, so the user asking about their own limit
+    // cannot steal the parse however much limit vocabulary the question carries.
+    const typed = '❯ why do I keep hitting the usage limit? it said resets 3pm';
+    assert.equal(findRateLimitMessage([BANNER, '', typed].join('\n'), [], 12), BANNER);
   });
   it('prefers the multi-line render over prose below it (#73)', () => {
     const text = ["⚠ You've hit your limit", '· resets 3pm (UTC)', PROSE].join('\n');
@@ -399,12 +414,16 @@ describe('findRateLimitMessage', () => {
     assert.equal(findRateLimitMessage(text, [], 12), 'Claude usage limit reached. Resets at 2pm');
   });
   it('a stale banner never outranks an unrecognised render below it', () => {
-    // The freshness inversion an allowlist would introduce, and the reason the rule is a
-    // veto. Demoting every render this file doesn't know hands the monitor the stale time —
-    // and #70's latch, seeing a parsed result, marks it non-correctable.
-    const text = ["You've hit your limit · resets 11:30am (UTC)", 'output',
-      'API Error: rate_limit_error, try again in 15 minutes'].join('\n');
-    assert.equal(findRateLimitMessage(text, [], 12), 'API Error: rate_limit_error, try again in 15 minutes');
+    // The freshness inversion an allowlist would introduce. Demoting every render this file
+    // doesn't know hands the monitor the stale time — and #70's latch, seeing a parsed
+    // result, marks it non-correctable. BOTH glyph forms are asserted: the bulleted one is
+    // how real API errors render (toolEchoMask's comment documents "● API Error: …"), and
+    // testing only the bare form is what let the bullet veto demote the real shape unnoticed.
+    for (const live of ['API Error: rate_limit_error, try again in 15 minutes',
+      '● API Error: rate_limit_error, try again in 15 minutes']) {
+      const text = ["You've hit your limit · resets 11:30am (UTC)", 'output', live].join('\n');
+      assert.equal(findRateLimitMessage(text, [], 12), live);
+    }
   });
   it('a timezone-qualified render is not mistaken for prose', () => {
     // The veto's second signal counts what follows the reset clause; a bare timezone word
@@ -414,9 +433,39 @@ describe('findRateLimitMessage', () => {
   });
   it('a parenthesised timezone does not spend the tail budget', () => {
     // Qualifiers in brackets are furniture whatever their length — "(NZDT, UTC+13)" would
-    // otherwise consume the whole budget and veto a real render.
-    const banner = 'Rate limit hit. Resets at 11:40pm Auckland (NZDT, UTC+13)';
-    assert.equal(findRateLimitMessage([banner, '', PROSE].join('\n'), [], 12), banner);
+    // otherwise consume the whole budget and veto a real render. The BARE form is the one
+    // that exercises the budget: the limit-naming form is rescued before the tail is read.
+    for (const banner of ['· resets 11:40pm Auckland (NZDT, UTC+13)',
+      'Rate limit hit. Resets at 11:40pm Auckland (NZDT, UTC+13)']) {
+      assert.equal(findRateLimitMessage([banner, '', PROSE].join('\n'), [], 12), banner);
+      assert.equal(findRateLimitMessage([STALE, 'output', banner].join('\n'), [], 12), banner);
+    }
+  });
+  it('a bullet followed straight by the clause is a render continuation, not a sentence', () => {
+    // Load-bearing because this change ADDED ∙ to the glyph class: a render whose reset line
+    // is bulleted ("∙ resets 8:40pm (Europe/London)") names no limit, so without the
+    // clause-leading exemption the widened glyph would demote it under any stale banner —
+    // a regression introduced by the very fix for the ∙ gap. Mutation testing caught that
+    // removing the exemption changed nothing any test could see.
+    for (const live of ['∙ resets 3pm (UTC)', '⏺ resets 3pm (UTC)', '● resets 8:40pm (Europe/London)',
+      '● try again in 5 hours']) {
+      assert.equal(findRateLimitMessage([STALE, 'output', live].join('\n'), [], 12), live);
+    }
+  });
+  it('a contraction after the clause spends the tail budget', () => {
+    // The tail counts WORDS, not whitespace runs: "I'll" is two, which is what takes this
+    // over budget. Splitting on whitespace instead would leave it eligible — the shape that
+    // distinguishes the word class from a plain \s+ split, and nothing else pinned it.
+    for (const prose of ["· resets 3pm, I'll wait", "  resets 3pm, it's fine"]) {
+      assert.equal(findRateLimitMessage([BANNER, '', prose].join('\n'), [], 12), BANNER);
+    }
+  });
+  it('a compound duration is not read as a sentence carrying on, clause-only', () => {
+    // Same reasoning: "· resets in 3 hours 15 minutes" carries no limit name, so the
+    // duration tail is what keeps it eligible rather than the rescue.
+    for (const live of ['· resets in 3 hours 15 minutes', '· try again in 4 hours and 12 minutes']) {
+      assert.equal(findRateLimitMessage([STALE, 'output', live].join('\n'), [], 12), live);
+    }
   });
   it('WRAPPED prose whose continuation line begins with the clause cannot win', () => {
     // tmux capture-pane is unjoined, so a wrapped sentence arrives as its own line — and
@@ -446,15 +495,13 @@ describe('findRateLimitMessage', () => {
     const live = "● You've hit your session limit · resets 2:10am (Australia/Melbourne)";
     assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
   });
-  // The bullet exemption is an ALLOWLIST of limit phrasings, so it recognises only the
-  // wordings enumerated in BULLET_LEADS_WITH_CLAUSE. Every render below is one this file
-  // already treats as real — each phrase comes straight out of LIMIT_PATTERNS — but none
-  // of them leads with a phrase the exemption lists, so the bullet condemns them and the
-  // STALE banner above wins. That is the freshness inversion the veto is documented as
-  // never introducing ("Widening it into 'does this look like a banner I know' is what
-  // re-introduces the freshness inversion, one unrecognised render at a time"), reached
-  // by narrowing instead. The bullet is the ONLY discriminator: strip it and each line
-  // wins, which is what the second assertion pins.
+  // These are why the limit-name rescue asks LIMIT_NAME_PATTERNS rather than restating the
+  // phrasings: an exemption that enumerates its own wordings recognises only those, so every
+  // render below — each phrase straight out of LIMIT_PATTERNS — was condemned by its bullet
+  // and lost to the STALE banner above. Being an exemption rather than an allowlist does not
+  // make that safe on its own; the other signals do not fire on a bulleted render, so one the
+  // exemption misses is not "judged as before", it is demoted. The bullet is the ONLY
+  // discriminator here: strip it and each line wins, which is what the second assertion pins.
   for (const live of [
     '● Claude usage limit reached · resets 2pm',        // /limit reached/, /usage limit/
     '● Session limit reached · resets 9pm',             // /limit reached/
@@ -503,11 +550,14 @@ describe('findRateLimitMessage', () => {
   });
   it('a limit-naming render survives a tail longer than the budget', () => {
     // The tail budget is a prose signal, and prose is what it may veto. A render that NAMES
-    // a limit is a render however long its inline hint runs. The second of these is the shape
-    // #75 turns from chrome into content: every inline-hint banner has a >2-word tail, so the
-    // day both land, this veto would demote exactly the render #75 makes parseable.
+    // a limit is a render however long its inline hint runs. This is also the shape #75
+    // turns from chrome into content — every inline-hint banner carries a >2-word tail, so
+    // the day both land, the veto as written would demote exactly the render #75 makes
+    // parseable. The rescue keys on the limit name, not the tail, so it covers those too;
+    // the `/usage-credits` wording itself can't be asserted here because on this branch
+    // isChromeLine still classifies it as furniture, which is what #75 changes.
     for (const live of ["You've hit your session limit · resets 5:20pm · /upgrade to increase your limits",
-      "You've hit your limit · resets 5:20pm (UTC) · run /usage-credits to finish"]) {
+      "You've hit your limit · resets 5:20pm (UTC) · run /upgrade to finish what you're working on"]) {
       assert.equal(findRateLimitMessage([STALE, 'some output', live].join('\n'), [], 12), live);
     }
   });
@@ -540,7 +590,13 @@ describe('findRateLimitMessage', () => {
     assert.equal(findRateLimitMessage([STALE, 'output', live].join('\n'), [], 12), live);
   });
   it('a separator does not count as one of the tail words', () => {
-    for (const live of ['5-hour limit reached · resets 3pm - see above',
+    // Deliberately BARE clause lines, with no limit named. A line that names a limit is
+    // rescued before the tail budget is ever consulted, so pinning this on "5-hour limit
+    // reached · resets 3pm - see above" would assert the rescue and leave the separator
+    // handling itself untested — mutation testing caught exactly that. The bare continuation
+    // line of a multi-line render is the shape that actually reaches the tail check.
+    for (const live of ['· resets 3pm - see above', '· resets 3pm / 10:30 UTC',
+      '5-hour limit reached · resets 3pm - see above',
       '5-hour limit reached · resets 3pm / 10:30 UTC']) {
       assert.equal(findRateLimitMessage([STALE, 'output', live].join('\n'), [], 12), live);
     }


### PR DESCRIPTION
Closes #73.

## Heads-up: this is not option (2)

You picked (2) and sketched a tiered `findRateLimitMessage`. I built it, and three of its properties broke on an adversarial pass — all traceable to **qualifying a candidate by looking at a neighbour**. Implementing your sketch literally (strong-LIMIT = `LIMIT_PATTERNS` minus `/try again in/i`; tier 1 same-line; tier 2 reset with a strong-LIMIT within `WINDOW`; tier 3 unchanged):

- **tier 2 reopens #73 one render up.** With prose below the multi-line banner (`⚠ You've hit your limit` / `· resets 3pm (UTC)`), the banner's own limit line is what qualifies the prose — tier 2 returns `⏺ The API said to try again in 2 minutes …`, which is the reported bug.
- **tier 1 inverts freshness.** On `[banner resets 11:30am, output, "Please try again in 15 minutes"]` the one-line banner satisfies both vocabularies, so tier 1 returns the stale 11:30am: 1 min when the reset had just passed, 21h when it hadn't. And since that parses, #70's latch marks it non-correctable.
- **prose becomes the qualifier.** Strong-LIMIT still contains bare `/usage limit/i` and `/rate limit/i`, and #73's premise is that conversation about the limit is on screen, so `❯ why do I keep hitting the usage limit?` qualifies `⏺ it said to try again in 2 minutes` two lines down.

*(An earlier revision of this description also listed a doubled `candidate→anchor→reset` window and a tail-boundary fallback. Those were defects of my own neighbourhood implementation, not of your sketch — tier 2 as you wrote it returns the reset line itself, one hop, and tier 3 keeps master's answer when qualification fails. Retracted.)*

So I dropped the neighbourhood entirely. If you'd still rather have the tiered shape, say so and I'll implement it with these cases pinned — but I think per-line eligibility is the better trade.

## What this does instead

**A reset-shaped line is eligible unless its shape makes it conversation.** The scan is otherwise untouched: still bottom-up, both historical fallbacks still there, so a vetoed line degrades to exactly what the scan returned before rather than to null. Three per-line signals, no neighbour lookups:

1. **The prompt glyph.** `❯`/`>` introduce the user's own input, which is never a render.
2. **Sentence punctuation.** A render does not end in `.`/`?`/`!`; a sentence does — including one whose *wrapped* continuation happens to begin with the clause (`  try again in 2 minutes, so I'll wait.`). `capture-pane` is called without `-J` (`src/tmux.js`), so a wrap arrives as its own line, and a rule keyed on what *leads* a line reads that continuation as a render.
3. **What follows the reset clause.** A render stops at the time, give or take a timezone qualifier or the rest of a compound duration — `· resets 3pm (UTC)`, `resets 3am NY` (the #6 fixture), `resets in 3 hours 15 minutes`. A sentence keeps going: `…resets 9am tomorrow according to the header`.

The message bullets `⏺`/`●` are deliberately **not** a signal on their own — #63's fixture has a live banner rendering as `● You've hit your session limit · resets 2:10am`, so vetoing the glyph demotes a real render. They mark a line only when what follows them is *not* a limit or reset clause, i.e. the bullet introduces a sentence about one. That test is an exemption inside the veto, so it can only ever rescue a line, never demote one.

### Why a veto rather than an allowlist of banner shapes

The first commit did it the other way round — a line was eligible if it *led* with a known limit or reset clause. Re-reading its own claim of "never worse than master" turned up two defects, fixed in the second commit:

- **Freshness inverted for unrecognised renders.** An allowlist demotes every render this file doesn't know, so an eligible *stale* banner outranks a live one below it. `Claude usage limit reached. Resets at 2pm` — already in the suite as an `isRateLimited` fixture — buries the phrase behind a word, so under a stale `resets 11:30am` it lost the scan: master commits a **16min** wait, the allowlist committed **22h**, latched non-correctable. That is the same failure I cite above for rejecting the tiered proposal, reintroduced from the other side.
- **Wrapped prose still won.** The wrap can land right before the clause, leaving `  try again in 2 minutes, so I will wait` leading with a reset. The exact bug in #73, one wrap away; #73's own repro line is 71 columns wide.

A veto only ever demotes what it can identify, so an unrecognised render keeps the freshness ordering it had before. `LIMIT_PATTERNS`, `RESET_PATTERNS` and `SPEND_LIMIT` stay byte-identical to master — nothing asks "is there a limit nearby" any more, so your invariant is satisfied by there being no such qualification at all.

### Renders the veto wrongly claimed, found in review (third commit)

Five shapes the pre-#73 scan returned and the second commit demoted. All five now agree with master again, each pinned by a test:

| render | why it was vetoed |
|---|---|
| `● You've hit your session limit · resets 2:10am` | the bullet glyph, before it became conditional |
| `· resets in 3 hours 15 minutes` | the clause matcher stops at the first unit, so `hours 15 minutes` read as a sentence carrying on |
| `Please try again in 4 hours and 12 minutes` | same |
| `5-hour limit resets 3pm, weekly limit resets 9am Monday` | two clauses of the *same* matcher: `exec()` without `/g` measured from the first |
| `· resets 3pm - see above`, `· resets 3pm / 10:30 UTC` | a lone separator counted as one of the two tail words |

## Verification

Differential over a 792-pane corpus (11 banner forms × 12 noise shapes × stale banner × chrome), scored on "does the result carry the live banner's reset time":

```
this branch       792/792 correct
pre-#73 master     72/792      -> 720 fixed, 0 regressions
first cut (f77e878) 390/792     -> 402 fixed, 0 regressions
```

`isRateLimited`, `resumedAfterLimit`, `isRateLimitOptionsPrompt`, `isWorking`, `menuStepsToWaitOption`: **0 behavioural diffs** vs pre-#73 master across 24,565 calls (4,913 panes × 5 detectors).

Monitor level:

| scenario | master | this PR |
|---|---|---|
| banner + model prose below | 3min | **300min** |
| banner + user-typed text below | 3min | **300min** |
| banner + *wrapped* prose below | 3min | **300min** |
| multi-line render + prose below | 3min | **150min** |
| stale banner + fresh unrecognised render | 16min | **16min** (first cut: 1320min) |
| banner alone (control) | 300min | **300min** |

**Mutation testing**, since the first draft's tests passed while the code was wrong — 13 mutants, all killed, with one test per signal shaped so the other two don't fire:

```
veto removed                        duration tail not consumed
prompt-glyph signal dropped         parentheses not stripped
bullet signal dropped               separator tokens count as words
bullet exemption removed            tail budget 0 / infinite
sentence-punctuation dropped        clause scan not global
eligibility pass scans top-down     skip() dropped from the eligibility pass
```

Suite: **491 pass, 0 fail**. (`reconcile.test.js`'s cross-process hold test is flaky on master too — ~50% locally, unrelated to this change.)

## Known boundary

An **unglyphed, unpunctuated continuation that begins with the clause and ends within two words** still wins — `│  try again in 20 minutes  │` (a wrapped input-box row), or a wrap whose sentence carries on into the *next* line:

```
⏺ The API told me I should
  try again in 2 minutes
  before the window rolls
```

This one is not closable per line: a *banner* that wraps has exactly the same shape — `⚠ You've hit your session limit ·` / `  resets 8:40pm (Europe/London)` — and vetoing it would drop the only line carrying the time. Both cases are unchanged from master, which returns the same lines.

## Commits

1. `f77e878` — the fix itself: prefer a live banner over reset-shaped prose below it.
2. `98ebc46` — state the rule as a veto rather than an allowlist, closing the freshness inversion and the wrapped-prose hole.
3. `8e911ff` — narrow the veto to shapes that are only ever conversation, restoring the five renders above.
