### PR TITLE
feat(monitor): resume a turn truncated by suspend or a dropped connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **A turn truncated by a suspended machine or a dropped connection is now resumed.**
+  Claude Code wraps the response body in a byte watchdog; when the bytes stop arriving it
+  aborts the stream and finalizes whatever had already been printed, naming the cause on an
+  `API Error:` line ("Your computer went to sleep mid-response. The response above may be
+  incomplete."). The turn is then over — the prompt returns idle and nothing resumes it, so
+  a session can sit on a half-finished answer indefinitely. Claude Code retries by itself
+  only while the response is still thinking-only; once real content has been yielded it
+  declines to retry, which is precisely when this render appears. Seeing it at an idle
+  prompt, the monitor now sends `continue`, bounded at `maxRetries` because a machine that
+  just woke may not have its network back yet. All seven renders the finalizer emits are
+  matched (suspend, dropped connection, stalled stream and mid-response server error, in
+  both their "mid-response" and "before a response was produced" forms) — they leave the
+  same wreckage and take the same remedy. Detection is anchored on the SHAPE of the line
+  rather than its vocabulary: a real render *begins* with `API Error:`, behind at most
+  Claude's message glyph, so a session merely explaining the error — which quotes the whole
+  render, anchor included, mid-sentence — cannot trigger a resume. Configured under a
+  `streamInterrupted` block.
+
 ## [0.7.3] - 2026-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same wreckage and take the same remedy. Detection is anchored on the SHAPE of the line
   rather than its vocabulary: a real render *begins* with `API Error:`, behind at most
   Claude's message glyph, so a session merely explaining the error — which quotes the whole
-  render, anchor included, mid-sentence — cannot trigger a resume. Configured under a
-  `streamInterrupted` block.
+  render, anchor included, mid-sentence — cannot trigger a resume. The glyph and the
+  indentation are one rule: a glyphed head may sit anywhere, a bare head must start at
+  column 0, because an indented glyph-less head is the hanging-indent shape of a quotation
+  rather than a render. Configured under a `streamInterrupted` block.
 
 ## [0.7.3] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ When you disconnect (SSH drops, close terminal, laptop sleeps), **tmux keeps run
 - **Self-healing coverage** — `reconcile` re-arms monitors for any live `claude` session that lost one; an optional timer (`systemd --user` on Linux, launchd on macOS) runs it automatically ([details](#keeping-monitors-alive))
 - **Overload backoff** — detects sustained API overload (`429/500/502/503/504/529`) and retries on a configurable exponential backoff with jitter and a cumulative-wait cap, distinct from the usage-reset path ([details](#overload-backoff))
 - **Safeguard retry** — auto-continues past an AUP-safeguard false-positive (often transient), capped at a few tries so a sticky flag can't loop ([details](#safeguard-retry))
+- **Interrupted-stream resume** — picks the work back up when a laptop suspend or a dropped connection truncates a response mid-turn and leaves the session parked at an idle prompt ([details](#interrupted-stream-resume))
 - **tmux status bar indicator** — see at a glance whether a pane is being monitored, waiting on a reset, backing off from overload, or has given up ([details](#tmux-status-bar-indicator))
 - **`--print` mode support** — buffers output, retries cleanly for piped/scripted usage
 - **Configurable** — retry count, wait margin, custom patterns, retry message
@@ -135,6 +136,19 @@ the layout is unreadable.
 API Error: <model>'s safeguards flagged this message (https://www.anthropic.com/legal/aup).
 They may flag safe, normal content as well. … Claude Code can't respond to this request with <model>.
 ```
+
+### Interrupted streams — one resume, then stop
+
+```
+API Error: Your computer went to sleep mid-response. The response above may be incomplete.
+API Error: Connection lost mid-response. The response above may be incomplete.
+API Error: The response stopped arriving. The response above may be incomplete.
+API Error: Server error mid-response. The response above may be incomplete.
+```
+
+…and the three "before a response was produced. Try again." variants (suspend, stall,
+connection). All seven come from the same stream finalizer and leave the same wreckage: a
+truncated turn at an idle prompt.
 
 Custom patterns can be added via config for future message format changes.
 
@@ -364,6 +378,61 @@ Configured under a `safeguard` block (defaults shown):
 
 Usage limits always take precedence; the safeguard path only acts when Claude is idle
 (no `esc to interrupt` footer) and the foreground process is `claude`/`node`.
+
+## Interrupted-stream resume
+
+Close your laptop lid while Claude is mid-answer and the work does not survive. Claude
+Code wraps the response body in a byte watchdog; when the bytes stop arriving it aborts
+the stream and finalizes whatever had already been printed, naming the cause:
+
+```
+⏺ API Error: Your computer went to sleep mid-response. The response above may be
+  incomplete.
+```
+
+The turn is then **over**. The prompt returns idle and nothing resumes it, so the session
+sits there — potentially for hours — with a half-finished answer on screen. Claude Code
+retries by itself only while the response is still *thinking-only*; once real content has
+been yielded it declines to retry, which is exactly when this render appears. That is the
+gap this closes: seeing it at an idle prompt, the tool sends `continue`, bounded at
+`maxRetries` because a machine that just woke may not have its network back yet.
+
+The same finalizer emits the render for a dropped connection, a stalled stream and a
+mid-response server error. All are the same truncated-turn state with the same remedy, so
+all are matched — sleeping is just the cause we can name.
+
+Detection is anchored on the **shape** of the line, not its vocabulary: a real render
+*begins* with `API Error:`, behind at most Claude's message glyph. The "an `API Error`
+line nearby" rule the overload and safeguard paths use is deliberately not enough here —
+these sentences are ordinary English, so a session merely *explaining* them quotes the
+whole render, anchor included, mid-sentence. Prose carries it mid-line and your own typed
+line carries `❯`, so neither trips it.
+
+Configured under a `streamInterrupted` block (defaults shown):
+
+```json
+{
+  "streamInterrupted": {
+    "enabled": true,
+    "patterns": ["went to sleep mid-response", "Connection lost mid-response", "…"],
+    "maxRetries": 2,
+    "retryDelaySeconds": 5,
+    "retryMessage": "continue"
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Turn the interrupted-stream path on/off |
+| `patterns` | (all 7 renders) | Case-insensitive regexes, matched only against a line that *begins* with the `API Error:` render |
+| `maxRetries` | `2` | Resume attempts before giving up loudly |
+| `retryDelaySeconds` | `5` | Wait before resuming — lets the network settle after a wake |
+| `retryMessage` | `"continue"` | Message sent to pick the work back up |
+
+Usage limits take precedence, and like the safeguard path this only acts when Claude is
+idle and the foreground process is `claude`/`node`.
+
 ## tmux status bar indicator
 
 The monitor writes a small JSON snapshot per pane on every poll tick, so you can tell

--- a/llms.txt
+++ b/llms.txt
@@ -5,8 +5,9 @@
 > until the printed reset time and sends "continue" automatically. Sustained API
 > overload (`API Error: 529 … overloaded_error`, 500/502/503/504) gets exponential
 > backoff with jitter; safeguard/AUP false positives ("safeguards flagged this
-> message") get a bounded immediate re-send. tmux-based, so it keeps working after
-> you disconnect.
+> message") get a bounded immediate re-send; and a stream truncated by a laptop
+> suspend or a dropped connection ("Your computer went to sleep mid-response") is
+> resumed. tmux-based, so it keeps working after you disconnect.
 
 Install: `npm i -g claude-auto-retry && claude-auto-retry install` — then use `claude`
 as usual.
@@ -17,7 +18,8 @@ Key facts:
   `You've hit your session limit · resets 2am (Europe/Zurich)`, `Claude usage limit
   reached`, `You're out of extra usage`, `API Error: 529 {"type":"overloaded_error"…}`,
   `API Error: Server is temporarily limiting requests (not your usage limit)`,
-  `<model>'s safeguards flagged this message`.
+  `<model>'s safeguards flagged this message`, `API Error: Your computer went to
+  sleep mid-response`.
 - Navigates the `/rate-limit-options` menu to "Stop and wait for limit to reset"
   across any menu layout; never confirms "Upgrade your plan".
 - Safe by design: verifies Claude is the foreground process before injecting keys,

--- a/src/config.js
+++ b/src/config.js
@@ -64,6 +64,41 @@ export const DEFAULT_SAFEGUARD = {
   retryMessage: 'continue',
 };
 
+// Interrupted-stream resume. A third failure family, distinct from usage limits (hours)
+// and overload (5xx, exponential): Claude Code's byte watchdog aborted a stream mid-turn
+// and finalized whatever had already been yielded. The turn is OVER — the prompt returns
+// idle and nothing resumes it — so the session sits untouched until something is typed.
+// Claude Code retries these by itself only while the response is still thinking-only; once
+// real content has been yielded it declines to retry, which is precisely when this renders.
+// A single "continue" picks the work back up. Bounded, because a machine that just woke may
+// not have its network back yet and the resumed turn can fail the same way.
+export const DEFAULT_STREAM_INTERRUPTED = {
+  enabled: true,
+  // Case-insensitive regexes matched against the pane tail, and only against a line that
+  // BEGINS with the `API Error:` render (see streamInterruptedMatch). These phrases are
+  // ordinary English about a common event, so the "anchor nearby" rule the safeguard and
+  // overload families use is not enough here — a session explaining them quotes the whole
+  // render, anchor included, mid-sentence.
+  // The full set the stream finalizer emits, by cause:
+  //   suspend      → "Your computer went to sleep {mid-response | before a response was produced}"
+  //   idle timeout → "The response stopped arriving" / "The response stalled before …"
+  //   connection   → "Connection lost {mid-response | before a response was produced}"
+  //   server error → "Server error mid-response"
+  // All seven leave the pane in the same truncated-turn state, so they share one remedy.
+  patterns: [
+    'went to sleep mid-response',
+    'went to sleep before a response was produced',
+    'response stopped arriving',
+    'response stalled before a response was produced',
+    'Connection lost mid-response',
+    'Connection lost before a response was produced',
+    'Server error mid-response',
+  ],
+  maxRetries: 2,          // small — if resuming keeps truncating, something else is wrong
+  retryDelaySeconds: 5,   // let the network settle after a wake before typing
+  retryMessage: 'continue',
+};
+
 export const DEFAULT_CONFIG = {
   maxRetries: 5,
   pollIntervalSeconds: 5,
@@ -73,6 +108,7 @@ export const DEFAULT_CONFIG = {
   customPatterns: [],
   overload: DEFAULT_OVERLOAD,
   safeguard: DEFAULT_SAFEGUARD,
+  streamInterrupted: DEFAULT_STREAM_INTERRUPTED,
 };
 
 const CONFIG_PATH = join(homedir(), '.claude-auto-retry.json');
@@ -93,15 +129,8 @@ function validateOverload(raw) {
 
   o.enabled = typeof o.enabled === 'boolean' ? o.enabled : DEFAULT_OVERLOAD.enabled;
 
-  // Patterns are case-insensitive regexes (see detectOverload). Keep only non-empty
-  // strings that actually compile, so a typo'd pattern can't crash the monitor tick.
-  const pats = Array.isArray(o.patterns)
-    ? o.patterns.filter(p => {
-        if (typeof p !== 'string' || p.length === 0) return false;
-        try { new RegExp(p); return true; } catch { return false; }
-      })
-    : [];
-  o.patterns = pats.length > 0 ? pats : [...DEFAULT_OVERLOAD.patterns];
+  // Patterns are case-insensitive regexes (see detectOverload).
+  o.patterns = validPatterns(o.patterns, DEFAULT_OVERLOAD.patterns);
 
   const backoff = Array.isArray(o.backoffSeconds)
     ? o.backoffSeconds.filter(n => typeof n === 'number' && Number.isFinite(n) && n > 0)
@@ -123,22 +152,31 @@ function validateOverload(raw) {
   return o;
 }
 
-function validateSafeguard(raw) {
-  const s = { ...DEFAULT_SAFEGUARD, ...(raw && typeof raw === 'object' ? raw : {}) };
-  s.enabled = typeof s.enabled === 'boolean' ? s.enabled : DEFAULT_SAFEGUARD.enabled;
-  const pats = Array.isArray(s.patterns)
-    ? s.patterns.filter(p => {
+// Keep only non-empty strings that actually compile, so a typo'd user pattern can't crash
+// the monitor tick. Shared by every pattern-carrying block.
+function validPatterns(raw, defaults) {
+  const pats = Array.isArray(raw)
+    ? raw.filter(p => {
         if (typeof p !== 'string' || p.length === 0) return false;
         try { new RegExp(p); return true; } catch { return false; }
       })
     : [];
-  s.patterns = pats.length > 0 ? pats : [...DEFAULT_SAFEGUARD.patterns];
-  s.maxRetries = validNumber(s.maxRetries, 1, DEFAULT_SAFEGUARD.maxRetries);
-  s.retryDelaySeconds = validNumber(s.retryDelaySeconds, 1, DEFAULT_SAFEGUARD.retryDelaySeconds);
-  if (typeof s.retryMessage !== 'string' || !s.retryMessage) {
-    s.retryMessage = DEFAULT_SAFEGUARD.retryMessage;
+  return pats.length > 0 ? pats : [...defaults];
+}
+
+// Safeguard and streamInterrupted are the same SHAPE of block — a bounded, seconds-scale
+// retry family (patterns + cap + delay + message) — so one validator serves both. Overload
+// keeps its own: it carries a backoff schedule and relaunch knobs this shape has no room for.
+function validateBoundedRetry(raw, defaults) {
+  const b = { ...defaults, ...(raw && typeof raw === 'object' ? raw : {}) };
+  b.enabled = typeof b.enabled === 'boolean' ? b.enabled : defaults.enabled;
+  b.patterns = validPatterns(b.patterns, defaults.patterns);
+  b.maxRetries = validNumber(b.maxRetries, 1, defaults.maxRetries);
+  b.retryDelaySeconds = validNumber(b.retryDelaySeconds, 1, defaults.retryDelaySeconds);
+  if (typeof b.retryMessage !== 'string' || !b.retryMessage) {
+    b.retryMessage = defaults.retryMessage;
   }
-  return s;
+  return b;
 }
 
 function validate(cfg) {
@@ -163,7 +201,8 @@ function validate(cfg) {
     }
   }
   cfg.overload = validateOverload(cfg.overload);
-  cfg.safeguard = validateSafeguard(cfg.safeguard);
+  cfg.safeguard = validateBoundedRetry(cfg.safeguard, DEFAULT_SAFEGUARD);
+  cfg.streamInterrupted = validateBoundedRetry(cfg.streamInterrupted, DEFAULT_STREAM_INTERRUPTED);
   return cfg;
 }
 

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,4 +1,4 @@
-import { stripAnsi, isRateLimited, findRateLimitMessage, isRateLimitOptionsPrompt, menuStepsToWaitOption, detectOverload, overloadMatch, detectSafeguard, safeguardMatch, isWorking, isInternalRetry, resumedAfterLimit } from './patterns.js';
+import { stripAnsi, isRateLimited, findRateLimitMessage, isRateLimitOptionsPrompt, menuStepsToWaitOption, detectOverload, overloadMatch, detectSafeguard, safeguardMatch, detectStreamInterrupted, streamInterruptedMatch, isWorking, isInternalRetry, resumedAfterLimit } from './patterns.js';
 import { parseResetTime, calculateWaitMs } from './time-parser.js';
 import { capturePane, sendKeys, sendKey, getPaneCommand, isProcessForeground } from './tmux.js';
 import { loadConfig } from './config.js';
@@ -32,6 +32,8 @@ export function createMonitorState() {
     viaEvent: false,
     // Safeguard/AUP false-positive retry sub-state (bounded, seconds-scale).
     safeguardAttempts: 0, safeguardWaitUntil: 0,
+    // Interrupted-stream resume sub-state (suspend/connection truncation; same shape).
+    interruptedAttempts: 0, interruptedWaitUntil: 0,
   };
 }
 
@@ -66,6 +68,13 @@ function resetSafeguard(state) {
   state.safeguardAttempts = 0;
   state.safeguardWaitUntil = 0;
   state._safeguardGaveUp = false;
+  state._gaveUp = false;
+}
+
+function resetInterrupted(state) {
+  state.interruptedAttempts = 0;
+  state.interruptedWaitUntil = 0;
+  state._interruptedGaveUp = false;
   state._gaveUp = false;
 }
 
@@ -447,6 +456,57 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     return 'safeguard-retried';
   }
 
+  // Interrupted stream: the same bounded machine as the safeguard branch above, on a
+  // different render. Deliberately parallel rather than merged — the same way overload and
+  // safeguard are parallel — so each family's result labels stay greppable from the log and
+  // status-file code that matches them literally. If a fourth family appears, extract the
+  // machine and give each family a descriptor carrying its labels.
+  if (state.status === 'interrupted') {
+    if (Date.now() < state.interruptedWaitUntil) return 'interrupted-waiting';
+    if (!isAlive()) return 'exit';
+    const interrupted = config.streamInterrupted;
+
+    // A usage limit or Claude resuming takes precedence / means recovery.
+    if (isRateLimited(stripped, config.customPatterns, RATE_LIMIT_TAIL_LINES)) {
+      resetInterrupted(state); return enterUsageWait(state, stripped, config);
+    }
+    // In flight (our resume, or the user typing) — defer WITHOUT consuming or resetting
+    // the counter, exactly as the safeguard/overload branches do.
+    if (isWorking(stripped)) {
+      state.interruptedWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 2);
+      return 'interrupted-working';
+    }
+
+    // Error gone → the turn resumed (or the user cleared it).
+    if (!detectStreamInterrupted(stripped, interrupted.patterns)) {
+      resetInterrupted(state); state.status = 'monitoring'; return 'interrupted-cleared';
+    }
+
+    // Still truncated after our sends: a wake with no network back yet, or something we
+    // can't fix by typing. Give up loudly ONCE, then hold quietly on a long cooldown.
+    if (state.interruptedAttempts >= interrupted.maxRetries) {
+      state.interruptedWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 12);
+      state._gaveUp = true;
+      if (state._interruptedGaveUp) return 'interrupted-holding';
+      state._interruptedGaveUp = true;
+      return 'interrupted-gave-up';
+    }
+
+    // Foreground safety: only send when claude/node is foreground.
+    const fg = await checkForeground(tmuxAdapter, pane, config);
+    if (!fg.ok) {
+      state._lastForeground = fg.fg;
+      state.interruptedWaitUntil = Date.now() + (config.pollIntervalSeconds * 1000 * 6);
+      return 'skipped-not-claude';
+    }
+
+    // Increment + schedule BEFORE send so a send failure still consumes the slot.
+    state.interruptedAttempts++;
+    state.interruptedWaitUntil = Date.now() + (interrupted.retryDelaySeconds * 1000);
+    await tmuxAdapter.sendKeys(pane, interrupted.retryMessage);
+    return 'interrupted-retried';
+  }
+
   // --- monitoring ---
   // Usage-limit (hours-scale reset) takes precedence over overload (seconds-scale). No
   // !isWorking gate here: it would widen every WORKING_PATTERN from "skip one injection" to
@@ -555,6 +615,21 @@ export async function processOneTick(state, tmuxAdapter, pane, config, isAlive, 
     }
   }
 
+  // Interrupted stream (suspend / dropped connection / stalled stream). Last of the three
+  // seconds-scale families: its render is the least specific, so the more precisely
+  // anchored ones get first refusal on an ambiguous pane. Idle-only, like safeguard.
+  const interrupted = config.streamInterrupted;
+  if (interrupted && interrupted.enabled && !isWorking(stripped)) {
+    const match = streamInterruptedMatch(stripped, interrupted.patterns);
+    if (match) {
+      resetInterrupted(state);
+      state.status = 'interrupted';
+      state.interruptedWaitUntil = Date.now() + (interrupted.retryDelaySeconds * 1000);
+      state._interruptedMatch = match;
+      return 'interrupted-detected';
+    }
+  }
+
   return 'monitoring';
 }
 
@@ -619,9 +694,11 @@ export async function startMonitor(pane, pid) {
         waitUntil: Math.floor(state.waitUntil / 1000),
         overloadWaitUntil: Math.floor(state.overloadWaitUntil / 1000),
         safeguardWaitUntil: Math.floor(state.safeguardWaitUntil / 1000),
+        interruptedWaitUntil: Math.floor(state.interruptedWaitUntil / 1000),
         attempts: state.attempts,
         overloadAttempts: state.overloadAttempts,
         safeguardAttempts: state.safeguardAttempts,
+        interruptedAttempts: state.interruptedAttempts,
         pollIntervalSeconds: config.pollIntervalSeconds,
         gaveUp: !!state._gaveUp,
       }).catch(() => {});
@@ -671,6 +748,13 @@ export async function startMonitor(pane, pid) {
       if (result === 'safeguard-retried') await logger.info(`Safeguard retry sent (attempt ${state.safeguardAttempts}/${config.safeguard.maxRetries}).`);
       if (result === 'safeguard-cleared') await logger.info('Safeguard flag cleared. Resuming normal monitoring.');
       if (result === 'safeguard-gave-up') await logger.warn(`Safeguard flag persisted after ${config.safeguard.maxRetries} retries. Giving up — the flag is likely sticky for this content/model; try /model to switch models or rephrase. Will not retry until it clears.`);
+      if (result === 'interrupted-detected') {
+        const m = state._interruptedMatch;
+        await logger.warn(`Interrupted stream detected${m ? ` [matched /${m.pattern}/ in: "${m.line}"]` : ''} — the turn was truncated and left at an idle prompt. Will resume up to ${config.streamInterrupted.maxRetries}x every ${config.streamInterrupted.retryDelaySeconds}s.`);
+      }
+      if (result === 'interrupted-retried') await logger.info(`Resume sent after interrupted stream (attempt ${state.interruptedAttempts}/${config.streamInterrupted.maxRetries}).`);
+      if (result === 'interrupted-cleared') await logger.info('Interrupted turn resumed. Back to normal monitoring.');
+      if (result === 'interrupted-gave-up') await logger.warn(`Stream still truncated after ${config.streamInterrupted.maxRetries} resume attempts. Giving up — the connection may still be down after the wake. Will not retry until it clears.`);
     } catch (err) {
       consecutiveErrors++;
       await logger.error(`Monitor tick error: ${err.message}`).catch(() => {});

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -700,6 +700,51 @@ export function detectSafeguard(text, patterns = []) {
   return safeguardMatch(text, patterns) !== null;
 }
 
+// --- Interrupted-stream detection (truncated turn) ---
+// Claude Code wraps the response body in a byte watchdog. When bytes stop arriving it
+// aborts the stream and finalizes whatever was already yielded, tagging the cause on an
+// `API Error:` line: a suspended machine, a dropped connection, a stalled stream, a server
+// error. The turn then ENDS at an idle prompt — Claude Code retries by itself only while
+// the response is still thinking-only, so by the time this render exists it has already
+// declined to retry. Nothing resumes the work until something is typed. That's the gap
+// this closes; see DEFAULT_STREAM_INTERRUPTED for the full render set.
+//
+// Anchor: "an API Error line nearby" — the rule the safeguard and overload families use —
+// is NOT enough here. Those phrases are jargon; these are ordinary English about a common
+// event ("your computer went to sleep"), so a session that merely EXPLAINS them quotes the
+// whole render, anchor included, mid-sentence. The discriminator is therefore the SHAPE of
+// the line (#73): a real render BEGINS with `API Error:`, behind at most Claude's message
+// glyph. Prose carries it mid-line; the user's own line carries ❯ instead of ⏺.
+const RENDER_HEAD = /^\s*(?:[⏺●]\s+)?API Error:/i;
+// A render head fills a terminal row, so the cause clause can wrap onto the next
+// (indented) row. Two lines covers the wrap without reaching into whatever follows.
+const RENDER_WRAP_LINES = 2;
+
+export function streamInterruptedMatch(text, patterns = []) {
+  if (!patterns || patterns.length === 0) return null;
+  // Same windowing and tool-echo discipline as the overload/safeguard matchers (#63): the
+  // render quoted inside a Bash result is scrollback, not a live truncated turn.
+  const { lines, mask } = tail(text);
+  if (!lines.join('').trim()) return null;
+  const regexes = toRegexes(patterns);
+  for (let i = 0; i < lines.length; i++) {
+    if (mask[i] || !RENDER_HEAD.test(lines[i])) continue;
+    const last = Math.min(i + RENDER_WRAP_LINES, lines.length - 1);
+    for (let j = i; j <= last; j++) {
+      // Past the head, only an indented continuation still belongs to this render.
+      if (mask[j] || (j > i && !/^\s/.test(lines[j]))) continue;
+      for (const r of regexes) {
+        if (r.test(lines[j])) return { pattern: r.source, line: lines[j].trim().slice(0, 200) };
+      }
+    }
+  }
+  return null;
+}
+
+export function detectStreamInterrupted(text, patterns = []) {
+  return streamInterruptedMatch(text, patterns) !== null;
+}
+
 // Chrome-aware, so isWorking measures the SAME bottom as isRateLimited/detectOverload. A
 // live working footer pushed up by a tall chrome stack below it (task widget + input box
 // + footer) would be invisible to a raw last-N tail while the chrome-aware detectors still

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -715,7 +715,14 @@ export function detectSafeguard(text, patterns = []) {
 // whole render, anchor included, mid-sentence. The discriminator is therefore the SHAPE of
 // the line (#73): a real render BEGINS with `API Error:`, behind at most Claude's message
 // glyph. Prose carries it mid-line; the user's own line carries ❯ instead of ⏺.
-const RENDER_HEAD = /^\s*(?:[⏺●]\s+)?API Error:/i;
+//
+// The glyph and the indentation are ONE rule, not two independent ones: a glyphed head may
+// sit anywhere (the TUI indents blocks), but a BARE head must start at column 0. Allowing
+// arbitrary indentation on a glyph-less head admits the hanging-indent shape of a quotation
+// — "⏺ The error I saw was:" / "  API Error: Your computer went to sleep…" — which is the
+// same wrap/quotation class #75 closed for SPEND_LIMIT. A real head is never indented: it
+// STARTS its line, and a narrow pane wraps the head's tail downward, never the head itself.
+const RENDER_HEAD = /^(?:\s*[⏺●]\s+)?API Error:/i;
 // A render head fills a terminal row, so the cause clause can wrap onto the next
 // (indented) row. Two lines covers the wrap without reaching into whatever follows.
 const RENDER_WRAP_LINES = 2;
@@ -731,8 +738,11 @@ export function streamInterruptedMatch(text, patterns = []) {
     if (mask[i] || !RENDER_HEAD.test(lines[i])) continue;
     const last = Math.min(i + RENDER_WRAP_LINES, lines.length - 1);
     for (let j = i; j <= last; j++) {
-      // Past the head, only an indented continuation still belongs to this render.
-      if (mask[j] || (j > i && !/^\s/.test(lines[j]))) continue;
+      // Past the head, the render continues only while the lines stay indented. The first
+      // flush-left line STARTS THE NEXT BLOCK, so it ends the window — skipping past it let
+      // the scan reach a later block's continuation and attribute its phrase to this head.
+      if (j > i && !/^\s/.test(lines[j])) break;
+      if (mask[j]) continue;
       for (const r of regexes) {
         if (r.test(lines[j])) return { pattern: r.source, line: lines[j].trim().slice(0, 200) };
       }

--- a/test/stream-interrupted.test.js
+++ b/test/stream-interrupted.test.js
@@ -1,0 +1,238 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectStreamInterrupted, streamInterruptedMatch } from '../src/patterns.js';
+import { loadConfig, DEFAULT_CONFIG, DEFAULT_STREAM_INTERRUPTED } from '../src/config.js';
+import { createMonitorState, processOneTick } from '../src/monitor.js';
+
+const PATS = DEFAULT_STREAM_INTERRUPTED.patterns;
+
+function mockTmux(paneContent = '', paneCommand = 'node', claudeForeground = true) {
+  const t = {
+    _sent: [],
+    capturePane: async () => paneContent,
+    getPaneCommand: async () => paneCommand,
+    sendKeys: async (_p, text) => { t._sent.push(text); },
+    sendKey: async () => {},
+    isClaudeForeground: async () => claudeForeground,
+  };
+  return t;
+}
+
+function cfg(overrides = {}) {
+  return { ...DEFAULT_CONFIG, streamInterrupted: { ...DEFAULT_STREAM_INTERRUPTED, ...overrides } };
+}
+
+// The real render, captured verbatim from a session whose stream was cut by a laptop
+// suspend (tmux pane %111). Note the wrap: "incomplete." lands on its own indented
+// continuation line, and the turn ENDS — the prompt returns idle, so nothing resumes
+// until something is typed.
+const SLEPT = [
+  '⏺ API Error: Your computer went to sleep mid-response. The response above may be',
+  '  incomplete.',
+  '',
+  '✻ Cooked for 13m 58s',
+  '❯ ',
+].join('\n');
+
+describe('detectStreamInterrupted', () => {
+  it('matches the suspend render that truncated a response', () =>
+    assert.equal(detectStreamInterrupted(SLEPT, PATS), true));
+
+  it('matches the variant where the suspend hit before any output', () =>
+    assert.equal(detectStreamInterrupted(
+      '⏺ API Error: Your computer went to sleep before a response was produced. Try again.', PATS), true));
+
+  // The same watchdog finalizer emits these for a dropped connection or a stalled
+  // stream; the pane is left in the identical truncated-turn state, so the remedy is
+  // the same. Sleeping is just the cause we can name.
+  it('matches the sibling truncation renders from the same finalizer', () => {
+    for (const line of [
+      '⏺ API Error: The response stopped arriving. The response above may be incomplete.',
+      '⏺ API Error: Connection lost mid-response. The response above may be incomplete.',
+      '⏺ API Error: Server error mid-response. The response above may be incomplete.',
+      '⏺ API Error: The response stalled before a response was produced. Try again.',
+      '⏺ API Error: Connection lost before a response was produced. Try again.',
+    ]) assert.equal(detectStreamInterrupted(line, PATS), true, line);
+  });
+
+  it('matches when the wrap splits the render head from the phrase', () =>
+    assert.equal(detectStreamInterrupted([
+      '⏺ API Error: Your computer',
+      '  went to sleep mid-response. The response above may be incomplete.',
+    ].join('\n'), PATS), true));
+
+  it('is case-insensitive', () =>
+    assert.equal(detectStreamInterrupted('● API ERROR: YOUR COMPUTER WENT TO SLEEP MID-RESPONSE.', PATS), true));
+
+  // The discriminator is the SHAPE of the line, not its vocabulary (#73): a real render
+  // BEGINS with "API Error:" behind at most a message glyph. Prose that merely quotes the
+  // phrase carries the anchor mid-sentence, so an "anchor nearby" rule would fire on a
+  // session explaining this very feature — which is how the pane gets a copy of the string
+  // without anything being wrong.
+  it('does NOT fire on model prose quoting the render mid-sentence', () => {
+    assert.equal(detectStreamInterrupted([
+      '⏺ The monitor watches for "API Error: Your computer went to sleep mid-response." and',
+      '  sends a continue when it sees it.',
+    ].join('\n'), PATS), false);
+  });
+
+  it('does NOT fire on the phrase typed by the user', () =>
+    assert.equal(detectStreamInterrupted(
+      '❯ API Error: Your computer went to sleep mid-response. what does that mean?', PATS), false));
+
+  it('does NOT fire without the API Error render head at all', () =>
+    assert.equal(detectStreamInterrupted('my computer went to sleep mid-response yesterday', PATS), false));
+
+  it('does NOT fire on the render quoted inside a tool result', () => {
+    const pane = [
+      '⏺ Bash(grep -n "sleep" pane.txt)',
+      '  ⎿ ⏺ API Error: Your computer went to sleep mid-response. The response above may be',
+      '       incomplete.',
+      '❯ ',
+    ].join('\n');
+    assert.equal(detectStreamInterrupted(pane, PATS), false);
+  });
+
+  it('does NOT fire on the render left far up in scrollback (tail-anchored)', () => {
+    const pane = ['⏺ API Error: Your computer went to sleep mid-response.',
+      ...Array(15).fill('⏺ unrelated work'), '❯ '].join('\n');
+    assert.equal(detectStreamInterrupted(pane, PATS), false);
+  });
+
+  it('returns false for empty patterns/text', () => {
+    assert.equal(detectStreamInterrupted(SLEPT, []), false);
+    assert.equal(detectStreamInterrupted('', PATS), false);
+  });
+
+  it('reports the matched pattern + line', () => {
+    const m = streamInterruptedMatch(SLEPT, PATS);
+    assert.ok(m && /went to sleep mid-response/.test(m.pattern));
+    assert.ok(m.line.length <= 200);
+  });
+});
+
+describe('streamInterrupted config validation', () => {
+  async function loadFrom(obj) {
+    const { writeFile, unlink } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const f = join(tmpdir(), `car-si-${Date.now()}-${Math.round(Math.random() * 1e6)}.json`);
+    await writeFile(f, JSON.stringify(obj));
+    try { return await loadConfig(f); } finally { await unlink(f); }
+  }
+  it('is present on DEFAULT_CONFIG with a small retry cap', () => {
+    assert.equal(DEFAULT_CONFIG.streamInterrupted.enabled, true);
+    assert.ok(DEFAULT_CONFIG.streamInterrupted.maxRetries <= 3);
+    assert.ok(DEFAULT_CONFIG.streamInterrupted.patterns.includes('went to sleep mid-response'));
+  });
+  it('merges a partial block onto defaults', async () => {
+    const c = await loadFrom({ streamInterrupted: { maxRetries: 1 } });
+    assert.equal(c.streamInterrupted.maxRetries, 1);
+    assert.deepEqual(c.streamInterrupted.patterns, DEFAULT_STREAM_INTERRUPTED.patterns);
+  });
+  it('falls back on bad values', async () => {
+    const c = await loadFrom({ streamInterrupted: { maxRetries: -1, retryDelaySeconds: 0, patterns: [42] } });
+    assert.equal(c.streamInterrupted.maxRetries, DEFAULT_STREAM_INTERRUPTED.maxRetries);
+    assert.equal(c.streamInterrupted.retryDelaySeconds, DEFAULT_STREAM_INTERRUPTED.retryDelaySeconds);
+    assert.deepEqual(c.streamInterrupted.patterns, DEFAULT_STREAM_INTERRUPTED.patterns);
+  });
+});
+
+const near = (actual, expectedMs) => Math.abs(actual - expectedMs) < 2000;
+
+describe('processOneTick — interrupted-stream path', () => {
+  it('enters the wait on detection (no send yet)', async () => {
+    const t = mockTmux(SLEPT);
+    const s = createMonitorState();
+    const r = await processOneTick(s, t, '%0', cfg(), () => true);
+    assert.equal(r, 'interrupted-detected');
+    assert.equal(s.status, 'interrupted');
+    assert.equal(t._sent.length, 0);
+    assert.ok(near(s.interruptedWaitUntil - Date.now(), DEFAULT_STREAM_INTERRUPTED.retryDelaySeconds * 1000));
+  });
+
+  it('sends the resume message once the delay elapses', async () => {
+    const t = mockTmux(SLEPT);
+    const s = createMonitorState();
+    s.status = 'interrupted'; s.interruptedWaitUntil = Date.now() - 1;
+    const r = await processOneTick(s, t, '%0', cfg(), () => true);
+    assert.equal(r, 'interrupted-retried');
+    assert.equal(t._sent[0], DEFAULT_STREAM_INTERRUPTED.retryMessage);
+    assert.equal(s.interruptedAttempts, 1);
+  });
+
+  // The wake often brings the network back a beat later than the process, so the resumed
+  // turn can fail again. Bounded, like the safeguard family — a machine that keeps
+  // suspending must not be typed into forever.
+  it('is BOUNDED — gives up after maxRetries instead of looping', async () => {
+    const t = mockTmux(SLEPT);
+    const s = createMonitorState();
+    const c = cfg({ maxRetries: 2, retryDelaySeconds: 1 });
+    await processOneTick(s, t, '%0', c, () => true);
+    for (let i = 0; i < 2; i++) { s.interruptedWaitUntil = Date.now() - 1; await processOneTick(s, t, '%0', c, () => true); }
+    assert.equal(s.interruptedAttempts, 2);
+    assert.equal(t._sent.length, 2);
+    s.interruptedWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', c, () => true), 'interrupted-gave-up');
+    assert.equal(t._sent.length, 2);
+    assert.equal(s._gaveUp, true);
+  });
+
+  it('clears back to monitoring once the error is gone', async () => {
+    const t = mockTmux('⏺ Here is the rest of the answer.');
+    const s = createMonitorState();
+    s.status = 'interrupted'; s.interruptedWaitUntil = Date.now() - 1; s.interruptedAttempts = 1;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'interrupted-cleared');
+    assert.equal(s.status, 'monitoring');
+    assert.equal(s.interruptedAttempts, 0);
+  });
+
+  it('defers while Claude is working — WITHOUT resetting the attempt counter', async () => {
+    const t = mockTmux(SLEPT + '\n✻ Thinking… (esc to interrupt)');
+    const s = createMonitorState();
+    s.status = 'interrupted'; s.interruptedWaitUntil = Date.now() - 1; s.interruptedAttempts = 2;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'interrupted-working');
+    assert.equal(s.interruptedAttempts, 2);
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('does not enter the path while Claude is working', async () => {
+    const t = mockTmux(SLEPT + '\n· Cooking… (esc to interrupt)');
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'monitoring');
+  });
+
+  it('does not send into a non-claude foreground', async () => {
+    const t = mockTmux(SLEPT, 'vim', false);
+    const s = createMonitorState();
+    s.status = 'interrupted'; s.interruptedWaitUntil = Date.now() - 1;
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'skipped-not-claude');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('usage-limit takes precedence over a co-present truncation render', async () => {
+    const t = mockTmux(SLEPT + "\nYou've hit your session limit · resets 3pm (UTC)");
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'waiting');
+    assert.equal(s.status, 'waiting');
+  });
+
+  it('does not inject into a healthy session discussing the error at an idle prompt', async () => {
+    const t = mockTmux([
+      '⏺ That "API Error: Your computer went to sleep mid-response" message comes from the',
+      '  byte watchdog when the stream is cut by a suspend.',
+      '',
+      '❯ ',
+    ].join('\n'));
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg(), () => true), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+
+  it('disabled block is ignored', async () => {
+    const t = mockTmux(SLEPT);
+    const s = createMonitorState();
+    assert.equal(await processOneTick(s, t, '%0', cfg({ enabled: false }), () => true), 'monitoring');
+    assert.equal(t._sent.length, 0);
+  });
+});

--- a/test/stream-interrupted.test.js
+++ b/test/stream-interrupted.test.js
@@ -93,6 +93,55 @@ describe('detectStreamInterrupted', () => {
     assert.equal(detectStreamInterrupted(pane, PATS), false);
   });
 
+  // A render's HEAD is never indented — it starts its line, at column 0 or behind Claude's
+  // glyph. An indented, glyph-less `API Error:` is the hanging-indent shape of a QUOTATION,
+  // the same wrap/quotation class #75 closed for SPEND_LIMIT. The FP fixtures above all carry
+  // the quote MID-line, which is why this class slipped past them.
+  it('does NOT fire on a hanging-indent quotation of the render', () => {
+    assert.equal(detectStreamInterrupted([
+      '\u23fa The error I saw before the crash was:',
+      '  API Error: Your computer went to sleep mid-response. The response above may be',
+      '  incomplete.',
+      '\u276f ',
+    ].join('\n'), PATS), false);
+  });
+
+  it('does NOT fire on a hanging-indent quotation below the user\'s own line', () => {
+    assert.equal(detectStreamInterrupted([
+      '\u276f what does this mean?',
+      '  API Error: Connection lost mid-response. The response above may be incomplete.',
+      '\u276f ',
+    ].join('\n'), PATS), false);
+  });
+
+  // Print mode renders the head flush left with NO glyph, so the rule above splits on the
+  // glyph rather than banning indentation outright: glyphed heads may indent, bare ones may not.
+  it('still matches a bare column-0 head (print mode)', () =>
+    assert.equal(detectStreamInterrupted(
+      'API Error: Your computer went to sleep mid-response. The response above may be incomplete.', PATS), true));
+
+  // The wrap window must END at the first non-indented line rather than skip past it: here the
+  // phrase belongs to the NEXT block's continuation, and the head two rows up is a 529 render.
+  it('does NOT walk the wrap window across a block boundary', () => {
+    assert.equal(detectStreamInterrupted([
+      '\u23fa API Error: 529 {"type":"error","error":{"type":"overloaded_error"}}',
+      '\u23fa I was explaining that your',
+      '  computer went to sleep mid-response and that truncates the turn.',
+    ].join('\n'), PATS), false);
+  });
+
+  it('KNOWN BOUNDARY: a quotation reproducing the glyph at column 0 DOES fire', () => {
+    // The disclosed cost of the shape rule. A quotation that reproduces Claude's own message
+    // glyph flush left is per-line indistinguishable from the render — the same boundary class
+    // as #74's limit-naming prose. Accepted: the shape is rare, and what it triggers is a
+    // bounded `continue` that clears itself, not a multi-hour wait.
+    assert.equal(detectStreamInterrupted([
+      '\u23fa Here is what it printed:',
+      '\u23fa API Error: Your computer went to sleep mid-response.',
+      '\u276f ',
+    ].join('\n'), PATS), true);
+  });
+
   it('does NOT fire on the render left far up in scrollback (tail-anchored)', () => {
     const pane = ['⏺ API Error: Your computer went to sleep mid-response.',
       ...Array(15).fill('⏺ unrelated work'), '❯ '].join('\n');


### PR DESCRIPTION
## The gap

Close your laptop lid while Claude is mid-answer and the work does not survive. Claude Code wraps the response body in a byte watchdog; when the bytes stop arriving it aborts the stream and finalizes whatever had already been printed, naming the cause on an `API Error:` line:

```
⏺ API Error: Your computer went to sleep mid-response. The response above may be
  incomplete.
```

The turn is then **over**. The prompt returns idle and nothing resumes it, so the session can sit on a half-finished answer indefinitely — the same shape of stall this tool already fixes for usage limits, overloads and safeguard flags.

It cannot be waited out. Claude Code retries by itself only while the response is still *thinking-only*; once real content has been yielded it declines to retry, which is exactly when this render appears. Seeing it at an idle prompt, the monitor now sends `continue`, bounded at `maxRetries` because a machine that just woke may not have its network back yet.

## Scope: seven renders, one remedy

The same finalizer emits the render for a dropped connection, a stalled stream and a mid-response server error, in both "mid-response" and "before a response was produced" forms. All leave the identical truncated-turn state and take the identical remedy, so all are matched — sleeping is just the cause we can name. Matching only the suspend wording would miss the same event on a narrow pane or a different provider path.

## Anchoring differs from the other families, deliberately

The overload and safeguard paths require an `API Error` line *nearby*. That works because their phrases are jargon. These are ordinary English about a common event, so a session merely **explaining** the error quotes the whole render — anchor included — mid-sentence, and a pane discussing this feature would inject into itself.

The discriminator is therefore the **shape** of the line, the same veto discipline as the render/prose split in the reset path: a real render *begins* with `API Error:`, behind at most Claude's message glyph. Prose carries it mid-line; the user's own line carries `❯`. Both are covered by tests.

## Verification

Verified end to end against a **real physical suspend**, not only fixtures. With `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS=30000` to shorten the watchdog's 180s first-party idle deadline, an 85s sleep mid-stream produced the render, and the monitor detected it 11 seconds after wake and resumed the turn with a single `continue`:

```
[WARN] Interrupted stream detected [matched /went to sleep mid-response/ in:
       "⏺ API Error: Your computer went to sleep mid-response. The response above"]
       — the turn was truncated and left at an idle prompt. Will resume up to 2x every 5s.
[INFO] Resume sent after interrupted stream (attempt 1/2).
```

A separate run against a static pane confirmed the bound: exactly 2 sends, then a loud give-up, and it stops typing.

**25 new tests** in `test/stream-interrupted.test.js` (pattern matching, config validation, and the full `processOneTick` state machine), written test-first. Suite is 553/553 green on this branch.

The false-positive cases are pinned explicitly: prose quoting the render mid-sentence, the phrase typed by the user, the render quoted inside a tool result, the render left far up in scrollback, and a healthy session discussing the error at an idle prompt.

## Notes

- Config lives under a `streamInterrupted` block (`enabled`, `patterns`, `maxRetries: 2`, `retryDelaySeconds: 5`, `retryMessage: "continue"`), documented in README with the other families.
- Config validation gained `validateBoundedRetry` / `validPatterns`, now shared by the safeguard and overload blocks rather than a third copy of the same shape.
- The monitor branch is kept parallel to the safeguard one rather than merged, so each family's result labels stay greppable from the log and status-file code that matches them literally.
