### PR TITLE
feat(launcher): name the auto-created tmux session (--tmux-session)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reset already in the past means the limit cleared — retry now rather than a year later.
 
 ### Added
+- **The auto-created tmux session can be named.** It was hardcoded to
+  `claude-retry-<pid>-<timestamp>`: unique, but opaque — `tmux ls` after a few launches is
+  a wall of timestamps and nothing says which checkout each session belongs to, so
+  re-attaching to a specific run meant guessing. `claude --tmux-session api` names one
+  launch and `CLAUDE_AUTO_RETRY_SESSION_NAME` names every launch from a shell; the flag
+  wins over the env var and is consumed by the launcher, so it never reaches `claude`
+  (which would reject it as an unknown option). Unnamed launches are unchanged. `.` and
+  `:` are normalized to `_` up front because tmux rewrites its own target separators as it
+  creates the session — without that the name we hold would stop matching the session tmux
+  made, and the follow-up `-t` targets would miss. A name already in use fails with the
+  `tmux attach` command for the existing session rather than a raw tmux error, and attach
+  now uses an exact-name target (`-t '=api'`) so a name that is a prefix of another
+  session's no longer resolves to the wrong one.
+
 - **A session Claude Code winds down near the 5-hour limit is nudged back to work (#78).**
   At ~95% of the window Claude Code injects a checkpoint instruction into the model's
   context and prints "⏺ Approaching your 5-hour usage limit — Claude will wrap up the

--- a/README.md
+++ b/README.md
@@ -215,6 +215,32 @@ export CLAUDE_AUTO_RETRY_LAUNCH_WRAPPER="caffeinate -i"
 Generic (not macOS-specific — e.g. `nice`, `chrt …` work too). Unset or blank spawns
 `claude` directly, unchanged.
 
+### Naming the session
+
+The auto-created session is named `claude-retry-<pid>-<timestamp>` by default — unique,
+but `tmux ls` after a few launches is a wall of timestamps with nothing to say which
+checkout each one belongs to. Name it instead:
+
+```sh
+claude --tmux-session api          # this launch
+tmux attach -t '=api'              # …and back to it later
+
+export CLAUDE_AUTO_RETRY_SESSION_NAME=api   # every launch from this shell (direnv, etc.)
+```
+
+`--tmux-session` is consumed by the launcher and never reaches `claude`; the flag wins
+over the env var. Notes:
+
+- **`.` and `:` are rewritten to `_`** — tmux reserves them as target separators, so
+  `--tmux-session my.api` creates `my_api` (the launcher tells you when it does this).
+- **A name already in use is an error**, not a second session: the launcher prints the
+  `tmux attach` command for the existing one and exits non-zero. Unnamed launches keep
+  their generated name and never collide.
+- **Attaching uses an exact-name target** (`-t '=api'`), so a session whose name is a
+  prefix of another's (`api` vs `api-worker`) still resolves to the right one.
+- Inside an existing tmux session, or in `--print` mode, no session is created and the
+  flag does nothing — the launcher says so rather than ignoring it silently.
+
 ### Session lifetime
 
 When `claude` exits **cleanly** inside the auto-created tmux session, the session now

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -286,6 +286,103 @@ async function launchPrintMode(args) {
   }
 }
 
