### PR TITLE
fix(patterns): four spend-limit render defects (#71 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A banner that names `/usage-credits` inline is no longer treated as UI furniture.** The
+  chrome allowlist matched the hint anywhere on a line, but the companion row is not the
+  only place it renders — a session banner can carry it inline ("You've hit your session
+  limit · resets 5:20pm · run /usage-credits to finish"), and the spend-limit banner always
+  does. Those lines were stripped as chrome, so the tail dropped the only line naming the
+  limit: the spend banner needed a special case to be seen at all, and a session banner's
+  reset time was invisible to the parse, sending the monitor to the `fallbackWaitHours`
+  default instead of the real reset. The entry is now anchored to the hint *leading* its
+  row, which covers every banner that mentions it — and removes both the special case and
+  its forward reference to a constant declared 100 lines below.
+
 ## [0.7.1] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its forward reference to a constant declared 100 lines below.
 - **Spend-limit render shapes that were total misses (#71 follow-up).** The banner pattern
   admitted only the `⎿`/`└` echo markers, so the `⚠`- and `·`-prefixed renders — markers
-  this file already expects on limit banners — were never matched; and it required an ASCII
-  apostrophe in "you've" while the qualifier beside it already admitted `’`, so a render in
-  typographic quotes was missed too. Both compounded with the chrome misclassification
-  above: invisible rather than merely unanchored.
+  this file already expects on limit banners — were never matched; the `⚠` in emoji
+  presentation (`⚠️`, U+26A0 + U+FE0F) failed on the variation selector; the **boxed** form
+  (`│ ⚠ You've hit … │`, the render this suite already pins for session banners) was not
+  admitted at all, and unlike a session banner the spend render has no reset line to fall
+  back on; and the pattern required an ASCII apostrophe in "you've" while the qualifier
+  beside it already admitted `’`, so a render in typographic quotes was missed too. All of
+  them compounded with the chrome misclassification above: invisible rather than merely
+  unanchored. The apostrophe is now *required* in the other direction — "youve hit your
+  monthly spend limit" no longer walks the one detection path that needs no reset time.
 - **A wrapped or bulleted quotation of the spend banner no longer false-fires a wait.**
   `^\s*` is not an anchor when model output wraps with a hanging indent: a continuation line
   beginning "You've hit your org's monthly spend limit …" entered a 5-hour wait and typed
-  retries into an idle session. A render starts at column 0, behind a flush-left `⚠`/`·`
-  banner marker, or behind a `⎿`/`└` tool-echo marker (the only ones that legitimately render
-  indented, as children of the notice above them). An indented `⚠`/`·`/`•` is a prose bullet
-  — the shape a model quoting the banner actually produces — and no longer counts as a
-  render. (Trailing punctuation deliberately stays out of it — "You've hit your monthly spend
-  limit." is a real render with a full stop.)
+  retries into an idle session. A render starts at column 0, behind a box border, behind a
+  flush-left `⚠`/`·` banner marker, or behind a `⎿`/`└` tool-echo marker (the only ones that
+  legitimately render indented, as children of the notice above them). An indented `⚠`/`·`/`•`
+  is a prose bullet — the shape a model quoting the banner actually produces — and no longer
+  counts as a render. (Trailing punctuation deliberately stays out of it — "You've hit your
+  monthly spend limit." is a real render with a full stop.) The column-0 rule is a rendering
+  assumption, so it has one escape hatch: when the **standalone** `/usage-credits` companion
+  row renders below the banner — evidence a quotation essentially never carries, since it
+  reproduces the banner line and not the separate row beneath it — the indented form is
+  accepted, keeping a real render printed one space too far right, or wrapped.
 
 ## [0.7.1] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   apostrophe in "you've" while the qualifier beside it already admitted `’`, so a render in
   typographic quotes was missed too. Both compounded with the chrome misclassification
   above: invisible rather than merely unanchored.
-- **A wrapped quotation of the spend banner no longer false-fires a wait.** `^\s*` is not an
-  anchor when model output wraps with a hanging indent: a continuation line beginning
-  "You've hit your org's monthly spend limit …" entered a 5-hour wait and typed retries into
-  an idle session. A render starts at column 0 or behind an echo marker; indented with no
-  marker is a wrap. (Trailing punctuation deliberately stays out of it — "You've hit your
-  monthly spend limit." is a real render with a full stop.)
+- **A wrapped or bulleted quotation of the spend banner no longer false-fires a wait.**
+  `^\s*` is not an anchor when model output wraps with a hanging indent: a continuation line
+  beginning "You've hit your org's monthly spend limit …" entered a 5-hour wait and typed
+  retries into an idle session. A render starts at column 0, behind a flush-left `⚠`/`·`
+  banner marker, or behind a `⎿`/`└` tool-echo marker (the only ones that legitimately render
+  indented, as children of the notice above them). An indented `⚠`/`·`/`•` is a prose bullet
+  — the shape a model quoting the banner actually produces — and no longer counts as a
+  render. (Trailing punctuation deliberately stays out of it — "You've hit your monthly spend
+  limit." is a real render with a full stop.)
 
 ## [0.7.1] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   apostrophe in "you've" while the qualifier beside it already admitted `’`, so a render in
   typographic quotes was missed too. Both compounded with the chrome misclassification
   above: invisible rather than merely unanchored.
+- **A wrapped quotation of the spend banner no longer false-fires a wait.** `^\s*` is not an
+  anchor when model output wraps with a hanging indent: a continuation line beginning
+  "You've hit your org's monthly spend limit …" entered a 5-hour wait and typed retries into
+  an idle session. A render starts at column 0 or behind an echo marker; indented with no
+  marker is a wrap. (Trailing punctuation deliberately stays out of it — "You've hit your
+  monthly spend limit." is a real render with a full stop.)
 
 ## [0.7.1] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default instead of the real reset. The entry is now anchored to the hint *leading* its
   row, which covers every banner that mentions it — and removes both the special case and
   its forward reference to a constant declared 100 lines below.
+- **Spend-limit render shapes that were total misses (#71 follow-up).** The banner pattern
+  admitted only the `⎿`/`└` echo markers, so the `⚠`- and `·`-prefixed renders — markers
+  this file already expects on limit banners — were never matched; and it required an ASCII
+  apostrophe in "you've" while the qualifier beside it already admitted `’`, so a render in
+  typographic quotes was missed too. Both compounded with the chrome misclassification
+  above: invisible rather than merely unanchored.
 
 ## [0.7.1] - 2026-08-14
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -29,8 +29,16 @@ const USAGE_CREDITS = /\/usage-credits\b/i;
 // classified those banners as furniture: contentTail stripped them, so the only line
 // naming the limit — and, for a session banner, the only line carrying the reset time —
 // was invisible to every detector. The companion always renders on its own row (indented,
-// or behind the ⎿/└/· echo marker).
-const USAGE_CREDITS_HINT = /^\s*(?:[⎿└·]\s*)*\/usage-credits\b/i;
+// or behind ONE ⎿/└/· echo marker — no render stacks them), so this is the same literal as
+// the signal above with a leading anchor, composed from it rather than re-spelled.
+//
+// Leading indentation is admitted here and REFUSED for the same `·` in SPEND_LIMIT below.
+// The two constants answer different questions about opposite failure costs: this one asks
+// "is this row furniture?" about a row the TUI renders INDENTED in every observed pane, and
+// over-matching costs at most a stripped line that carries no limit signal of its own.
+// SPEND_LIMIT asks "is this row a live render?" about a line the TUI prints flush left, and
+// over-matching there commits a multi-hour wait with no reset time to sanity-check it.
+const USAGE_CREDITS_HINT = new RegExp(`^\\s*(?:[⎿└·]\\s*)?${USAGE_CREDITS.source}`, 'i');
 
 // Indicators that Claude is mid-flight and the pane is NOT in a terminal error state.
 // Two kinds: the streaming footer, and Claude Code's OWN internal-retry indicator.
@@ -171,36 +179,59 @@ const RESET_PATTERNS = [
 // spend limit …"). The remaining anchors are the /usage-credits companion in the live
 // region, and the wait produced downstream being the bounded, correctable fallback.
 //
-// Two things the shape has to tolerate, neither of which it did — and each a TOTAL miss,
+// Four things the shape has to tolerate, none of which it did — and each a TOTAL miss,
 // not a weaker match, because a banner naming /usage-credits inline that fails this pattern
 // is also the banner nothing else in the file recognises:
 //   - THE MARKER VARIES. ⚠ and · prefix limit renders elsewhere in this file (see the TUI
 //     sketch above); admitting only ⎿/└ made "⚠ You've hit your org's monthly spend limit …"
 //     invisible.
+//   - ⚠ ALSO ARRIVES IN EMOJI PRESENTATION. "⚠️" is U+26A0 + U+FE0F, and the variation
+//     selector is neither whitespace nor part of the phrase, so it failed the whole pattern.
+//   - THE BANNER CAN BE BOXED. "│ ⚠ You've hit your limit │" is the render this suite
+//     already pins for SESSION banners; those survive on the unanchored LIMIT+RESET pair,
+//     but the spend banner has no reset line, so this pattern is its only path in.
 //   - APOSTROPHES ARE TYPOGRAPHIC. The qualifier class already admits ’ for "org’s"; the
-//     "you've" ahead of it did not, so a render in curly quotes was missed as well.
+//     "you've" ahead of it did not, so a render in curly quotes was missed as well. The
+//     apostrophe itself is REQUIRED though — every real render prints one, and without it
+//     "youve hit your monthly spend limit" walks the one path into a wait that needs no
+//     reset time to corroborate it.
 //
 // And one it has to EXCLUDE: `^\s*` is not an anchor. Model output wraps with a hanging
 // indent, so a continuation line begins with whitespace and then whatever the sentence was
 // up to — quoting the banner ("⏺ The team banner reads:" / "  You've hit your org's monthly
 // spend limit · …") false-fired a 5h wait and then typed retries into an idle session. A
-// render starts at column 0 or behind an echo marker; indented with no marker is a wrap.
-// (A quotation that lands at column 0 still fires; the remaining anchors are the live-region
-// gate and the bounded, correctable fallback the wait lands on.) Trailing punctuation is
-// deliberately NOT a signal: "You've hit your monthly spend limit." — the individual variant
-// from the #71 report — is a real render with a full stop.
+// render starts at column 0, behind a box border, or behind an echo marker; indented with
+// none of those is a wrap. (A quotation that lands at column 0 still fires; the remaining
+// anchors are the live-region gate and the bounded, correctable fallback the wait lands on.)
+// Trailing punctuation is deliberately NOT a signal: "You've hit your monthly spend limit."
+// — the individual variant from the #71 report — is a real render with a full stop.
 //
-// WHICH MARKER MAY BE INDENTED IS THEREFORE PART OF THE SHAPE, and the two classes differ:
+// WHICH PREFIX MAY BE INDENTED IS THEREFORE PART OF THE SHAPE, and the classes differ:
 //   - ⎿/└ are TOOL-ECHO markers. They render as indented children of the notice above them
 //     ("● Agent \"…\" finished" / "  ⎿ You've hit …"), so they must be allowed leading space.
 //     Neither is a character prose reaches for, so that costs nothing.
-//   - ⚠/· are BANNER markers, and the TUI renders them flush left — every render in this
-//     file and its suite sits at column 0. Indented, they are prose BULLETS: a model quoting
-//     the banner bullets it far more often than it hangs it under a bare indent, so admitting
-//     them there reopens the very wrap hole the paragraph above closes. Column 0 only.
-// (A leading `•` is not admitted at all: no render in this file uses it, and it is the one
-// glyph that is purely a prose bullet.)
-const SPEND_LIMIT = /^(?:\s*[⎿└]\s*|[⚠·]\s*)?you['’]?ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/i;
+//   - │ is a BOX BORDER, and a box is indented or not as a whole — it carries its own
+//     column-0 evidence, so leading space costs nothing there either.
+//   - ⚠/· are BARE BANNER markers, and outside a box the TUI prints them flush left.
+//     Indented, they are prose BULLETS: a model quoting the banner bullets it far more often
+//     than it hangs it under a bare indent, so admitting them there reopens the very wrap
+//     hole the paragraph above closes.
+// (● / ⏺ stay out entirely: the assistant-message glyph, so "⏺ You've hit …" is likelier a
+// model quoting the banner than a render — the most dangerous prefix that could be added,
+// with no reset time to check it against. A leading • stays out for the mirror-image reason:
+// no render uses it, and it is purely a prose bullet.)
+const SPEND_LIMIT_BODY = /you['’]ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/;
+const SPEND_LIMIT = new RegExp(
+  `^(?:\\s*[⎿└]\\s*|\\s*│\\s*(?:[⚠·]\\uFE0F?\\s*)?|[⚠·]\\uFE0F?\\s*)?${SPEND_LIMIT_BODY.source}`, 'i');
+// The column-0 rule above is a rendering assumption, and a one-space margin ahead of ⚠ — or
+// a genuine hanging wrap of a REAL banner — is a total miss when it turns out wrong. This is
+// the escape hatch: same banner words, no column-0 rule, and consulted ONLY when the pane's
+// companion is a STANDALONE row rather than a hint the banner names inline (see
+// isRateLimited). Quoting prose reproduces the banner LINE; it essentially never also
+// reproduces the separate "/usage-credits to finish…" row beneath it, so that row
+// substitutes for the shape evidence the indent gave up. Prose bullet glyphs (•, -, *) stay
+// out even here: no render prints them at any indent.
+const SPEND_LIMIT_INDENTED = new RegExp(`^\\s*(?:[⚠·]\\uFE0F?\\s*)?${SPEND_LIMIT_BODY.source}`, 'i');
 
 const WINDOW = 6;
 
@@ -298,11 +329,19 @@ export function isRateLimited(text, customPatterns = [], tailLines = 0) {
     // The SPEND_LIMIT alternative (#71) is the one exception to the reset-anchor rule:
     // that banner never prints a reset time, so the companion + live-region gates above
     // are its whole defense, and the pattern stays banner-shaped to compensate.
-    if (companionIdx !== -1
-        && all.slice(companionIdx + 1).every(isChromeLine)
-        && (hasNearbyMatch(all, companionIdx, RESET_PATTERNS, fullMask)
-          || hasNearbyMatch(all, companionIdx, [SPEND_LIMIT], fullMask))) {
-      return true;
+    if (companionIdx !== -1 && all.slice(companionIdx + 1).every(isChromeLine)) {
+      // …unless the companion we found is the STANDALONE row rather than a hint named
+      // inline by the banner itself. That row is a liveness signal a quotation essentially
+      // never carries, so it stands in for the banner's column-0 shape and the indent-
+      // tolerant pattern is allowed in — recovering a real render printed one space too far
+      // right, or wrapped. companionIdx is the LAST /usage-credits line, so "the companion
+      // is its own row" is exactly USAGE_CREDITS_HINT applied to it.
+      const spendShapes = USAGE_CREDITS_HINT.test(all[companionIdx])
+        ? [SPEND_LIMIT, SPEND_LIMIT_INDENTED] : [SPEND_LIMIT];
+      if (hasNearbyMatch(all, companionIdx, RESET_PATTERNS, fullMask)
+          || hasNearbyMatch(all, companionIdx, spendShapes, fullMask)) {
+        return true;
+      }
     }
   }
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -22,6 +22,15 @@ export function stripAnsi(text) {
 // doubles as furniture in the chrome allowlist and as the high-confidence live-limit
 // backstop signal below — one source of truth for both.
 const USAGE_CREDITS = /\/usage-credits\b/i;
+// …but only the SIGNAL may match the hint anywhere on the line. As FURNITURE it has to
+// LEAD its line, because a banner can name the hint INLINE — "You've hit your session
+// limit · resets 5:20pm · run /usage-credits to finish" is one line, not two, and the
+// spend-limit render (#71) always carries it. Matched loosely, the chrome allowlist
+// classified those banners as furniture: contentTail stripped them, so the only line
+// naming the limit — and, for a session banner, the only line carrying the reset time —
+// was invisible to every detector. The companion always renders on its own row (indented,
+// or behind the ⎿/└/· echo marker).
+const USAGE_CREDITS_HINT = /^\s*(?:[⎿└·•]\s*)*\/usage-credits\b/i;
 
 // Indicators that Claude is mid-flight and the pane is NOT in a terminal error state.
 // Two kinds: the streaming footer, and Claude Code's OWN internal-retry indicator.
@@ -86,7 +95,8 @@ const CHROME_LINE = [
   /\/clear to save/i,                               // "new task? /clear to save …k tokens" — anchored to the
                                                      // save hint; bare /new task\?/ matched prose questions
                                                      // ("Should I start the new task?")
-  USAGE_CREDITS,                                     // live-limit companion hint (shared w/ the backstop)
+  USAGE_CREDITS_HINT,                                // live-limit companion ROW — anchored, so a banner
+                                                     // naming the hint mid-line stays content
   /^\s*[✻✢✽✳✴✶✷]\s/,                                 // status spinner ("✻ Brewed for …")
   // Usage-meter statusline rows (#61, ccusage-style). The "⟳ resets in 1 hr 47 min"
   // countdown matches RESET_PATTERNS and renders permanently at the very bottom, BELOW
@@ -106,12 +116,11 @@ const CHROME_LINE = [
 ];
 // A live working footer ("✻ Cogitating… (esc to interrupt)") matches the spinner glyph
 // pattern above, so it must be excluded explicitly — it is live content, never furniture.
-// Likewise the spend-limit banner (#71): it carries "/usage-credits" INLINE ("…spend
-// limit · run /usage-credits to raise it"), so the companion entry would classify the
-// banner itself as furniture and findRateLimitMessage would skip the only line naming
-// the limit. A line that IS a limit banner is content, never chrome.
-const isChromeLine = (l) => !isWorkingLine(l) && !SPEND_LIMIT.test(l)
-  && CHROME_LINE.some((r) => r.test(l));
+// The spend-limit banner (#71) needed a second exemption here for the same reason a session
+// banner does: it names /usage-credits inline. Anchoring the companion entry to the hint
+// LEADING its row covers every banner that mentions it, so the special case is gone — along
+// with its forward reference to a const declared 100 lines further down.
+const isChromeLine = (l) => !isWorkingLine(l) && CHROME_LINE.some((r) => r.test(l));
 
 // Last `n` lines AFTER dropping trailing chrome, so a tall widget / input box below a
 // banner doesn't consume the window budget. Operates on an array of already-split lines.

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -166,11 +166,19 @@ const RESET_PATTERNS = [
 // "You've hit your org's monthly spend limit · run /usage-credits …" carries NO reset,
 // yet both reporters confirmed the underlying 5h block resets and waiting works. With no
 // reset line to anchor on, the shape itself carries the false-positive defense: both real
-// renders START the line with "You've hit …" (optionally behind the ⎿/└ echo marker),
-// while prose explaining spend limits references them mid-sentence ("when you hit your
-// monthly spend limit …"). The remaining anchors are the /usage-credits companion in the
-// live region, and the wait produced downstream being the bounded, correctable fallback.
-const SPEND_LIMIT = /^\s*(?:[⎿└]\s*)?you'?ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/i;
+// renders START the line with "You've hit …" (optionally behind an echo marker), while
+// prose explaining spend limits references them mid-sentence ("when you hit your monthly
+// spend limit …"). The remaining anchors are the /usage-credits companion in the live
+// region, and the wait produced downstream being the bounded, correctable fallback.
+//
+// Two things the shape has to tolerate, neither of which it did — and each a TOTAL miss,
+// not a weaker match, because a banner naming /usage-credits inline that fails this pattern
+// is also the banner nothing else in the file recognises:
+//   - THE ECHO MARKER VARIES. ⚠ and · prefix limit renders elsewhere in this file; admitting
+//     only ⎿/└ made "⚠ You've hit your org's monthly spend limit …" invisible.
+//   - APOSTROPHES ARE TYPOGRAPHIC. The qualifier class already admits ’ for "org’s"; the
+//     "you've" ahead of it did not, so a render in curly quotes was missed as well.
+const SPEND_LIMIT = /^\s*(?:[⎿└⚠·•]\s*)*you['’]?ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/i;
 
 const WINDOW = 6;
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -178,7 +178,17 @@ const RESET_PATTERNS = [
 //     only ⎿/└ made "⚠ You've hit your org's monthly spend limit …" invisible.
 //   - APOSTROPHES ARE TYPOGRAPHIC. The qualifier class already admits ’ for "org’s"; the
 //     "you've" ahead of it did not, so a render in curly quotes was missed as well.
-const SPEND_LIMIT = /^\s*(?:[⎿└⚠·•]\s*)*you['’]?ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/i;
+//
+// And one it has to EXCLUDE: `^\s*` is not an anchor. Model output wraps with a hanging
+// indent, so a continuation line begins with whitespace and then whatever the sentence was
+// up to — quoting the banner ("⏺ The team banner reads:" / "  You've hit your org's monthly
+// spend limit · …") false-fired a 5h wait and then typed retries into an idle session. A
+// render starts at column 0 or behind an echo marker; indented with no marker is a wrap.
+// (A quotation that lands at column 0 still fires; the remaining anchors are the live-region
+// gate and the bounded, correctable fallback the wait lands on.) Trailing punctuation is
+// deliberately NOT a signal: "You've hit your monthly spend limit." — the individual variant
+// from the #71 report — is a real render with a full stop.
+const SPEND_LIMIT = /^(?:(?:\s*[⎿└⚠·•])+\s*)?you['’]?ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/i;
 
 const WINDOW = 6;
 

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -30,7 +30,7 @@ const USAGE_CREDITS = /\/usage-credits\b/i;
 // naming the limit — and, for a session banner, the only line carrying the reset time —
 // was invisible to every detector. The companion always renders on its own row (indented,
 // or behind the ⎿/└/· echo marker).
-const USAGE_CREDITS_HINT = /^\s*(?:[⎿└·•]\s*)*\/usage-credits\b/i;
+const USAGE_CREDITS_HINT = /^\s*(?:[⎿└·]\s*)*\/usage-credits\b/i;
 
 // Indicators that Claude is mid-flight and the pane is NOT in a terminal error state.
 // Two kinds: the streaming footer, and Claude Code's OWN internal-retry indicator.
@@ -174,8 +174,9 @@ const RESET_PATTERNS = [
 // Two things the shape has to tolerate, neither of which it did — and each a TOTAL miss,
 // not a weaker match, because a banner naming /usage-credits inline that fails this pattern
 // is also the banner nothing else in the file recognises:
-//   - THE ECHO MARKER VARIES. ⚠ and · prefix limit renders elsewhere in this file; admitting
-//     only ⎿/└ made "⚠ You've hit your org's monthly spend limit …" invisible.
+//   - THE MARKER VARIES. ⚠ and · prefix limit renders elsewhere in this file (see the TUI
+//     sketch above); admitting only ⎿/└ made "⚠ You've hit your org's monthly spend limit …"
+//     invisible.
 //   - APOSTROPHES ARE TYPOGRAPHIC. The qualifier class already admits ’ for "org’s"; the
 //     "you've" ahead of it did not, so a render in curly quotes was missed as well.
 //
@@ -188,7 +189,18 @@ const RESET_PATTERNS = [
 // gate and the bounded, correctable fallback the wait lands on.) Trailing punctuation is
 // deliberately NOT a signal: "You've hit your monthly spend limit." — the individual variant
 // from the #71 report — is a real render with a full stop.
-const SPEND_LIMIT = /^(?:(?:\s*[⎿└⚠·•])+\s*)?you['’]?ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/i;
+//
+// WHICH MARKER MAY BE INDENTED IS THEREFORE PART OF THE SHAPE, and the two classes differ:
+//   - ⎿/└ are TOOL-ECHO markers. They render as indented children of the notice above them
+//     ("● Agent \"…\" finished" / "  ⎿ You've hit …"), so they must be allowed leading space.
+//     Neither is a character prose reaches for, so that costs nothing.
+//   - ⚠/· are BANNER markers, and the TUI renders them flush left — every render in this
+//     file and its suite sits at column 0. Indented, they are prose BULLETS: a model quoting
+//     the banner bullets it far more often than it hangs it under a bare indent, so admitting
+//     them there reopens the very wrap hole the paragraph above closes. Column 0 only.
+// (A leading `•` is not admitted at all: no render in this file uses it, and it is the one
+// glyph that is purely a prose bullet.)
+const SPEND_LIMIT = /^(?:\s*[⎿└]\s*|[⚠·]\s*)?you['’]?ve\s+(?:hit|exceeded|reached)\s+(?:your|the)\s+(?:[\w'’-]+\s+){0,3}spend limit/i;
 
 const WINDOW = 6;
 

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -492,6 +492,21 @@ describe('processOneTick', () => {
     assert.equal(s._waitIsFallback, true);
   });
 
+  // --- A banner that names /usage-credits INLINE was classified as chrome, so the tail
+  //     dropped the only line carrying the reset time: the limit was still detected via the
+  //     live-region backstop, but the wait fell back to fallbackWaitHours instead of the
+  //     real reset — and the latch marks a fallback correctable, so the monitor re-derives
+  //     it on every poll for the whole window. ---
+  it('derives the real reset time from a banner naming /usage-credits inline', async () => {
+    const pane = [`${bannerAt(3 * 3600_000)} · run /usage-credits to finish`, '', '❯ '].join('\n');
+    const t = mockTmux(pane);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', DEFAULT_CONFIG, () => true), 'waiting');
+    assert.equal(s._waitIsFallback, false);          // parsed, not the fallbackWaitHours default
+    const secs = (s.waitUntil - Date.now()) / 1000;
+    assert.ok(secs > 2.5 * 3600 && secs < 3.5 * 3600, `expected ~3h from the banner, got ${Math.round(secs)}s`);
+  });
+
   // --- Regression: a LIVE limit banner pushed far up the pane by UI chrome (a tall task
   //     widget + input box + footer) must still be detected. Observed live: a session-limit
   //     banner ~16 lines up behind a task list went unretried for ~54 min because the fixed

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -404,6 +404,22 @@ describe('org/monthly spend-limit banner (#71)', () => {
   it('findRateLimitMessage returns the spend line (unparseable → bounded fallback downstream)', () => {
     assert.match(findRateLimitMessage(spendRender, [], 12), /spend limit/i);
   });
+
+  // --- Render shapes the banner pattern has to tolerate. Each was a total miss: the shape
+  //     failed, and a spend banner nothing recognises is also the banner nothing else in
+  //     the file can fall back on. ---
+  const withCompanion = (banner) => [banner,
+    "     /usage-credits to finish what you're working on.", '', '❯ '].join('\n');
+  for (const [label, marker] of [['⚠', '⚠ '], ['·', '· '], ['└ echo', '  └ ']]) {
+    it(`detects the spend banner behind the ${label} marker`, () => {
+      assert.equal(isRateLimited(withCompanion(marker + SPEND_ORG), [], 12), true);
+    });
+  }
+  it('detects the spend banner written with typographic apostrophes', () => {
+    // The qualifier class already admitted ’ for "org’s"; the "you’ve" ahead of it did not.
+    const curly = "You’ve hit your org’s monthly spend limit · run /usage-credits to raise it";
+    assert.equal(isRateLimited(withCompanion(curly), [], 12), true);
+  });
 });
 
 describe('a banner that names /usage-credits inline is content, not chrome', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -420,6 +420,17 @@ describe('org/monthly spend-limit banner (#71)', () => {
     const curly = "You’ve hit your org’s monthly spend limit · run /usage-credits to raise it";
     assert.equal(isRateLimited(withCompanion(curly), [], 12), true);
   });
+  it('does NOT fire on a WRAPPED quotation of the banner', () => {
+    // Model output wraps with a hanging indent, so the continuation begins at whitespace
+    // and then whatever the sentence was up to. Indented with no echo marker is a wrap,
+    // not a render — otherwise this false-fires a 5h wait on an idle session.
+    const pane = ['⏺ The team banner reads:', `  ${SPEND_ORG}`, '', '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
+  it('still detects the render behind an INDENTED echo marker', () => {
+    // The exclusion is "indented with no marker", not "indented": the ⎿ echo form is real.
+    assert.equal(isRateLimited(withCompanion(`  ⎿  ${SPEND_ORG}`), [], 12), true);
+  });
 });
 
 describe('a banner that names /usage-credits inline is content, not chrome', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -406,6 +406,38 @@ describe('org/monthly spend-limit banner (#71)', () => {
   });
 });
 
+describe('a banner that names /usage-credits inline is content, not chrome', () => {
+  // The companion hint renders on its own row, but a banner can also name it mid-line. The
+  // chrome allowlist matched the hint anywhere, so those banners were stripped as
+  // furniture: the limit was still detected via the live-region backstop, but the line
+  // carrying the reset time was invisible to the parse, and the monitor took the 5h
+  // fallback instead of waking at the real time.
+  const inlineHint = "You've hit your session limit · resets 5:20pm (UTC) · run /usage-credits to finish";
+  it('parses the reset time off a banner naming the hint inline', () => {
+    const pane = [inlineHint, '', '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), true);
+    assert.equal(findRateLimitMessage(pane, [], 12), inlineHint);
+  });
+  it('does NOT fire on prose that names the hint mid-sentence', () => {
+    // The hint stops being furniture on these lines, so they become content the detectors
+    // can see. They must still fail on their own merits: no reset time, no banner shape.
+    for (const pane of [
+      ['⏺ When you hit your monthly spend limit, run /usage-credits', '', '❯ '],
+      ['⏺ You can run /usage-credits when you hit your usage limit', '', '❯ '],
+    ]) assert.equal(isRateLimited(pane.join('\n'), [], 12), false);
+  });
+  it('still treats the companion ROW as chrome', () => {
+    // Anchored, not abandoned: the hint leading its line is still furniture, indented or
+    // behind an echo marker, or the tail budget goes on it instead of on the banner.
+    const pane = ["You've hit your session limit · resets 2am (Europe/Zurich)",
+      "     /usage-credits to finish what you're working on.",
+      '', '✻ Brewed for 12m 3s', '', '  8 tasks (4 done, 1 in progress, 3 open)',
+      '  □ a', '  □ b', '  □ c', '  □ d', '  □ e', '  □ f', '  □ g',
+      '', '──────', '❯ ', '──────'].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), true);
+  });
+});
+
 // --- Usage-meter statusline footer (#61) ---
 // A ccusage-style statusline renders a permanent usage meter at the very bottom of the
 // pane: "current ●●●●●●●●●● 100%  ⟳ resets in 1 hr 47 min". That row matches

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -431,6 +431,17 @@ describe('org/monthly spend-limit banner (#71)', () => {
     // The exclusion is "indented with no marker", not "indented": the ⎿ echo form is real.
     assert.equal(isRateLimited(withCompanion(`  ⎿  ${SPEND_ORG}`), [], 12), true);
   });
+  it('does NOT fire on an indented BULLET quotation of the banner', () => {
+    // The same wrap the test above pins, written as a list item — the likelier shape by far,
+    // since a model quoting a banner bullets it. ⚠/· earn their place at column 0 (that is
+    // how the TUI renders them, here and everywhere else in this file), but INDENTED they
+    // are prose bullets, and admitting them there reopens the wrap hole. The tool-echo
+    // markers ⎿/└ are the only ones that legitimately render indented.
+    for (const bullet of ['·', '•', '-', '*']) {
+      const pane = ['⏺ Two things could be happening:', `  ${bullet} ${SPEND_ORG}`, '', '❯ '].join('\n');
+      assert.equal(isRateLimited(pane, [], 12), false, `bullet ${bullet} fired`);
+    }
+  });
 });
 
 describe('a banner that names /usage-credits inline is content, not chrome', () => {

--- a/test/patterns.test.js
+++ b/test/patterns.test.js
@@ -436,10 +436,66 @@ describe('org/monthly spend-limit banner (#71)', () => {
     // since a model quoting a banner bullets it. ⚠/· earn their place at column 0 (that is
     // how the TUI renders them, here and everywhere else in this file), but INDENTED they
     // are prose bullets, and admitting them there reopens the wrap hole. The tool-echo
-    // markers ⎿/└ are the only ones that legitimately render indented.
+    // markers ⎿/└ are the only ones that legitimately render indented. What the quotation
+    // never brings with it is the STANDALONE companion row — see the escape-hatch tests below.
     for (const bullet of ['·', '•', '-', '*']) {
       const pane = ['⏺ Two things could be happening:', `  ${bullet} ${SPEND_ORG}`, '', '❯ '].join('\n');
       assert.equal(isRateLimited(pane, [], 12), false, `bullet ${bullet} fired`);
+    }
+  });
+  it('detects the BOXED spend render', () => {
+    // The suite pins the boxed form for SESSION banners ("│ ⚠ You've hit your limit │"),
+    // which survive on the unanchored LIMIT+RESET pair. The spend banner has no reset line,
+    // so the shape pattern is its only path in and the border has to be part of the shape.
+    const boxed = ['╭──────────╮', `│ ⚠ ${SPEND_ORG} │`,
+      "│      /usage-credits to finish what you're working on. │",
+      '╰──────────╯', '', '❯ '].join('\n');
+    assert.equal(isRateLimited(boxed, [], 12), true);
+    assert.equal(isRateLimited(withCompanion(`│ ${SPEND_ORG} │`), [], 12), true);
+  });
+  it('detects the ⚠ marker in EMOJI presentation ("⚠️" = U+26A0 U+FE0F)', () => {
+    // The variation selector is neither whitespace nor part of the phrase, so an unhandled
+    // U+FE0F failed the whole pattern — a total miss, not a weaker match.
+    assert.equal(isRateLimited(withCompanion(`⚠️ ${SPEND_ORG}`), [], 12), true);
+    assert.equal(isRateLimited(withCompanion(`⚠️${SPEND_ORG}`), [], 12), true);
+  });
+  it('does NOT fire without the apostrophe ("youve hit your monthly spend limit")', () => {
+    // Every real render prints one. This is the only path into a wait that needs no reset
+    // time to corroborate it, so the cheap tightening is worth having.
+    const pane = withCompanion('youve hit your monthly spend limit');
+    assert.equal(isRateLimited(pane, [], 12), false);
+  });
+
+  // --- The standalone companion ROW as a substitute for column-0 shape. The flush-left rule
+  //     is a rendering assumption; when it turns out wrong the cost is a total miss. A model
+  //     quoting a banner reproduces the banner LINE — essentially never the separate
+  //     "/usage-credits to finish…" row beneath it — so that row is the liveness evidence
+  //     that lets the indent-tolerant pattern in. ---
+  it('detects a render printed one space right of column 0, given the companion row', () => {
+    assert.equal(isRateLimited(withCompanion(` ⚠ ${SPEND_ORG}`), [], 12), true);
+  });
+  it('detects an INDENTED markerless render, given the companion row', () => {
+    // Master detected this; the wrap veto took it out even when the genuine companion row
+    // rendered directly below. The row buys it back without reopening the quotation hole.
+    const pane = ['  ' + "You've hit your monthly spend limit.",
+      "     /usage-credits to finish what you're working on.", '', '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), true);
+  });
+  it('KNOWN BOUNDARY: a two-row quotation reproducing the companion row too DOES fire', () => {
+    // The disclosed cost of the rule above. A quotation that reproduces the banner AND the
+    // standalone companion row beneath it, with nothing but chrome below, is indistinguishable
+    // from the render at the shape level — the live-region gate is what remains. Accepted:
+    // that shape is rare, and the wait it produces is the bounded, correctable fallback.
+    const pane = ['⏺ The team banner reads:', `  ${SPEND_ORG}`,
+      "     /usage-credits to finish what you're working on.", '', '❯ '].join('\n');
+    assert.equal(isRateLimited(pane, [], 12), true);
+  });
+  it('a wrapped quotation stays inert when only the INLINE hint is present', () => {
+    // The banner names /usage-credits mid-line, so the last companion match is the quoted
+    // line itself, not a standalone row — the escape hatch stays shut and the shape decides.
+    for (const quoted of [`  ${SPEND_ORG}`, `  · ${SPEND_ORG}`, `  ⚠ ${SPEND_ORG}`]) {
+      const pane = ['⏺ The team banner reads:', quoted, '', '❯ '].join('\n');
+      assert.equal(isRateLimited(pane, [], 12), false, `fired on: ${quoted}`);
     }
   });
 });


### PR DESCRIPTION
Four defects in the #71 spend-limit path, found while reviewing #74. All four reproduce on `master` (v0.7.1) and are independent of #74 — the two branches touch different parts of `patterns.js`, so they can land in either order (the CHANGELOG will conflict trivially).

Three of them share a root cause: **a limit banner can name `/usage-credits` on the same line as the limit itself**, and the chrome allowlist matched that hint anywhere.

## 1. A banner naming the hint inline is classified as furniture

`USAGE_CREDITS` is used for two jobs — the live-limit *signal* (wants the hint anywhere) and the chrome *entry* (wants the companion row). The companion is not the only place it renders:

```
You've hit your session limit · resets 5:20pm (UTC) · run /usage-credits to finish
```

That line is chrome on master, so `contentTail` strips it. The limit is still detected through the live-region backstop, but the line carrying the reset time never reaches the parse:

```
master:  isRateLimited=true   findRateLimitMessage=null   -> fallbackWaitHours, latched correctable
this PR: isRateLimited=true   findRateLimitMessage=<the banner>  -> the real reset time
```

The spend banner (which *always* carries the hint inline) needed an explicit `!SPEND_LIMIT.test(l)` exemption in `isChromeLine` to be visible at all. Anchoring the chrome entry to the hint **leading** its row covers every banner that mentions it, so that exemption is gone — and with it the forward reference to a `const` declared 100 lines further down, which survives today only because nothing calls `isChromeLine` during module evaluation.

Lines that stop being furniture become content the detectors can see, so prose naming the hint mid-sentence is pinned inert: no reset time, no banner shape, fails on its own merits.

## 2 & 3. Two spend-banner shapes that were total misses

```
⚠ You've hit your org's monthly spend limit · run /usage-credits to raise it   -> master: undetected
· You've hit your org's monthly spend limit · run /usage-credits to raise it   -> master: undetected
You’ve hit your org’s monthly spend limit · run /usage-credits to raise it     -> master: undetected
```

The marker class admitted only `⎿`/`└`, though `⚠` and `·` prefix limit renders everywhere else in this file. And `you'?ve` required an ASCII apostrophe while the qualifier class beside it already admitted `’` for `org’s` — that class was widened for exactly this reason when #71 landed; the word in front of it was not.

Each is a *total* miss rather than a weaker match, because the banner also carries the hint inline: pattern rejects it → defect 1 hides it → nothing downstream sees it.

## 4. A wrapped quotation of the banner false-fires a wait

`^\s*` is not an anchor. Model output wraps with a hanging indent, so a continuation line begins with whitespace and then whatever the sentence was up to:

```
⏺ The team banner reads:
  You've hit your org's monthly spend limit · run /usage-credits to raise it
```

On master that enters a 5-hour wait and then types up to `maxRetries` messages into an idle session. The spend render has no reset time to sanity-check against, so its shape is the whole defense and has to hold.

A render starts at column 0 or behind an echo marker; indented with no marker is a wrap. A quotation that lands at column 0 still fires — the remaining anchors are the live-region gate and the bounded, correctable fallback. Trailing punctuation is deliberately *not* a signal: `You've hit your monthly spend limit.` is a real render with a full stop, pinned in the suite since #71.

## Verification

Differential over 4,913 three-line panes built from the spend/companion/prose/banner shapes, master vs this branch — every diff is one of the four fixes above:

```
252x  findRateLimitMessage null -> the banner   (inline-hint session banner, defect 1)
181x  isRateLimited false -> true               (⚠-prefixed render)
181x  isRateLimited false -> true               (·-prefixed render)
181x  isRateLimited false -> true               (typographic apostrophes)
133x  isRateLimited true -> false               (wrapped quotation, defect 4)
```

No new false positives: prose naming the hint mid-sentence, prose explaining spend limits, and a stale spend banner with real work below it all stay inert. A separate 4,913-pane corpus over the *unchanged* shapes (`isRateLimited`, `resumedAfterLimit`, `isRateLimitOptionsPrompt`, `isWorking`, `menuStepsToWaitOption`) shows **0 behavioural diffs** across 24,565 calls.

Suite: **463 pass, 0 fail**. (`reconcile.test.js`'s cross-process hold test is flaky on master too — ~50% locally, unrelated.)

## Commits

1. `fb39ad0` — the `/usage-credits` hint is furniture only when it leads its row.
2. `667fd68` — the spend banner's marker and apostrophe shapes were misses.
3. `dfd6d3e` — a wrapped quotation of the spend banner is not a render.