+// --- Naming the auto-created tmux session ---
+// A generated `claude-retry-<pid>-<ms>` name is unique but opaque: after a few launches
+// `tmux ls` is a wall of timestamps with nothing to say which checkout each one belongs
+// to, so re-attaching means guessing. `--tmux-session <name>` names one launch;
+// CLAUDE_AUTO_RETRY_SESSION_NAME names every launch from a shell (direnv, per-project).
+// The flag is CONSUMED by the launcher — it is ours, not claude's, and claude would
+// reject it as an unknown option.
+export const SESSION_NAME_FLAG = '--tmux-session';
+export const SESSION_NAME_ENV = 'CLAUDE_AUTO_RETRY_SESSION_NAME';
+
+export function defaultSessionName(pid = process.pid, now = Date.now()) {
+  return `claude-retry-${pid}-${now}`;
+}
+
+// tmux reserves '.' and ':' as target separators and silently rewrites them to '_' as it
+// creates the session (verified on 3.5a). Normalize up front so the name we hold IS the
+// name tmux made — otherwise every later `-t <name>` misses the session we just created.
+// Control characters are rejected rather than rewritten: tmux accepts them, but the
+// resulting session name can't be typed back at `tmux attach -t`.
+export function normalizeSessionName(raw) {
+  const trimmed = String(raw).trim();
+  if (!trimmed) throw new Error('tmux session name is empty');
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) {
+    throw new Error(`tmux session name contains a control character: ${JSON.stringify(trimmed)}`);
+  }
+  const name = trimmed.replace(/[.:]/g, '_');
+  return { name, changed: name !== trimmed };
+}
+
+// Pull our flag out of the argv bound for claude. `--tmux-session name` and
+// `--tmux-session=name` are both accepted, the last one wins, and the env var is the
+// fallback. Returns the surviving argv as `rest`.
+export function extractSessionName(args, env = process.env) {
+  const rest = [];
+  let raw = null;
+  let fromFlag = false;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === SESSION_NAME_FLAG) {
+      if (i + 1 >= args.length) {
+        throw new Error(`${SESSION_NAME_FLAG} requires a value (e.g. ${SESSION_NAME_FLAG} api)`);
+      }
+      raw = args[++i];
+      fromFlag = true;
+    } else if (a.startsWith(`${SESSION_NAME_FLAG}=`)) {
+      raw = a.slice(SESSION_NAME_FLAG.length + 1);
+      fromFlag = true;
+    } else {
+      rest.push(a);
+    }
+  }
+  if (!fromFlag) {
+    raw = (env[SESSION_NAME_ENV] || '').trim();
+    if (!raw) return { name: null, changed: false, fromFlag: false, rest };
+  }
+  const { name, changed } = normalizeSessionName(raw);
+  return { name, changed, fromFlag, rest };
+}
+
+// A chosen name can be a prefix of another session's ("api" vs "api-worker"), and tmux
+// matches targets by prefix by default — it would attach to the wrong session. The '='
+// prefix forces an exact-name match.
+export function buildAttachSessionArgs(name) {
+  return ['attach-session', '-t', `=${name}`];
+}
+
+export function buildFirstWindowTarget(name) {
+  return `=${name}:0`;
+}
+
+// tmux refuses a second session under an existing name. Generated names never collided;
+// a chosen one is the obvious way to trip, so it earns a message that says what to do
+// next instead of a raw tmux error. Permanent, so retryTransientServerError must not
+// treat it as transient — it doesn't: the two patterns are disjoint.
+export function isDuplicateSessionError(err) {
+  const text = [err?.message, err?.stderr].filter(Boolean).map(String).join('\n');
+  return /duplicate session/.test(text);
+}
+
+export function duplicateSessionMessage(name) {
+  return `[claude-auto-retry] A tmux session named '${name}' already exists.\n`
+    + `  Attach to it:   tmux attach -t '=${name}'\n`
+    + `  Or name a new one:   claude ${SESSION_NAME_FLAG} ${name}-2\n`;
+}
+
+// The name only means anything when this launch is the one creating a session. Inside an
+// existing session, or in -p mode, there is nothing to name — say so for the per-launch
+// flag, but stay quiet for the env var, which is ambient and would warn at every prompt.
+export function sessionNameIgnoredWarning(mode, fromFlag) {
+  if (!fromFlag || mode === 'tmux-session') return null;
+  const why = mode === 'print'
+    ? 'print mode (-p) runs claude directly, without a tmux session'
+    : 'this launch reuses the tmux session you are already in';
+  return `[claude-auto-retry] ${SESSION_NAME_FLAG} ignored: ${why}.\n`;
+}
+
 // Session creation carries NO environment: the env crosses via the snapshot file (#68),
 // which also makes the tmux version irrelevant here — `-e` (3.2+) and the inline-export
 // fallback (< 3.2) are both gone, and with them the whole class of "tmux rejects this
@@ -323,8 +420,7 @@ export async function retryTransientServerError(fn, {
   }
 }
 
-async function createTmuxSession(args) {
-  const sessionName = `claude-retry-${process.pid}-${Date.now()}`;
+async function createTmuxSession(args, sessionName = defaultSessionName()) {
   const launcherPath = __filename;
 
   sweepStaleEnvSnapshots();
@@ -344,12 +440,13 @@ async function createTmuxSession(args) {
     // wrapped so an older tmux that rejects these options doesn't fail the whole
     // session creation.
     try {
-      execFileSync('tmux', buildSetWindowOptionArgs(`${sessionName}:0`, 'mouse', 'on'));
-      execFileSync('tmux', buildSetWindowOptionArgs(`${sessionName}:0`, 'mode-keys', 'vi'));
+      const win = buildFirstWindowTarget(sessionName);
+      execFileSync('tmux', buildSetWindowOptionArgs(win, 'mouse', 'on'));
+      execFileSync('tmux', buildSetWindowOptionArgs(win, 'mode-keys', 'vi'));
     } catch { /* old tmux without these options — skip silently */ }
 
     // Attach to the session
-    const attachResult = spawn('tmux', ['attach-session', '-t', sessionName], {
+    const attachResult = spawn('tmux', buildAttachSessionArgs(sessionName), {
       stdio: 'inherit',
     });
 
@@ -361,6 +458,10 @@ async function createTmuxSession(args) {
     // The inner launcher never ran, so nothing will consume the snapshot — remove it now
     // rather than leaving a secrets file for the 24h sweep.
     if (envFile) { try { unlinkSync(envFile); } catch { /* already gone */ } }
+    if (isDuplicateSessionError(err)) {
+      process.stderr.write(duplicateSessionMessage(sessionName));
+      return 1;
+    }
     process.stderr.write(`[claude-auto-retry] Failed to create tmux session: ${err.message}\n`);
     return 1;
   }
@@ -381,20 +482,35 @@ export function chooseLaunchMode(args, env = process.env) {
 // exported helpers (e.g. resolveLaunchCommand under test).
 const isDirectRun = process.argv[1]?.endsWith('launcher.js');
 if (isDirectRun) {
-  const args = process.argv.slice(2);
-
   // Inside the pane: adopt the launching shell's environment before anything reads it
-  // (config load, claude spawn, monitor fork all inherit from here).
+  // (config load, claude spawn, monitor fork all inherit from here) — including
+  // CLAUDE_AUTO_RETRY_SESSION_NAME, which extractSessionName reads next.
   consumeEnvSnapshot(process.env);
 
+  let named;
+  try {
+    named = extractSessionName(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`[claude-auto-retry] ${err.message}\n`);
+    process.exit(2);
+  }
+  const args = named.rest;   // our flag stripped; everything else belongs to claude
+
   const mode = chooseLaunchMode(args);
+  const ignored = sessionNameIgnoredWarning(mode, named.fromFlag);
+  if (ignored) process.stderr.write(ignored);
+  if (named.changed && mode === 'tmux-session') {
+    process.stderr.write(`[claude-auto-retry] tmux reserves '.' and ':' in session names; `
+      + `using '${named.name}'.\n`);
+  }
+
   let exitCode;
   if (mode === 'print') {
     exitCode = await launchPrintMode(args);
   } else if (mode === 'interactive') {
     exitCode = await launchInteractive(args);
   } else {
-    exitCode = await createTmuxSession(args);
+    exitCode = await createTmuxSession(args, named.name || defaultSessionName());
   }
 
   process.exit(exitCode);

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -8,6 +8,9 @@ import {
   resolveLaunchCommand, buildTmuxInnerCmd, buildNewSessionArgs,
   writeEnvSnapshot, writeEnvSnapshotSafe, applyEnvSnapshot, consumeEnvSnapshot, sweepStaleEnvSnapshots,
   chooseLaunchMode, isTransientTmuxServerError, retryTransientServerError,
+  extractSessionName, normalizeSessionName, defaultSessionName,
+  buildAttachSessionArgs, buildFirstWindowTarget, isDuplicateSessionError,
+  sessionNameIgnoredWarning, duplicateSessionMessage,
 } from '../src/launcher.js';
 
 describe('resolveLaunchCommand', () => {
@@ -305,5 +308,160 @@ describe('chooseLaunchMode (#69 escape hatch)', () => {
   });
   it('CLAUDE_AUTO_RETRY_NO_TMUX=1 skips session creation (Zellij/screen users opting out)', () => {
     assert.equal(chooseLaunchMode([], { CLAUDE_AUTO_RETRY_NO_TMUX: '1' }), 'interactive');
+  });
+});
+
+// --- Naming the auto-created session (--tmux-session) ---
+// The session name was hardcoded to `claude-retry-<pid>-<ms>`, which is unique but
+// unfindable: `tmux ls` gives you a wall of timestamps and nothing says which checkout
+// each one is. A name can now be given per launch (`--tmux-session api`) or per shell
+// (CLAUDE_AUTO_RETRY_SESSION_NAME), and the flag is consumed by the launcher — it must
+// never reach `claude`, which would reject it as an unknown option.
+describe('session naming: extractSessionName', () => {
+  it('leaves argv untouched and yields no name when neither flag nor env is set', () => {
+    assert.deepEqual(extractSessionName(['-c', 'hello'], {}),
+      { name: null, changed: false, fromFlag: false, rest: ['-c', 'hello'] });
+  });
+
+  it('takes the space-separated form and strips both tokens from the claude argv', () => {
+    assert.deepEqual(extractSessionName(['--model', 'opus', '--tmux-session', 'api', '-c'], {}),
+      { name: 'api', changed: false, fromFlag: true, rest: ['--model', 'opus', '-c'] });
+  });
+
+  it('takes the --tmux-session=name form', () => {
+    assert.deepEqual(extractSessionName(['--tmux-session=api', '-c'], {}),
+      { name: 'api', changed: false, fromFlag: true, rest: ['-c'] });
+  });
+
+  it('falls back to CLAUDE_AUTO_RETRY_SESSION_NAME', () => {
+    assert.deepEqual(extractSessionName([], { CLAUDE_AUTO_RETRY_SESSION_NAME: 'api' }),
+      { name: 'api', changed: false, fromFlag: false, rest: [] });
+  });
+
+  it('lets the flag override the env var', () => {
+    const r = extractSessionName(['--tmux-session', 'flag'], { CLAUDE_AUTO_RETRY_SESSION_NAME: 'env' });
+    assert.equal(r.name, 'flag');
+    assert.equal(r.fromFlag, true);
+  });
+
+  it('treats a blank env var as unset', () => {
+    assert.equal(extractSessionName([], { CLAUDE_AUTO_RETRY_SESSION_NAME: '   ' }).name, null);
+  });
+
+  it('lets the last flag win when given twice', () => {
+    assert.deepEqual(extractSessionName(['--tmux-session', 'a', '--tmux-session=b'], {}),
+      { name: 'b', changed: false, fromFlag: true, rest: [] });
+  });
+
+  it('rejects a trailing flag with no value instead of eating the next claude arg', () => {
+    assert.throws(() => extractSessionName(['-c', '--tmux-session'], {}), /requires a value/);
+  });
+
+  it('rejects an empty value', () => {
+    assert.throws(() => extractSessionName(['--tmux-session='], {}), /empty/i);
+    assert.throws(() => extractSessionName(['--tmux-session', '  '], {}), /empty/i);
+  });
+
+  // tmux rewrites '.' and ':' — its target separators — to '_' when creating a session
+  // (verified on 3.5a). Normalizing up front keeps the name we hold equal to the name
+  // tmux actually made, so the later `-t` targets resolve.
+  it('normalizes the target separators tmux would rewrite, and says so', () => {
+    assert.deepEqual(extractSessionName(['--tmux-session', 'work.api:2'], {}),
+      { name: 'work_api_2', changed: true, fromFlag: true, rest: [] });
+  });
+});
+
+describe('session naming: normalizeSessionName', () => {
+  it('passes an ordinary name through unchanged', () => {
+    assert.deepEqual(normalizeSessionName('api-worker'), { name: 'api-worker', changed: false });
+  });
+
+  it('trims surrounding whitespace without flagging a change', () => {
+    assert.deepEqual(normalizeSessionName('  api  '), { name: 'api', changed: false });
+  });
+
+  it('replaces every "." and ":" with "_"', () => {
+    assert.deepEqual(normalizeSessionName('a.b:c'), { name: 'a_b_c', changed: true });
+  });
+
+  it('rejects a whitespace-only name', () => {
+    assert.throws(() => normalizeSessionName('\t '), /empty/i);
+  });
+
+  it('rejects control characters, which produce an unattachable session', () => {
+    assert.throws(() => normalizeSessionName('a\nb'), /control character/i);
+  });
+});
+
+describe('session naming: defaults and tmux targeting', () => {
+  it('keeps the unique pid+timestamp name when the user names nothing', () => {
+    assert.equal(defaultSessionName(4321, 1700000000000), 'claude-retry-4321-1700000000000');
+  });
+
+  // A user-chosen name can be a prefix of another session's ("api" vs "api-worker"), and
+  // tmux's default target matching is by prefix — it would attach to the wrong session.
+  // '=' forces an exact-name match.
+  it('attaches by exact name, not tmux prefix matching', () => {
+    assert.deepEqual(buildAttachSessionArgs('api'), ['attach-session', '-t', '=api']);
+  });
+
+  it('targets the first window by exact session name', () => {
+    assert.deepEqual(buildFirstWindowTarget('api'), '=api:0');
+  });
+});
+
+describe('session naming: duplicate-name failure', () => {
+  it('recognizes tmux\'s duplicate-session refusal', () => {
+    assert.ok(isDuplicateSessionError({ stderr: 'duplicate session: api\n' }));
+    assert.ok(isDuplicateSessionError(new Error('Command failed: tmux new-session\nduplicate session: api\n')));
+  });
+
+  it('does not mistake other failures for a duplicate name', () => {
+    assert.ok(!isDuplicateSessionError({ stderr: 'server exited unexpectedly' }));
+    assert.ok(!isDuplicateSessionError(new Error('spawnSync tmux ENOENT')));
+  });
+
+  // A name collision is permanent — retrying it three times just delays the same error.
+  it('is not treated as a transient server error', () => {
+    assert.ok(!isTransientTmuxServerError({ stderr: 'duplicate session: api' }));
+  });
+});
+
+describe('session naming: when no session is created', () => {
+  it('warns that an explicit --tmux-session is doing nothing', () => {
+    assert.match(sessionNameIgnoredWarning('interactive', true), /--tmux-session/);
+    assert.match(sessionNameIgnoredWarning('print', true), /--tmux-session/);
+  });
+
+  it('stays silent when a session is actually being created', () => {
+    assert.equal(sessionNameIgnoredWarning('tmux-session', true), null);
+  });
+
+  // The env var is set once per shell and rides along on every launch, including the
+  // ones inside an existing session — warning there would be noise on every prompt.
+  it('stays silent for the env var, which is ambient rather than per-launch', () => {
+    assert.equal(sessionNameIgnoredWarning('interactive', false), null);
+  });
+});
+
+describe('session naming: the flag never reaches claude', () => {
+  // The pane re-invokes this launcher with the surviving argv, which then execs claude.
+  // If --tmux-session leaked through, claude would abort on an unknown option — so the
+  // stripping and the inner command have to hold together, not just individually.
+  it('is absent from the command the tmux pane runs', () => {
+    const { rest } = extractSessionName(['--tmux-session', 'api', '--model', 'opus'], {});
+    const cmd = buildTmuxInnerCmd('/path/launcher.js', rest, {});
+    assert.ok(!cmd.includes('--tmux-session'), cmd);
+    assert.ok(!cmd.includes('api'), cmd);
+    assert.ok(cmd.includes("'--model' 'opus'"), cmd);
+  });
+});
+
+describe('session naming: duplicate-name message', () => {
+  it('names the collision and gives a runnable way out of it', () => {
+    const msg = duplicateSessionMessage('api');
+    assert.match(msg, /already exists/);
+    assert.match(msg, /tmux attach -t '=api'/);          // exact-match target, copy-pasteable
+    assert.match(msg, /--tmux-session api-2/);           // and how to launch a second one
   });
 });


### PR DESCRIPTION
## Problem

The auto-created session is named `claude-retry-<pid>-<timestamp>`. It's unique, but opaque — after a few launches `tmux ls` is a wall of timestamps with nothing to say which checkout each session belongs to, so re-attaching to a specific run means guessing at PIDs. There was no way to override it: the name was built inline in `createTmuxSession`.

## What this adds

```sh
claude --tmux-session api          # this launch
tmux attach -t '=api'              # ...and back to it later

export CLAUDE_AUTO_RETRY_SESSION_NAME=api   # every launch from this shell (direnv, per-project)
```

The flag wins over the env var and is **consumed by the launcher** — it's ours, not claude's, and claude would abort on an unknown option. Unnamed launches keep the generated name and behave exactly as before.

## Three details worth reviewing

- **`.` and `:` are normalized to `_` up front.** tmux reserves them as target separators and silently rewrites them while creating the session (verified on 3.5a — `new-session -s a.b` yields `a_b`, rc 0). Without normalizing, the name we hold stops matching the session tmux made and the follow-up `-t <name>` targets (`set-window-option`, `attach-session`) miss it. The launcher prints a line when it rewrites.
- **Attach now uses an exact-name target.** A chosen name can be a prefix of another session's (`api` vs `api-worker`) and tmux matches targets by prefix by default, which would attach to the wrong session. `-t '=api'` forces exact match. This also applies to the first-window target.
- **A duplicate name fails with something actionable.** Generated names never collided; a chosen one is the obvious way to trip. tmux's bare `duplicate session:` becomes a message naming the collision plus the `tmux attach` command for the existing session, still exit non-zero. It's a permanent failure, so it stays outside `retryTransientServerError` — the two patterns are disjoint, and there's a test pinning that.

Inside an existing tmux session, or in `--print` mode, no session is created and the flag does nothing — the launcher says so rather than ignoring it silently. The env var stays quiet in that case, since it rides along on every launch and would warn at every prompt.

## Testing

24 new unit tests in `test/launcher.test.js` (argv/env parsing, normalization, exact targeting, duplicate classification, the ignored-flag warning), plus one that runs the extracted argv through `buildTmuxInnerCmd` to pin that the flag never reaches the pane command. Full suite: **610 passing**.

Verified end-to-end against a real tmux server (isolated via `TMUX_TMPDIR`, stub `claude` on `PATH`):

| case | result |
|---|---|
| `--tmux-session my.api --model opus` | session `my_api` created; claude received exactly `--model opus` |
| same name again | duplicate message + attach command, exit 1 |
| `CLAUDE_AUTO_RETRY_SESSION_NAME=from-env` | session `from-env` |
| no name given | `claude-retry-<pid>-<ts>`, unchanged |
| `--tmux-session` with no value / empty value | usage error, exit 2 |
| `-p --tmux-session api` | flag consumed, "ignored" note, print mode runs |

README gets a "Naming the session" section; CHANGELOG entry under Unreleased.